### PR TITLE
Course Rename

### DIFF
--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
+import { SnackbarProvider } from 'notistack'
 
 import ConsumerTest from './components/ConsumerTest'
 import Home, { mergeSectionProps } from './pages/Home'
@@ -9,14 +10,16 @@ import './App.css'
 function App (): JSX.Element {
   return (
     <div className='App'>
-      <Router>
-        <Switch>
-          <Route exact={true} path="/" component={Home} />
-          <Route path={mergeSectionProps.route} component={MergeSections} />
-          <Route render={() => (<div><em>Under Construction</em></div>)} />
-        </Switch>
-      </Router>
-      <ConsumerTest/>
+      <SnackbarProvider maxSnack={3}>
+        <Router>
+          <Switch>
+            <Route exact={true} path="/" component={Home} />
+            <Route path={mergeSectionProps.route} component={MergeSections} />
+            <Route render={() => (<div><em>Under Construction</em></div>)} />
+          </Switch>
+        </Router>
+        <ConsumerTest/>
+      </SnackbarProvider>
     </div>
   )
 }

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -20,8 +20,10 @@ interface TitleTypographyProps {
   to?: string
 }
 
+const breadcrumbVariant = 'h5'
+
 function HomeBreadcrumb (isLink: boolean): JSX.Element {
-  const typography = (<Typography color='textPrimary'>
+  const typography = (<Typography color='textPrimary' variant={breadcrumbVariant}>
                         Canvas Course Manager
                       </Typography>)
   return isLink
@@ -50,7 +52,7 @@ function App (): JSX.Element {
                         const feature = features.filter(f => { return f.route.substring(1) === value })[0]
                         const titleTypographyProps: TitleTypographyProps = last ? { to: to } : {}
 
-                        return (<Typography color='textPrimary' key={to} {...titleTypographyProps}>
+                        return (<Typography color='textPrimary' variant={breadcrumbVariant} key={to} {...titleTypographyProps}>
                           {feature.data.title}
                         </Typography>)
                       })}

--- a/ccm_web/client/src/components/InlineTextEdit.tsx
+++ b/ccm_web/client/src/components/InlineTextEdit.tsx
@@ -12,14 +12,25 @@ interface InlineTextEditProps {
 
 const useStyles = makeStyles((theme) => ({
   root: {
+    textAlign: 'left',
     padding: '5px',
     '& .MuiInputBase-root.Mui-disabled': {
       color: 'rgba(0, 0, 0, 0.6)' // (default alpha is 0.38)
+    },
+    '& svg': {
+      paddingTop: '6px',
+      paddingBottom: '7px'
     }
+  },
+  inputRow: {
+    height: '60px',
+    paddingTop: '6px',
+    paddingBottom: '7px',
+    fontSize: '30px'
   },
   editIcon: {
     cursor: 'pointer',
-    textAlign: 'left'
+    fontSize: '30px'
   },
   inputArea: {
     width: '500px'
@@ -70,20 +81,20 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
   return (
     <form className={classes.root} noValidate autoComplete="off">
       <Grid container className={classes.inputArea}>
-        <Grid item xs={12} sm={8}>
-          <TextField onClick={toggleEdit} inputProps={{ style: { fontSize: 30 } }} ref={textInput} id="standard-basic" placeholder='Course Name' value={tempName} onKeyDown={(e) => keyPress(e.code)} onChange={(e) => setTempName(e.target.value)} disabled={!isEditing}/>
+        <Grid item xs={8} sm={8}>
+          <TextField className={classes.inputRow} aria-readonly={false} onClick={toggleEdit} inputProps={{ style: { fontSize: 30 } }} ref={textInput} id="standard-basic" placeholder='Course Name' value={tempName} onKeyDown={(e) => keyPress(e.code)} onChange={(e) => setTempName(e.target.value)} disabled={!isEditing}/>
         </Grid>
-      {!isEditing
-        ? (<Grid item xs={4} className={classes.editIcon} ><EditIcon onClick={toggleEdit}/></Grid>)
-        : (<Grid container item xs={12} sm={4}>
-            <Grid item xs={6} sm={6} >
-              <Button disabled={courseName === tempName} onClick={save}>Save</Button>
-            </Grid>
-            <Grid item xs={6} sm={6} >
-              <Button onClick={cancel}>Cancel</Button>
-            </Grid>
-          </Grid>)
-      }
+        {!isEditing
+          ? (<Grid item xs={4} className={classes.inputRow}><EditIcon className={classes.editIcon} fontSize='inherit' onClick={toggleEdit}/></Grid>)
+          : (<Grid container item xs={12} sm={4} className={classes.inputRow}>
+              <Grid item xs={6} sm={6} >
+                <Button disabled={courseName === tempName} onClick={save}>Save</Button>
+              </Grid>
+              <Grid item xs={6} sm={6} >
+                <Button onClick={cancel}>Cancel</Button>
+              </Grid>
+            </Grid>)
+        }
       </Grid>
     </form>
   )

--- a/ccm_web/client/src/components/InlineTextEdit.tsx
+++ b/ccm_web/client/src/components/InlineTextEdit.tsx
@@ -7,7 +7,10 @@ import { CODE_ENTER, CODE_NUMPAD_ENTER, CODE_ESCAPE } from 'keycode-js'
 
 interface InlineTextEditProps {
   text: string
-  save: (courseName: string) => Promise<void>
+  placeholderText: string
+  successMessage: string
+  failureMessage: string
+  save: (text: string) => Promise<void>
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -40,8 +43,8 @@ const useStyles = makeStyles((theme) => ({
 function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
   const classes = useStyles()
   const [isEditing, setIsEditing] = useState(false)
-  const [courseName, setCourseName] = useState(props.text)
-  const [tempName, setTempName] = useState(props.text)
+  const [textValue, setTextValue] = useState(props.text)
+  const [tempTextValue, setTempTextValue] = useState(props.text)
 
   const textInput = useRef(null)
 
@@ -49,20 +52,20 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
 
   const save = (): void => {
     setIsEditing(false)
-    if (courseName === tempName) return
-    props.save(tempName)
+    if (textValue === tempTextValue) return
+    props.save(tempTextValue)
       .then(() => {
-        enqueueSnackbar('Saved', { variant: 'success' })
-        setCourseName(tempName)
+        enqueueSnackbar(props.successMessage, { variant: 'success' })
+        setTextValue(tempTextValue)
       })
       .catch(function () {
-        enqueueSnackbar('Error saving course name:', { variant: 'error' })
+        enqueueSnackbar(props.failureMessage, { variant: 'error' })
         cancel()
       })
   }
   const cancel = (): void => {
     setIsEditing(false)
-    setTempName(courseName)
+    setTempTextValue(textValue)
   }
   const toggleEdit = (): void => {
     if (!isEditing) {
@@ -82,13 +85,13 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
     <form className={classes.root} noValidate autoComplete="off">
       <Grid container className={classes.inputArea}>
         <Grid item xs={8} sm={8}>
-          <TextField className={classes.inputRow} aria-readonly={false} onClick={toggleEdit} inputProps={{ style: { fontSize: 30 } }} ref={textInput} id="standard-basic" placeholder='Course Name' value={tempName} onKeyDown={(e) => keyPress(e.code)} onChange={(e) => setTempName(e.target.value)} disabled={!isEditing}/>
+          <TextField className={classes.inputRow} aria-readonly={false} onClick={toggleEdit} inputProps={{ style: { fontSize: 30 } }} ref={textInput} id="standard-basic" placeholder={props.placeholderText} value={tempTextValue} onKeyDown={(e) => keyPress(e.code)} onChange={(e) => setTempTextValue(e.target.value)} disabled={!isEditing}/>
         </Grid>
         {!isEditing
           ? (<Grid item xs={4} className={classes.inputRow}><EditIcon className={classes.editIcon} fontSize='inherit' onClick={toggleEdit}/></Grid>)
           : (<Grid container item xs={12} sm={4} className={classes.inputRow}>
               <Grid item xs={6} sm={6} >
-                <Button disabled={courseName === tempName} onClick={save}>Save</Button>
+                <Button disabled={textValue === tempTextValue} onClick={save}>Save</Button>
               </Grid>
               <Grid item xs={6} sm={6} >
                 <Button onClick={cancel}>Cancel</Button>

--- a/ccm_web/client/src/components/InlineTextEdit.tsx
+++ b/ccm_web/client/src/components/InlineTextEdit.tsx
@@ -23,17 +23,21 @@ const useStyles = makeStyles((theme) => ({
     '& svg': {
       paddingTop: '6px',
       paddingBottom: '7px'
+    },
+    '& input:disabled': {
+      cursor: 'pointer'
     }
+
   },
   inputRow: {
     height: '60px',
     paddingTop: '6px',
     paddingBottom: '7px',
-    fontSize: '30px'
+    fontSize: '24px'
   },
   editIcon: {
     cursor: 'pointer',
-    fontSize: '30px'
+    fontSize: '24px'
   },
   inputArea: {
     width: '500px'
@@ -85,7 +89,7 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
     <form className={classes.root} noValidate autoComplete="off">
       <Grid container className={classes.inputArea}>
         <Grid item xs={8} sm={8}>
-          <TextField className={classes.inputRow} aria-readonly={false} onClick={toggleEdit} inputProps={{ style: { fontSize: 30 } }} ref={textInput} id="standard-basic" placeholder={props.placeholderText} value={tempTextValue} onKeyDown={(e) => keyPress(e.code)} onChange={(e) => setTempTextValue(e.target.value)} disabled={!isEditing}/>
+          <TextField className={classes.inputRow} aria-readonly={false} onClick={toggleEdit} inputProps={{ style: { fontSize: 24 } }} ref={textInput} id="standard-basic" placeholder={props.placeholderText} value={tempTextValue} onKeyDown={(e) => keyPress(e.code)} onChange={(e) => setTempTextValue(e.target.value)} disabled={!isEditing}/>
         </Grid>
         {!isEditing
           ? (<Grid item xs={4} className={classes.inputRow}><EditIcon className={classes.editIcon} fontSize='inherit' onClick={toggleEdit}/></Grid>)

--- a/ccm_web/client/src/components/InlineTextEdit.tsx
+++ b/ccm_web/client/src/components/InlineTextEdit.tsx
@@ -1,0 +1,65 @@
+import React, { useRef, useState } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import { Button, TextField } from '@material-ui/core'
+import { Edit as EditIcon } from '@material-ui/icons'
+
+interface InlineTextEditProps {
+  text: string
+  save: (courseName: string) => Promise<void>
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: '5px'
+  }
+}))
+
+function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
+  const classes = useStyles()
+  const [isEditing, setIsEditing] = useState(false)
+  const [courseName, setCourseName] = useState(props.text)
+  const [tempName, setTempName] = useState(props.text)
+
+  const textInput = useRef(null)
+
+  const save = (): void => {
+    setIsEditing(false)
+    props.save(tempName)
+      .then(() => setCourseName(tempName))
+      .catch(function (error: string) {
+        alert('error: ' + error)
+        cancel()
+      })
+  }
+  const cancel = (): void => {
+    setIsEditing(false)
+    setTempName(courseName)
+  }
+  const toggleEdit = (): void => {
+    setIsEditing(!isEditing)
+  }
+
+  const keyPress = (code: string): void => {
+    if (code === 'Enter' || code === 'NumpadEnter') {
+      save()
+    } else if (code === 'Escape') {
+      cancel()
+    }
+  }
+
+  return (
+    <form className={classes.root} noValidate autoComplete="off">
+      <TextField ref={textInput} id="standard-basic" placeholder='Course Name' value={tempName} onKeyDown={(e) => keyPress(e.code)} onChange={(e) => setTempName(e.target.value)} disabled={!isEditing}/>
+      {!isEditing
+        ? (<EditIcon fontSize='small' onClick={toggleEdit}/>)
+        : (<span>
+        <Button onClick={save}>Save</Button>
+        <Button onClick={cancel}>Cancel</Button>
+        </span>)
+      }
+    </form>
+  )
+}
+
+export type { InlineTextEditProps }
+export default InlineTextEdit

--- a/ccm_web/client/src/pages/Home.tsx
+++ b/ccm_web/client/src/pages/Home.tsx
@@ -9,6 +9,7 @@ import LibraryBooksOutlinedIcon from '@material-ui/icons/LibraryBooksOutlined'
 import MergeTypeIcon from '@material-ui/icons/MergeType'
 import PersonAddIcon from '@material-ui/icons/PersonAdd'
 import PersonAddOutlinedIcon from '@material-ui/icons/PersonAddOutlined'
+import InlineTextEdit from '../components/InlineTextEdit'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -67,8 +68,18 @@ function Home (): JSX.Element {
 
   const cards: FeatureCardProps[] = [mergeSectionProps, gradebookToolsProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps]
 
+  const saveCourseName = async (courseName: string): Promise<void> => await new Promise<void>((resolve, reject) => {
+    console.log('saveCourseName ' + courseName)
+    if (courseName === 'reject') {
+      reject(new Error('Rejected as requested'))
+    } else {
+      return resolve()
+    }
+  })
+
   return (
     <div className={classes.root}>
+      <InlineTextEdit {...{ text: 'Course 123ABC', save: saveCourseName }} />
       <Grid container spacing={3}>
         {cards.sort((a, b) => (a.ordinality < b.ordinality) ? -1 : 1).map(p => {
           return (

--- a/ccm_web/client/src/pages/Home.tsx
+++ b/ccm_web/client/src/pages/Home.tsx
@@ -29,7 +29,7 @@ function Home (): JSX.Element {
 
   return (
     <div className={classes.root}>
-      <InlineTextEdit {...{ text: 'Course 123ABC', save: saveCourseName }} />
+      <InlineTextEdit {...{ text: 'Course 123ABC', save: saveCourseName, placeholderText: 'Course name', successMessage: 'Saved', failureMessage: 'Error saving course name' }} />
       <Grid container spacing={3}>
         {features.sort((a, b) => (a.data.ordinality < b.data.ordinality) ? -1 : 1).map(featureProps => {
           return (

--- a/ccm_web/package-lock.json
+++ b/ccm_web/package-lock.json
@@ -3448,6 +3448,11 @@
         "object.assign": "^4.1.2"
       }
     },
+    "keycode-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keycode-js/-/keycode-js-3.1.0.tgz",
+      "integrity": "sha512-aAa8PVW7kBDyG14ifGOseaVBjsT1LI953060yRSzzf3G0beKKEuwHVvFGcCI+AofY68NUkPxbLqrkfWPjXySCw=="
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -3886,6 +3891,15 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk=",
       "dev": true
+    },
+    "notistack": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-1.0.5.tgz",
+      "integrity": "sha512-xCMG0OhzEdczmDs2lDABEiphKQMZUavdOIRAJhfIcyJkCA4UqBDANL3YCLt+mz8VbAPCeKTn76kbCmYQIqksnA==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "npm-run-path": {
       "version": "4.0.1",

--- a/ccm_web/package.json
+++ b/ccm_web/package.json
@@ -18,6 +18,8 @@
     "css-loader": "^5.1.1",
     "express": "^4.17.1",
     "html-webpack-plugin": "^5.2.0",
+    "keycode-js": "^3.1.0",
+    "notistack": "^1.0.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",


### PR DESCRIPTION
I've done some work to create an inline text field editor for course rename.

I'm not sure how the data is going to get fed into it, and how it is going to save so it's going to have to be modified, but hopefully the general idea is sound.  Right now it is just passed a string, the course name, and a function to pass a string to to save changes.

That function is defined in Home.tsx where the InlineTextEdit element is declared.  I'm sure this will annoy @ssciolla :)

You can enable edit mode by clicking on the pencil icon, or clicking on the disabled text field (I haven't figured out how to override the cursor on the text field thus far)

Click save or cancel to save or cancel.  Enter or num-pad enter save. Escape cancels.  Only changes will be saved.
Trying to save 'reject' as a course name demonstrates a failed  save.

Success/failure notification through snackbar (toast) added to main app