### PR TITLE
Add server logging approach using `winston` (#38)

### DIFF
--- a/ccm_web/package-lock.json
+++ b/ccm_web/package-lock.json
@@ -160,6 +160,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
@@ -1866,6 +1876,30 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
       "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        }
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1878,8 +1912,16 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "color-string": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "colorette": {
       "version": "1.2.2",
@@ -1891,6 +1933,15 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
       "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -2368,6 +2419,11 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
+    },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -3039,6 +3095,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
     "fast-url-parser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
@@ -3068,6 +3129,11 @@
       "requires": {
         "reusify": "^1.0.4"
       }
+    },
+    "fecha": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -3137,6 +3203,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -3859,8 +3930,7 @@
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
     "is-string": {
       "version": "1.0.5",
@@ -4181,6 +4251,11 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "latest-version": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -4285,6 +4360,25 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
     },
     "long": {
       "version": "4.0.0",
@@ -5095,6 +5189,14 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "requires": {
+        "fn.name": "1.x.x"
       }
     },
     "onetime": {
@@ -6318,6 +6420,21 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6446,6 +6563,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "statuses": {
       "version": "1.5.0",
@@ -6745,6 +6867,11 @@
         }
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -6804,6 +6931,11 @@
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
       }
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-loader": {
       "version": "8.0.18",
@@ -7266,6 +7398,60 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
+    },
+    "winston": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "wkx": {
       "version": "0.5.0",

--- a/ccm_web/package.json
+++ b/ccm_web/package.json
@@ -23,7 +23,8 @@
     "notistack": "^1.0.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-router-dom": "^5.2.0"
+    "react-router-dom": "^5.2.0",
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.9",

--- a/ccm_web/server/app.ts
+++ b/ccm_web/server/app.ts
@@ -3,11 +3,15 @@ import path from 'path'
 import AppHandler from './appHandler'
 import apiRouter from './apiRouter'
 import { validateConfig } from './config'
+import baseLogger from './logger'
 
 const { NODE_ENV } = process.env
 
 const config = validateConfig(process.env)
 if (config === undefined) process.exit(1)
+
+baseLogger.level = config.server.logLevel
+const logger = baseLogger.child({ filePath: __filename })
 
 const isDev = NODE_ENV !== 'production'
 
@@ -20,6 +24,6 @@ const appHandler = new AppHandler(config, envOptions, apiRouter)
 // TO DO: need to implement database availability check
 setTimeout(() => {
   appHandler.startApp()
-    .then(() => console.log('The application was successfully started.'))
-    .catch((error) => console.error('An error occurred while starting the application.', error))
+    .then(() => logger.info('The application was successfully started.'))
+    .catch((error) => logger.error('An error occurred while starting the application.', error))
 }, 15000)

--- a/ccm_web/server/appHandler.ts
+++ b/ccm_web/server/appHandler.ts
@@ -6,11 +6,14 @@ import { IdToken, Provider } from 'ltijs'
 import Database from 'ltijs-sequelize'
 
 import { Config } from './config'
+import baseLogger from './logger'
 
 interface EnvOptions {
   isDev: boolean
   staticPath: string
 }
+
+const logger = baseLogger.child({ filePath: __filename })
 
 class AppHandler {
   private readonly config: Config
@@ -54,7 +57,7 @@ class AppHandler {
 
     // Redirect to the application root after a successful launch
     provider.onConnect(async (token: IdToken, req: Request, res: Response) => {
-      console.log(token.userInfo)
+      logger.debug(JSON.stringify(token.userInfo))
       return res.sendFile(path.join(this.envOptions.staticPath, 'index.html'))
     })
 
@@ -79,14 +82,14 @@ class AppHandler {
     const app = express()
 
     // Order of middleware matters
-    console.log('Loading client static assets...')
+    logger.info('Loading client static assets...')
     app.use('/static', express.static(this.envOptions.staticPath))
 
-    console.log('Adding ltijs as middleware...')
+    logger.info('Adding ltijs as middleware...')
     const ltiApp = await this.setupLTI()
     app.use(ltiApp)
 
-    console.log('Installing backend API router...')
+    logger.info('Installing backend API router...')
     app.use('/api', this.apiRouter)
 
     // Pass requests to other routes to SPA
@@ -95,7 +98,7 @@ class AppHandler {
     })
 
     app.listen(server.port, () => {
-      console.log(`Server started on localhost and port ${server.port}`)
+      logger.info(`Server started on localhost and port ${server.port}`)
     })
   }
 }

--- a/ccm_web/server/config.ts
+++ b/ccm_web/server/config.ts
@@ -1,5 +1,10 @@
+import baseLogger from './logger'
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
 interface ServerConfig {
   port: number
+  logLevel: LogLevel
 }
 
 interface LTIConfig {
@@ -25,8 +30,13 @@ export interface Config {
   db: DatabaseConfig
 }
 
+const logger = baseLogger.child({ filePath: __filename })
+
 const isString = (v: unknown): v is string => typeof v === 'string'
 const isNumber = (v: unknown): v is number => typeof v === 'number' && !isNaN(v)
+const isLogLevel = (v: unknown): v is LogLevel => {
+  return isString(v) && ['debug', 'info', 'warn', 'error'].includes(v)
+}
 
 function validate<T> (
   key: string,
@@ -37,7 +47,7 @@ function validate<T> (
   const errorBase = 'Exception while loading configuration: '
   if (check(value)) return value
   if (fallback !== undefined) {
-    console.log(`Value ${String(value)} for ${key} is invalid; using fallback ${String(fallback)}`)
+    logger.info(`Value ${String(value)} for ${key} is invalid; using fallback ${String(fallback)}`)
     return fallback
   }
   throw (Error(errorBase + `Value ${String(value)} for ${key} is not valid`))
@@ -50,7 +60,8 @@ export function validateConfig (env: Record<string, unknown>): Config | undefine
 
   try {
     server = {
-      port: validate<number>('PORT', Number(env.PORT), isNumber, 4000)
+      port: validate<number>('PORT', Number(env.PORT), isNumber, 4000),
+      logLevel: validate<LogLevel>('LOG_LEVEL', env.LOG_LEVEL, isLogLevel, 'debug')
     }
     lti = {
       encryptionKey: validate<string>('LTI_ENCRYPTION_KEY', env.LTI_ENCRYPTION_KEY, isString, 'LTIKEY'),
@@ -68,7 +79,7 @@ export function validateConfig (env: Record<string, unknown>): Config | undefine
       password: validate<string>('DB_PASSWORD', env.DB_PASSWORD, isString)
     }
   } catch (error) {
-    console.error(error)
+    logger.error(error)
   }
   if (server !== undefined && lti !== undefined && db !== undefined) {
     return { server, lti, db }

--- a/ccm_web/server/logger.ts
+++ b/ccm_web/server/logger.ts
@@ -1,0 +1,21 @@
+import path from 'path'
+import winston, { format } from 'winston'
+
+const logFormat = format.printf(
+  ({ level, message, timestamp, filePath }) => {
+    const moduleName = path.basename(filePath, '.ts')
+    return `${String(timestamp)} - ${moduleName} - ${level} - ${message}`
+  }
+)
+
+const baseLogger = winston.createLogger({
+  transports: [new winston.transports.Console()],
+  format: format.combine(
+    format.timestamp(),
+    format.colorize(),
+    logFormat
+  ),
+  exitOnError: false
+})
+
+export default baseLogger

--- a/ccm_web/server/logger.ts
+++ b/ccm_web/server/logger.ts
@@ -3,7 +3,7 @@ import winston, { format } from 'winston'
 
 const logFormat = format.printf(
   ({ level, message, timestamp, filePath }) => {
-    const moduleName = path.basename(filePath, '.ts')
+    const moduleName = path.basename(filePath)
     return `${String(timestamp)} - ${moduleName} - ${level} - ${message}`
   }
 )

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -2,6 +2,8 @@
 
 # Port that the server should listen on within the container (Optional)
 # PORT=4000
+# One of the following npm log levels: debug, info, warn, error
+# LOG_LEVEL=debug
 
 # Key used by ltijs for cookie signing and data encryption
 # LTI_ENCRYPTION_KEY=LTIKEY


### PR DESCRIPTION
This PR adds a server logging approach similar to our other applications using the `winston` library, which seems widely used (though has a lot of open PRs/issues). On a high level, a `baseLogger` is set with most configuration; configuration validation logic uses the default logging; the minimum log level shown is set in `app.ts` after the configuration is loaded; and each module sets up a child logger, passing `__filename` so the logger format function can determine the module. The PR aims to resolve #38.

Note: I am choosing to wait on determining the best HTTP request logging approach until we decide whether we will add an additional framework/tool for building out the internal application API. I will separate that piece out into a new issue.

Resources:
* [`winston`](https://github.com/winstonjs/winston)