### PR TITLE
Basic breadcrumb implementation.

### DIFF
--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -13,6 +13,10 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
+interface TitleTypographyProps {
+  to?: string
+}
+
 function App (): JSX.Element {
   const classes = useStyles()
   return (
@@ -34,17 +38,12 @@ function App (): JSX.Element {
                       const last = index === pathnames.length - 1
                       const to = `/${pathnames.slice(0, index + 1).join('/')}`
 
-                      return last
-                        ? (
-                            <Typography color="textPrimary" key={to}>
-                              {featureCardProps.filter(feature => { return feature.route.substring(1) === value })[0].title}
-                            </Typography>
-                          )
-                        : (
-                            <RouterLink color="textPrimary" to={to} key={to}>
-                              {featureCardProps.filter(feature => { return feature.route.substring(1) === value })[0].title}
-                            </RouterLink>
-                          )
+                      const feature = featureCardProps.filter(feature => { return feature.route.substring(1) === value })[0]
+                      const titleTypographyProps: TitleTypographyProps = last ? { to: to } : {}
+
+                      return <Typography color='textPrimary' key={to} {...titleTypographyProps}>
+                        {feature.title}
+                      </Typography>
                     })}
                   </Breadcrumbs>
                 )

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -6,7 +6,7 @@ import NavigateNextIcon from '@material-ui/icons/NavigateNext'
 import ConsumerTest from './components/ConsumerTest'
 import Home from './pages/Home'
 import './App.css'
-import AllFeatures from './models/FeatureCardData'
+import allFeatures from './models/FeatureUIData'
 
 const useStyles = makeStyles((theme) => ({
   breadcrumbs: {
@@ -21,7 +21,7 @@ interface TitleTypographyProps {
 
 function App (): JSX.Element {
   const classes = useStyles()
-  const features = AllFeatures
+  const features = allFeatures
   return (
     <div className='App'>
       <Router>

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -19,11 +19,11 @@ interface TitleTypographyProps {
   to?: string
 }
 
-function HomeBreadcrumb (pathnames: string[]): JSX.Element {
+function HomeBreadcrumb (isLink: boolean): JSX.Element {
   const typography = (<Typography color='textPrimary'>
                         Canvas Course Manager
                       </Typography>)
-  return pathnames.length > 0
+  return isLink
     ? (<Link component={RouterLink} to='/'>{typography}</Link>)
     : (typography)
 }
@@ -41,7 +41,7 @@ function App (): JSX.Element {
                 const pathnames = location.pathname.split('/').filter(x => x)
                 return (
                   <Breadcrumbs aria-label="breadcrumb" separator={<NavigateNextIcon fontSize="small" />}>
-                    {HomeBreadcrumb(pathnames)}
+                    {HomeBreadcrumb(pathnames.length > 0)}
                     {pathnames.map((value, index) => {
                       const last = index === pathnames.length - 1
                       const to = `/${pathnames.slice(0, index + 1).join('/')}`

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -19,9 +19,26 @@ interface TitleTypographyProps {
   to?: string
 }
 
+function HomeBreadcrumb (pathnames: string[]): JSX.Element {
+  return pathnames.length > 0
+    ? (
+      <Link component={RouterLink} to='/'>
+        <Typography color='textPrimary'>
+          Canvas Course Manager
+        </Typography>
+      </Link>
+      )
+    : (
+      <Typography color='textPrimary'>
+        Canvas Course Manager
+      </Typography>
+      )
+}
+
 function App (): JSX.Element {
   const classes = useStyles()
   const features = allFeatures
+
   return (
     <div className='App'>
       <Router>
@@ -31,21 +48,16 @@ function App (): JSX.Element {
                 const pathnames = location.pathname.split('/').filter(x => x)
                 return (
                   <Breadcrumbs aria-label="breadcrumb" separator={<NavigateNextIcon fontSize="small" />}>
-                    <Link component={RouterLink} to='/'>
-                      <Typography color='textPrimary'>
-                        Canvas Course Manager
-                      </Typography>
-                    </Link>
-
+                    {HomeBreadcrumb(pathnames)}
                     {pathnames.map((value, index) => {
                       const last = index === pathnames.length - 1
                       const to = `/${pathnames.slice(0, index + 1).join('/')}`
-                      const feature = features.filter(feature => { return feature.route.substring(1) === value })[0]
+                      const feature = features.filter(f => { return f.route.substring(1) === value })[0]
                       const titleTypographyProps: TitleTypographyProps = last ? { to: to } : {}
 
-                      return <Typography color='textPrimary' key={to} {...titleTypographyProps}>
+                      return (<Typography color='textPrimary' key={to} {...titleTypographyProps}>
                         {feature.data.title}
-                      </Typography>
+                      </Typography>)
                     })}
                   </Breadcrumbs>
                 )

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { BrowserRouter as Router, Link as RouterLink, Route, Switch } from 'react-router-dom'
 import { Breadcrumbs, Link, makeStyles, Typography } from '@material-ui/core'
+import NavigateNextIcon from '@material-ui/icons/NavigateNext'
 
 import ConsumerTest from './components/ConsumerTest'
 import Home from './pages/Home'
@@ -29,7 +30,7 @@ function App (): JSX.Element {
               {({ location }) => {
                 const pathnames = location.pathname.split('/').filter(x => x)
                 return (
-                  <Breadcrumbs aria-label="breadcrumb">
+                  <Breadcrumbs aria-label="breadcrumb" separator={<NavigateNextIcon fontSize="small" />}>
                     <Link component={RouterLink} to='/'>
                       <Typography color='textPrimary'>
                         Canvas Course Manager

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -20,19 +20,12 @@ interface TitleTypographyProps {
 }
 
 function HomeBreadcrumb (pathnames: string[]): JSX.Element {
+  const typography = (<Typography color='textPrimary'>
+                        Canvas Course Manager
+                      </Typography>)
   return pathnames.length > 0
-    ? (
-      <Link component={RouterLink} to='/'>
-        <Typography color='textPrimary'>
-          Canvas Course Manager
-        </Typography>
-      </Link>
-      )
-    : (
-      <Typography color='textPrimary'>
-        Canvas Course Manager
-      </Typography>
-      )
+    ? (<Link component={RouterLink} to='/'>{typography}</Link>)
+    : (typography)
 }
 
 function App (): JSX.Element {

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -1,18 +1,61 @@
 import React from 'react'
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
+import { BrowserRouter as Router, Link as RouterLink, Route, Switch } from 'react-router-dom'
+import { Breadcrumbs, Link, makeStyles, Typography } from '@material-ui/core'
 
 import ConsumerTest from './components/ConsumerTest'
-import Home, { mergeSectionProps } from './pages/Home'
-import MergeSections from './pages/MergeSections'
+import Home, { featureCardProps } from './pages/Home'
 import './App.css'
 
+const useStyles = makeStyles((theme) => ({
+  breadcrumbs: {
+    paddingLeft: 25,
+    paddingTop: 25
+  }
+}))
+
 function App (): JSX.Element {
+  const classes = useStyles()
   return (
     <div className='App'>
       <Router>
+        <div className={classes.breadcrumbs}>
+          <Route>
+              {({ location }) => {
+                const pathnames = location.pathname.split('/').filter(x => x)
+                return (
+                  <Breadcrumbs aria-label="breadcrumb">
+                    <Link component={RouterLink} to='/'>
+                      <Typography color='textPrimary'>
+                        Canvas Course Manager
+                      </Typography>
+                    </Link>
+
+                    {pathnames.map((value, index) => {
+                      const last = index === pathnames.length - 1
+                      const to = `/${pathnames.slice(0, index + 1).join('/')}`
+
+                      return last
+                        ? (
+                            <Typography color="textPrimary" key={to}>
+                              {featureCardProps.filter(feature => { return feature.route.substring(1) === value })[0].title}
+                            </Typography>
+                          )
+                        : (
+                            <RouterLink color="textPrimary" to={to} key={to}>
+                              {featureCardProps.filter(feature => { return feature.route.substring(1) === value })[0].title}
+                            </RouterLink>
+                          )
+                    })}
+                  </Breadcrumbs>
+                )
+              }}
+            </Route>
+          </div>
         <Switch>
           <Route exact={true} path="/" component={Home} />
-          <Route path={mergeSectionProps.route} component={MergeSections} />
+          {featureCardProps.map(feature => {
+            return <Route key={feature.id} path={feature.route} component={feature.component} />
+          })}
           <Route render={() => (<div><em>Under Construction</em></div>)} />
         </Switch>
       </Router>

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -3,7 +3,8 @@ import { BrowserRouter as Router, Link as RouterLink, Route, Switch } from 'reac
 import { Breadcrumbs, Link, makeStyles, Typography } from '@material-ui/core'
 
 import ConsumerTest from './components/ConsumerTest'
-import Home, { featureCardProps } from './pages/Home'
+import Home from './pages/Home'
+import { mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps } from './components/FeatureCard'
 import './App.css'
 
 const useStyles = makeStyles((theme) => ({
@@ -19,6 +20,7 @@ interface TitleTypographyProps {
 
 function App (): JSX.Element {
   const classes = useStyles()
+  const featureCardProps = [mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps]
   return (
     <div className='App'>
       <Router>
@@ -37,12 +39,11 @@ function App (): JSX.Element {
                     {pathnames.map((value, index) => {
                       const last = index === pathnames.length - 1
                       const to = `/${pathnames.slice(0, index + 1).join('/')}`
-
-                      const feature = featureCardProps.filter(feature => { return feature.route.substring(1) === value })[0]
+                      const feature = featureCardProps.filter(featureCard => { return featureCard.feature.route.substring(1) === value })[0]
                       const titleTypographyProps: TitleTypographyProps = last ? { to: to } : {}
 
                       return <Typography color='textPrimary' key={to} {...titleTypographyProps}>
-                        {feature.title}
+                        {feature.feature.title}
                       </Typography>
                     })}
                   </Breadcrumbs>
@@ -52,8 +53,8 @@ function App (): JSX.Element {
           </div>
         <Switch>
           <Route exact={true} path="/" component={Home} />
-          {featureCardProps.map(feature => {
-            return <Route key={feature.id} path={feature.route} component={feature.component} />
+          {featureCardProps.map(featureCard => {
+            return <Route key={featureCard.feature.id} path={featureCard.feature.route} component={featureCard.component} />
           })}
           <Route render={() => (<div><em>Under Construction</em></div>)} />
         </Switch>

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -4,8 +4,8 @@ import { Breadcrumbs, Link, makeStyles, Typography } from '@material-ui/core'
 
 import ConsumerTest from './components/ConsumerTest'
 import Home from './pages/Home'
-import { mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps } from './components/FeatureCard'
 import './App.css'
+import AllFeatures from './models/FeatureCardData'
 
 const useStyles = makeStyles((theme) => ({
   breadcrumbs: {
@@ -20,7 +20,7 @@ interface TitleTypographyProps {
 
 function App (): JSX.Element {
   const classes = useStyles()
-  const featureCardProps = [mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps]
+  const features = AllFeatures
   return (
     <div className='App'>
       <Router>
@@ -39,11 +39,11 @@ function App (): JSX.Element {
                     {pathnames.map((value, index) => {
                       const last = index === pathnames.length - 1
                       const to = `/${pathnames.slice(0, index + 1).join('/')}`
-                      const feature = featureCardProps.filter(featureCard => { return featureCard.feature.route.substring(1) === value })[0]
+                      const feature = features.filter(feature => { return feature.route.substring(1) === value })[0]
                       const titleTypographyProps: TitleTypographyProps = last ? { to: to } : {}
 
                       return <Typography color='textPrimary' key={to} {...titleTypographyProps}>
-                        {feature.feature.title}
+                        {feature.data.title}
                       </Typography>
                     })}
                   </Breadcrumbs>
@@ -53,8 +53,8 @@ function App (): JSX.Element {
           </div>
         <Switch>
           <Route exact={true} path="/" component={Home} />
-          {featureCardProps.map(featureCard => {
-            return <Route key={featureCard.feature.id} path={featureCard.feature.route} component={featureCard.component} />
+          {features.map(feature => {
+            return <Route key={feature.data.id} path={feature.route} component={feature.component} />
           })}
           <Route render={() => (<div><em>Under Construction</em></div>)} />
         </Switch>

--- a/ccm_web/client/src/components/FeatureCard.tsx
+++ b/ccm_web/client/src/components/FeatureCard.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { Card, CardContent, Grid, Typography } from '@material-ui/core'
 import { Link } from 'react-router-dom'
-import { FeatureCardProps } from '../models/FeatureCardData'
+import { FeatureUIProps } from '../models/FeatureUIData'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-function FeatureCard (props: FeatureCardProps): JSX.Element {
+function FeatureCard (props: FeatureUIProps): JSX.Element {
   const classes = useStyles()
 
   return (

--- a/ccm_web/client/src/components/FeatureCard.tsx
+++ b/ccm_web/client/src/components/FeatureCard.tsx
@@ -2,6 +2,14 @@ import React, { ComponentType } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { Card, CardContent, Grid, Typography } from '@material-ui/core'
 import { Link } from 'react-router-dom'
+import AccountCircleOutlinedIcon from '@material-ui/icons/AccountCircleOutlined'
+import LibraryBooksOutlinedIcon from '@material-ui/icons/LibraryBooksOutlined'
+import MergeTypeIcon from '@material-ui/icons/MergeType'
+import PersonAddIcon from '@material-ui/icons/PersonAdd'
+import PersonAddOutlinedIcon from '@material-ui/icons/PersonAddOutlined'
+
+import { FeatureProps, mergeSectionProps, gradebookToolsProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps } from '../models/feature'
+import MergeSections from '../pages/MergeSections'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -19,12 +27,48 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
+interface FeatureCardProps {
+  feature: FeatureProps
+  icon: JSX.Element
+  component: ComponentType
+}
+
+const mergeSectionCardProps: FeatureCardProps = {
+  feature: mergeSectionProps,
+  icon: <MergeTypeIcon fontSize='large' />,
+  component: MergeSections
+}
+
+const gradebookToolsCardProps: FeatureCardProps = {
+  feature: gradebookToolsProps,
+  icon: <LibraryBooksOutlinedIcon fontSize='large' />,
+  component: MergeSections
+}
+
+const createSectionsCardProps: FeatureCardProps = {
+  feature: createSectionsProps,
+  icon: <AccountCircleOutlinedIcon fontSize='large' />,
+  component: MergeSections
+}
+
+const addUMUsersCardProps: FeatureCardProps = {
+  feature: addUMUsersProps,
+  icon: <PersonAddIcon fontSize='large' />,
+  component: MergeSections
+}
+
+const addNonUMUsersCardProps: FeatureCardProps = {
+  feature: addNonUMUsersProps,
+  icon: <PersonAddOutlinedIcon fontSize='large' />,
+  component: MergeSections
+}
+
 function FeatureCard (props: FeatureCardProps): JSX.Element {
   const classes = useStyles()
 
   return (
-    <Link className={classes.cardLink} to={props.route} >
-      <Card className={`${classes.root}`} variant="outlined" tabIndex={props.ordinality}>
+    <Link className={classes.cardLink} to={props.feature.route} >
+      <Card className={`${classes.root}`} variant="outlined" tabIndex={props.feature.ordinality}>
         <CardContent>
           <Grid container>
             <Grid item xs={12}>
@@ -33,10 +77,10 @@ function FeatureCard (props: FeatureCardProps): JSX.Element {
               </div>
               <div className={classes.centered}>
                 <Typography className={classes.title} color="textPrimary" gutterBottom>
-                  {props.title}
+                  {props.feature.title}
                 </Typography>
                 <Typography variant="body2" component="p" color="textSecondary">
-                  {props.description}
+                  {props.feature.description}
                 </Typography>
               </div>
             </Grid>
@@ -47,15 +91,5 @@ function FeatureCard (props: FeatureCardProps): JSX.Element {
   )
 }
 
-interface FeatureCardProps {
-  id: string
-  title: string
-  description: string
-  icon: JSX.Element
-  ordinality: number
-  route: string
-  component: ComponentType
-}
-
-export { FeatureCard as default }
 export type { FeatureCardProps }
+export { FeatureCard as default, mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps }

--- a/ccm_web/client/src/components/FeatureCard.tsx
+++ b/ccm_web/client/src/components/FeatureCard.tsx
@@ -1,15 +1,8 @@
-import React, { ComponentType } from 'react'
+import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { Card, CardContent, Grid, Typography } from '@material-ui/core'
 import { Link } from 'react-router-dom'
-import AccountCircleOutlinedIcon from '@material-ui/icons/AccountCircleOutlined'
-import LibraryBooksOutlinedIcon from '@material-ui/icons/LibraryBooksOutlined'
-import MergeTypeIcon from '@material-ui/icons/MergeType'
-import PersonAddIcon from '@material-ui/icons/PersonAdd'
-import PersonAddOutlinedIcon from '@material-ui/icons/PersonAddOutlined'
-
-import { FeatureProps, mergeSectionProps, gradebookToolsProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps } from '../models/feature'
-import MergeSections from '../pages/MergeSections'
+import { FeatureCardProps } from '../models/FeatureCardData'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -27,48 +20,12 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-interface FeatureCardProps {
-  feature: FeatureProps
-  icon: JSX.Element
-  component: ComponentType
-}
-
-const mergeSectionCardProps: FeatureCardProps = {
-  feature: mergeSectionProps,
-  icon: <MergeTypeIcon fontSize='large' />,
-  component: MergeSections
-}
-
-const gradebookToolsCardProps: FeatureCardProps = {
-  feature: gradebookToolsProps,
-  icon: <LibraryBooksOutlinedIcon fontSize='large' />,
-  component: MergeSections
-}
-
-const createSectionsCardProps: FeatureCardProps = {
-  feature: createSectionsProps,
-  icon: <AccountCircleOutlinedIcon fontSize='large' />,
-  component: MergeSections
-}
-
-const addUMUsersCardProps: FeatureCardProps = {
-  feature: addUMUsersProps,
-  icon: <PersonAddIcon fontSize='large' />,
-  component: MergeSections
-}
-
-const addNonUMUsersCardProps: FeatureCardProps = {
-  feature: addNonUMUsersProps,
-  icon: <PersonAddOutlinedIcon fontSize='large' />,
-  component: MergeSections
-}
-
 function FeatureCard (props: FeatureCardProps): JSX.Element {
   const classes = useStyles()
 
   return (
-    <Link className={classes.cardLink} to={props.feature.route} >
-      <Card className={`${classes.root}`} variant="outlined" tabIndex={props.feature.ordinality}>
+    <Link className={classes.cardLink} to={props.route} >
+      <Card className={`${classes.root}`} variant="outlined" tabIndex={props.data.ordinality}>
         <CardContent>
           <Grid container>
             <Grid item xs={12}>
@@ -77,10 +34,10 @@ function FeatureCard (props: FeatureCardProps): JSX.Element {
               </div>
               <div className={classes.centered}>
                 <Typography className={classes.title} color="textPrimary" gutterBottom>
-                  {props.feature.title}
+                  {props.data.title}
                 </Typography>
                 <Typography variant="body2" component="p" color="textSecondary">
-                  {props.feature.description}
+                  {props.data.description}
                 </Typography>
               </div>
             </Grid>
@@ -91,5 +48,4 @@ function FeatureCard (props: FeatureCardProps): JSX.Element {
   )
 }
 
-export type { FeatureCardProps }
-export { FeatureCard as default, mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps }
+export default FeatureCard

--- a/ccm_web/client/src/components/FeatureCard.tsx
+++ b/ccm_web/client/src/components/FeatureCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ComponentType } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { Card, CardContent, Grid, Typography } from '@material-ui/core'
 import { Link } from 'react-router-dom'
@@ -54,6 +54,7 @@ interface FeatureCardProps {
   icon: JSX.Element
   ordinality: number
   route: string
+  component: ComponentType
 }
 
 export { FeatureCard as default }

--- a/ccm_web/client/src/models/FeatureCardData.tsx
+++ b/ccm_web/client/src/models/FeatureCardData.tsx
@@ -1,0 +1,56 @@
+import React, { ComponentType } from 'react'
+import AccountCircleOutlinedIcon from '@material-ui/icons/AccountCircleOutlined'
+import LibraryBooksOutlinedIcon from '@material-ui/icons/LibraryBooksOutlined'
+import MergeTypeIcon from '@material-ui/icons/MergeType'
+import PersonAddIcon from '@material-ui/icons/PersonAdd'
+import PersonAddOutlinedIcon from '@material-ui/icons/PersonAddOutlined'
+
+import { FeatureDataProps, mergeSectionProps, gradebookToolsProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps } from './feature'
+import MergeSections from '../pages/MergeSections'
+
+interface FeatureCardProps {
+  data: FeatureDataProps
+  icon: JSX.Element
+  component: ComponentType
+  route: string
+}
+
+const mergeSectionCardProps: FeatureCardProps = {
+  data: mergeSectionProps,
+  icon: <MergeTypeIcon fontSize='large' />,
+  component: MergeSections,
+  route: '/merge-sections'
+}
+
+const gradebookToolsCardProps: FeatureCardProps = {
+  data: gradebookToolsProps,
+  icon: <LibraryBooksOutlinedIcon fontSize='large' />,
+  component: MergeSections,
+  route: '/gradebook'
+}
+
+const createSectionsCardProps: FeatureCardProps = {
+  data: createSectionsProps,
+  icon: <AccountCircleOutlinedIcon fontSize='large' />,
+  component: MergeSections,
+  route: '/create-sections'
+}
+
+const addUMUsersCardProps: FeatureCardProps = {
+  data: addUMUsersProps,
+  icon: <PersonAddIcon fontSize='large' />,
+  component: MergeSections,
+  route: '/add-um-users'
+}
+
+const addNonUMUsersCardProps: FeatureCardProps = {
+  data: addNonUMUsersProps,
+  icon: <PersonAddOutlinedIcon fontSize='large' />,
+  component: MergeSections,
+  route: '/add-non-um-users'
+}
+
+const AllFeatures = [mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps]
+
+export type { FeatureCardProps }
+export default AllFeatures

--- a/ccm_web/client/src/models/FeatureUIData.tsx
+++ b/ccm_web/client/src/models/FeatureUIData.tsx
@@ -8,49 +8,49 @@ import PersonAddOutlinedIcon from '@material-ui/icons/PersonAddOutlined'
 import { FeatureDataProps, mergeSectionProps, gradebookToolsProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps } from './feature'
 import MergeSections from '../pages/MergeSections'
 
-interface FeatureCardProps {
+interface FeatureUIProps {
   data: FeatureDataProps
   icon: JSX.Element
   component: ComponentType
   route: string
 }
 
-const mergeSectionCardProps: FeatureCardProps = {
+const mergeSectionCardProps: FeatureUIProps = {
   data: mergeSectionProps,
   icon: <MergeTypeIcon fontSize='large' />,
   component: MergeSections,
   route: '/merge-sections'
 }
 
-const gradebookToolsCardProps: FeatureCardProps = {
+const gradebookToolsCardProps: FeatureUIProps = {
   data: gradebookToolsProps,
   icon: <LibraryBooksOutlinedIcon fontSize='large' />,
   component: MergeSections,
   route: '/gradebook'
 }
 
-const createSectionsCardProps: FeatureCardProps = {
+const createSectionsCardProps: FeatureUIProps = {
   data: createSectionsProps,
   icon: <AccountCircleOutlinedIcon fontSize='large' />,
   component: MergeSections,
   route: '/create-sections'
 }
 
-const addUMUsersCardProps: FeatureCardProps = {
+const addUMUsersCardProps: FeatureUIProps = {
   data: addUMUsersProps,
   icon: <PersonAddIcon fontSize='large' />,
   component: MergeSections,
   route: '/add-um-users'
 }
 
-const addNonUMUsersCardProps: FeatureCardProps = {
+const addNonUMUsersCardProps: FeatureUIProps = {
   data: addNonUMUsersProps,
   icon: <PersonAddOutlinedIcon fontSize='large' />,
   component: MergeSections,
   route: '/add-non-um-users'
 }
 
-const AllFeatures = [mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps]
+const allFeatures = [mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps]
 
-export type { FeatureCardProps }
-export default AllFeatures
+export type { FeatureUIProps }
+export default allFeatures

--- a/ccm_web/client/src/models/feature.ts
+++ b/ccm_web/client/src/models/feature.ts
@@ -1,0 +1,50 @@
+
+interface FeatureProps {
+  id: string
+  title: string
+  description: string
+  ordinality: number
+  route: string
+}
+
+const mergeSectionProps: FeatureProps = {
+  id: 'MergeSections',
+  title: 'Merge Sections',
+  description: 'Combine sections into one Canvas site for easier management',
+  ordinality: 1,
+  route: '/merge-sections'
+}
+const gradebookToolsProps: FeatureProps = {
+  id: 'GradebookTools',
+  title: 'Gradebook Tools',
+  description: 'Trim the gradebook from Canvas, or trim the gradebook from a third party to correct format',
+  ordinality: 2,
+  route: '/gradebook'
+}
+
+const createSectionsProps: FeatureProps = {
+  id: 'CreateSections',
+  title: 'Create Sections',
+  description: 'Create sections through csv files into your own course',
+  ordinality: 3,
+  route: '/create-sections'
+}
+
+const addUMUsersProps: FeatureProps = {
+  id: 'addUMUsers',
+  title: 'Add UM Users',
+  description: 'Add UM users to your available sections',
+  ordinality: 4,
+  route: '/add-um-users'
+}
+
+const addNonUMUsersProps: FeatureProps = {
+  id: 'addNonUMUsers',
+  title: 'Add Non-UM Users',
+  description: 'Enroll non-UM users to your available sections',
+  ordinality: 5,
+  route: '/add-non-um-users'
+}
+
+export type { FeatureProps }
+export { mergeSectionProps, gradebookToolsProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps }

--- a/ccm_web/client/src/models/feature.ts
+++ b/ccm_web/client/src/models/feature.ts
@@ -1,50 +1,44 @@
 
-interface FeatureProps {
+interface FeatureDataProps {
   id: string
   title: string
   description: string
   ordinality: number
-  route: string
 }
 
-const mergeSectionProps: FeatureProps = {
+const mergeSectionProps: FeatureDataProps = {
   id: 'MergeSections',
   title: 'Merge Sections',
   description: 'Combine sections into one Canvas site for easier management',
-  ordinality: 1,
-  route: '/merge-sections'
+  ordinality: 1
 }
-const gradebookToolsProps: FeatureProps = {
+const gradebookToolsProps: FeatureDataProps = {
   id: 'GradebookTools',
   title: 'Gradebook Tools',
   description: 'Trim the gradebook from Canvas, or trim the gradebook from a third party to correct format',
-  ordinality: 2,
-  route: '/gradebook'
+  ordinality: 2
 }
 
-const createSectionsProps: FeatureProps = {
+const createSectionsProps: FeatureDataProps = {
   id: 'CreateSections',
   title: 'Create Sections',
   description: 'Create sections through csv files into your own course',
-  ordinality: 3,
-  route: '/create-sections'
+  ordinality: 3
 }
 
-const addUMUsersProps: FeatureProps = {
+const addUMUsersProps: FeatureDataProps = {
   id: 'addUMUsers',
   title: 'Add UM Users',
   description: 'Add UM users to your available sections',
-  ordinality: 4,
-  route: '/add-um-users'
+  ordinality: 4
 }
 
-const addNonUMUsersProps: FeatureProps = {
+const addNonUMUsersProps: FeatureDataProps = {
   id: 'addNonUMUsers',
   title: 'Add Non-UM Users',
   description: 'Enroll non-UM users to your available sections',
-  ordinality: 5,
-  route: '/add-non-um-users'
+  ordinality: 5
 }
 
-export type { FeatureProps }
+export type { FeatureDataProps }
 export { mergeSectionProps, gradebookToolsProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps }

--- a/ccm_web/client/src/pages/Home.tsx
+++ b/ccm_web/client/src/pages/Home.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import Grid from '@material-ui/core/Grid'
 
-import FeatureCard, { mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps } from '../components/FeatureCard'
+import FeatureCard from '../components/FeatureCard'
+import AllFeatures from '../models/FeatureCardData'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -14,14 +15,14 @@ const useStyles = makeStyles((theme) => ({
 
 function Home (): JSX.Element {
   const classes = useStyles()
-  const featureCards = [mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps]
+  const features = AllFeatures
   return (
     <div className={classes.root}>
       <Grid container spacing={3}>
-        {featureCards.sort((a, b) => (a.feature.ordinality < b.feature.ordinality) ? -1 : 1).map(p => {
+        {features.sort((a, b) => (a.data.ordinality < b.data.ordinality) ? -1 : 1).map(featureProps => {
           return (
-            <Grid key={p.feature.id} item xs={12} sm={4}>
-              <FeatureCard {...p} />
+            <Grid key={featureProps.data.id} item xs={12} sm={4}>
+              <FeatureCard {...featureProps} />
             </Grid>
           )
         })}

--- a/ccm_web/client/src/pages/Home.tsx
+++ b/ccm_web/client/src/pages/Home.tsx
@@ -9,6 +9,7 @@ import LibraryBooksOutlinedIcon from '@material-ui/icons/LibraryBooksOutlined'
 import MergeTypeIcon from '@material-ui/icons/MergeType'
 import PersonAddIcon from '@material-ui/icons/PersonAdd'
 import PersonAddOutlinedIcon from '@material-ui/icons/PersonAddOutlined'
+import MergeSections from './MergeSections'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -24,7 +25,8 @@ const mergeSectionProps: FeatureCardProps = {
   description: 'Combine sections into one Canvas site for easier management',
   icon: <MergeTypeIcon fontSize='large' />,
   ordinality: 1,
-  route: '/merge-sections'
+  route: '/merge-sections',
+  component: MergeSections
 }
 const gradebookToolsProps: FeatureCardProps = {
   id: 'GradebookTools',
@@ -32,7 +34,8 @@ const gradebookToolsProps: FeatureCardProps = {
   description: 'Trim the gradebook from Canvas, or trim the gradebook from a third party to correct format',
   icon: <LibraryBooksOutlinedIcon fontSize='large' />,
   ordinality: 2,
-  route: '/gradebook'
+  route: '/gradebook',
+  component: MergeSections
 }
 
 const createSectionsProps: FeatureCardProps = {
@@ -41,7 +44,8 @@ const createSectionsProps: FeatureCardProps = {
   description: 'Create sections through csv files into your own course',
   icon: <AccountCircleOutlinedIcon fontSize='large' />,
   ordinality: 3,
-  route: '/create-sections'
+  route: '/create-sections',
+  component: MergeSections
 }
 
 const addUMUsersProps: FeatureCardProps = {
@@ -50,7 +54,8 @@ const addUMUsersProps: FeatureCardProps = {
   description: 'Add UM users to your available sections',
   icon: <PersonAddIcon fontSize='large' />,
   ordinality: 4,
-  route: '/add-um-users'
+  route: '/add-um-users',
+  component: MergeSections
 }
 
 const addNonUMUsersProps: FeatureCardProps = {
@@ -59,18 +64,19 @@ const addNonUMUsersProps: FeatureCardProps = {
   description: 'Enroll non-UM users to your available sections',
   icon: <PersonAddOutlinedIcon fontSize='large' />,
   ordinality: 5,
-  route: '/add-non-um-users'
+  route: '/add-non-um-users',
+  component: MergeSections
 }
+
+const featureCardProps: FeatureCardProps[] = [mergeSectionProps, gradebookToolsProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps]
 
 function Home (): JSX.Element {
   const classes = useStyles()
 
-  const cards: FeatureCardProps[] = [mergeSectionProps, gradebookToolsProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps]
-
   return (
     <div className={classes.root}>
       <Grid container spacing={3}>
-        {cards.sort((a, b) => (a.ordinality < b.ordinality) ? -1 : 1).map(p => {
+        {featureCardProps.sort((a, b) => (a.ordinality < b.ordinality) ? -1 : 1).map(p => {
           return (
             <Grid key={p.id} item xs={12} sm={4}>
               <FeatureCard {...p} />
@@ -82,4 +88,4 @@ function Home (): JSX.Element {
   )
 }
 
-export { Home as default, mergeSectionProps }
+export { Home as default, featureCardProps }

--- a/ccm_web/client/src/pages/Home.tsx
+++ b/ccm_web/client/src/pages/Home.tsx
@@ -2,14 +2,7 @@ import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import Grid from '@material-ui/core/Grid'
 
-import FeatureCard, { FeatureCardProps } from '../components/FeatureCard'
-
-import AccountCircleOutlinedIcon from '@material-ui/icons/AccountCircleOutlined'
-import LibraryBooksOutlinedIcon from '@material-ui/icons/LibraryBooksOutlined'
-import MergeTypeIcon from '@material-ui/icons/MergeType'
-import PersonAddIcon from '@material-ui/icons/PersonAdd'
-import PersonAddOutlinedIcon from '@material-ui/icons/PersonAddOutlined'
-import MergeSections from './MergeSections'
+import FeatureCard, { mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps } from '../components/FeatureCard'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -19,66 +12,15 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-const mergeSectionProps: FeatureCardProps = {
-  id: 'MergeSections',
-  title: 'Merge Sections',
-  description: 'Combine sections into one Canvas site for easier management',
-  icon: <MergeTypeIcon fontSize='large' />,
-  ordinality: 1,
-  route: '/merge-sections',
-  component: MergeSections
-}
-const gradebookToolsProps: FeatureCardProps = {
-  id: 'GradebookTools',
-  title: 'Gradebook Tools',
-  description: 'Trim the gradebook from Canvas, or trim the gradebook from a third party to correct format',
-  icon: <LibraryBooksOutlinedIcon fontSize='large' />,
-  ordinality: 2,
-  route: '/gradebook',
-  component: MergeSections
-}
-
-const createSectionsProps: FeatureCardProps = {
-  id: 'CreateSections',
-  title: 'Create Sections',
-  description: 'Create sections through csv files into your own course',
-  icon: <AccountCircleOutlinedIcon fontSize='large' />,
-  ordinality: 3,
-  route: '/create-sections',
-  component: MergeSections
-}
-
-const addUMUsersProps: FeatureCardProps = {
-  id: 'addUMUsers',
-  title: 'Add UM Users',
-  description: 'Add UM users to your available sections',
-  icon: <PersonAddIcon fontSize='large' />,
-  ordinality: 4,
-  route: '/add-um-users',
-  component: MergeSections
-}
-
-const addNonUMUsersProps: FeatureCardProps = {
-  id: 'addNonUMUsers',
-  title: 'Add Non-UM Users',
-  description: 'Enroll non-UM users to your available sections',
-  icon: <PersonAddOutlinedIcon fontSize='large' />,
-  ordinality: 5,
-  route: '/add-non-um-users',
-  component: MergeSections
-}
-
-const featureCardProps: FeatureCardProps[] = [mergeSectionProps, gradebookToolsProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps]
-
 function Home (): JSX.Element {
   const classes = useStyles()
-
+  const featureCards = [mergeSectionCardProps, gradebookToolsCardProps, createSectionsCardProps, addUMUsersCardProps, addNonUMUsersCardProps]
   return (
     <div className={classes.root}>
       <Grid container spacing={3}>
-        {featureCardProps.sort((a, b) => (a.ordinality < b.ordinality) ? -1 : 1).map(p => {
+        {featureCards.sort((a, b) => (a.feature.ordinality < b.feature.ordinality) ? -1 : 1).map(p => {
           return (
-            <Grid key={p.id} item xs={12} sm={4}>
+            <Grid key={p.feature.id} item xs={12} sm={4}>
               <FeatureCard {...p} />
             </Grid>
           )
@@ -88,4 +30,4 @@ function Home (): JSX.Element {
   )
 }
 
-export { Home as default, featureCardProps }
+export { Home as default }

--- a/ccm_web/client/src/pages/Home.tsx
+++ b/ccm_web/client/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import Grid from '@material-ui/core/Grid'
 
 import FeatureCard from '../components/FeatureCard'
-import AllFeatures from '../models/FeatureCardData'
+import allFeatures from '../models/FeatureUIData'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme) => ({
 
 function Home (): JSX.Element {
   const classes = useStyles()
-  const features = AllFeatures
+  const features = allFeatures
   return (
     <div className={classes.root}>
       <Grid container spacing={3}>


### PR DESCRIPTION
Added basic breadcrumbs.
Automatically constructed from the route so this *should* continue to work when we get more than 2 deep.

Each route is now automatically added as defined by the featureCardProps array defined in Home.tsx (for now)

All features currently direct to the placeholder Merge component (because they have to have a component defined) but use appropriate routes.