### PR TITLE
Add OpenAPI/Swagger (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,24 @@ for generating module and other code stubs and performing other tasks.
 As the necessary libraries are not included in `package.json`, follow the documentation's suggestion
 and install `@nestjs/cli` globally on your machine if you want to use the tool.
 
+#### Using OpenAPI and Swagger
+
+When in development mode (i.e. the `NODE_ENV` environment variable's value is `development`),
+the application generates [OpenAPI](https://www.openapis.org/) documentation and an explorer for
+the API endpoints using recommended [Nest patterns](https://docs.nestjs.com/openapi/introduction) and
+[Swagger](https://swagger.io/).
+
+To access and use the Swagger UI, launch the application from a course in Canvas,
+then click on the "Swagger UI" link in the application interface's footer.
+This will take you to the Swagger page where you can view the documented API endpoints.
+
+However, to execute requests using Swagger, you need to authenticate using a Bearer token.
+The token is currently made available as a URL parameter called `token`, which you can see and copy
+by using a browser tool to view the frame's source.
+Once the token is obtained, in the Swagger UI, click the "Authorize" button, paste the token in the popup field,
+and then click "Authorize" to complete the process.
+Subsequent requests made using the "Try it out" functionality will pass the token in the proper header.
+
 ### Production
 
 Taken together, all the stages in `ccm_web/Dockerfile` will build an optimized image for production.

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -92,6 +92,10 @@ function App (props: AppProps): JSX.Element {
           </Switch>
         </Router>
         <ConsumerTest ltiKey={props.ltiKey} />
+        {
+          globals?.environment === 'development' && props.ltiKey !== undefined &&
+            <Link href={`/swagger?token=${props.ltiKey}`}>Swagger UI</Link>
+        }
       </SnackbarProvider>
     </div>
   )

--- a/ccm_web/package-lock.json
+++ b/ccm_web/package-lock.json
@@ -995,6 +995,11 @@
         }
       }
     },
+    "@nestjs/mapped-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-0.4.0.tgz",
+      "integrity": "sha512-TVtd/aTb7EqPhVczdeuvzF9dY0fyE3ivvCstc2eO+AkNqrfzSG1kXYYiUUznKjd0qDa8g2TmPSmHUQ21AXsV1Q=="
+    },
     "@nestjs/platform-express": {
       "version": "7.6.15",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-7.6.15.tgz",
@@ -1005,6 +1010,23 @@
         "express": "4.17.1",
         "multer": "1.4.2",
         "tslib": "2.1.0"
+      }
+    },
+    "@nestjs/swagger": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-4.8.0.tgz",
+      "integrity": "sha512-YU+ahCOoOTZwSHrODHBiQDCqi7GWEjmSFg3Tot/lwVuQ321/3fIOz/lf+ehVQ5DFr7nVMhB7BRWFJLtE/+NhqQ==",
+      "requires": {
+        "@nestjs/mapped-types": "0.4.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
+          "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA=="
+        }
       }
     },
     "@nestjs/testing": {
@@ -1313,7 +1335,7 @@
     "@types/express-serve-static-core": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
-      "integrity": "sha1-AKz8FjLnKaysTxUw6eFvbdFQih0=",
+      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1503,7 +1525,7 @@
     "@types/qs": {
       "version": "6.9.6",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha1-35w8izGiR+wxXmmWVmvjFx30s7E=",
+      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==",
       "dev": true
     },
     "@types/range-parser": {
@@ -10249,6 +10271,19 @@
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.48.0.tgz",
+      "integrity": "sha512-UgpKIQW5RAb4nYRG8B615blmQzct0DNuvtX4904Fe2aMWAVfWeKHKl4kwzFXuBJgr2WYWTwM1PnhZ+qqkLrpPg=="
+    },
+    "swagger-ui-express": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
+      "integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
       }
     },
     "symbol-observable": {

--- a/ccm_web/package.json
+++ b/ccm_web/package.json
@@ -25,6 +25,7 @@
     "@nestjs/config": "^0.6.3",
     "@nestjs/core": "^7.6.15",
     "@nestjs/platform-express": "^7.6.15",
+    "@nestjs/swagger": "^4.8.0",
     "express": "^4.17.1",
     "keycode-js": "^3.1.0",
     "ltijs": "~5.7.3",
@@ -36,6 +37,7 @@
     "react-router-dom": "^5.2.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.6.6",
+    "swagger-ui-express": "^4.1.6",
     "winston": "^3.3.3"
   },
   "devDependencies": {

--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Get } from '@nestjs/common'
+import { ApiBearerAuth } from '@nestjs/swagger'
 
 import { HelloData, Globals } from './api.interfaces'
 import { APIService } from './api.service'
 
+@ApiBearerAuth()
 @Controller('api')
 export class APIController {
   constructor (private readonly apiService: APIService) {}

--- a/ccm_web/server/src/main.ts
+++ b/ccm_web/server/src/main.ts
@@ -26,20 +26,22 @@ async function bootstrap (): Promise<void> {
   )
   app.useStaticAssets(staticPath, { prefix: '/' })
 
-  const swaggerConfig = new DocumentBuilder()
-    .addBearerAuth({
-      type: 'http',
-      description: (
-        'The bearer token can be found in the "token" URL parameter' +
-        ' (use View Frame Source).'
-      )
-    })
-    .setTitle('Canvas Course Manager')
-    .setDescription('CCM application API description and explorer')
-    .build()
+  if (isDev) {
+    const swaggerConfig = new DocumentBuilder()
+      .setTitle('Canvas Course Manager')
+      .setDescription('CCM application API description and explorer')
+      .addBearerAuth({
+        type: 'http',
+        description: (
+          'The bearer token can be found in the "token" URL parameter' +
+          ' (use View Frame Source).'
+        )
+      })
+      .build()
 
-  const document = SwaggerModule.createDocument(app, swaggerConfig)
-  SwaggerModule.setup('swagger', app, document)
+    const document = SwaggerModule.createDocument(app, swaggerConfig)
+    SwaggerModule.setup('swagger', app, document)
+  }
 
   await app.listen(
     serverConfig.port,

--- a/ccm_web/server/src/main.ts
+++ b/ccm_web/server/src/main.ts
@@ -34,7 +34,7 @@ async function bootstrap (): Promise<void> {
         type: 'http',
         description: (
           'The bearer token can be found in the "token" URL parameter' +
-          ' (use View Frame Source).'
+          ' (use a browser tool to view the URL of the frame).'
         )
       })
       .build()

--- a/ccm_web/server/src/main.ts
+++ b/ccm_web/server/src/main.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { ConfigService } from '@nestjs/config'
 import { NestFactory } from '@nestjs/core'
 import { NestExpressApplication } from '@nestjs/platform-express'
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 
 import { AppModule } from './app.module'
 import { ServerConfig } from './config'
@@ -10,7 +11,7 @@ import baseLogger from './logger'
 
 const logger = baseLogger.child({ filePath: __filename })
 
-async function bootstrap () {
+async function bootstrap (): Promise<void> {
   const app = await NestFactory.create<NestExpressApplication>(AppModule)
 
   const configService = app.get(ConfigService)
@@ -24,6 +25,21 @@ async function bootstrap () {
     isDev ? path.join('dist', 'client') : 'client'
   )
   app.useStaticAssets(staticPath, { prefix: '/' })
+
+  const swaggerConfig = new DocumentBuilder()
+    .addBearerAuth({
+      type: 'http',
+      description: (
+        'The bearer token can be found in the "token" URL parameter' +
+        ' (use View Frame Source).'
+      )
+    })
+    .setTitle('Canvas Course Manager')
+    .setDescription('CCM application API description and explorer')
+    .build()
+
+  const document = SwaggerModule.createDocument(app, swaggerConfig)
+  SwaggerModule.setup('swagger', app, document)
 
   await app.listen(
     serverConfig.port,


### PR DESCRIPTION
This PR adds an OpenAPI API specification generator and a Swagger UI interface to the project, following the patterns laid out [here](https://docs.nestjs.com/openapi/introduction). Currently, it is only supported in an LTI context (same as the application). The code is only invoked in development. The PR resolves #82.

Note(s): 
* I looked into loading the necessary modules conditionally (so they can only be `devDependencies`), but because decorators are/will be used throughout to generate the spec, this seemed difficult. See https://github.com/nestjs/swagger/issues/184