### PR TITLE
Fix `returnFromOAuth` URL in README, provide recommended `CANVAS_INSTANCE_URL`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Explicit steps for setting up CCM in a development environment.
 
 14. Go to Canvas "Developer Keys" management available from the "Admin" page for your account. Click the button for "+ Developer Key", then "+ API Key".
 
-15. Add a tool name in the "Name" field, and under "Redirect URI(s)" add `https:{ngrok_url}/canvas/redirectFromOAuth` where `{ngrok_url}`
+15. Add a tool name in the "Name" field, and under "Redirect URI(s)" add `https:{ngrok_url}/canvas/returnFromOAuth` where `{ngrok_url}`
 is the `ngrok` hostname copied earlier (in step 2).
 
 16. Add all scopes needed by the application, i.e. so that they match those listed in `ccm_web/server/src/canvas/canvas.scopes.ts`.

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -23,7 +23,7 @@ LTI_TOKEN_ENDING=/login/oauth2/token
 LTI_KEYSET_ENDING=/api/lti/security/jwks
 
 # Base URL to use for auth and API calls
-CANVAS_INSTANCE_URL=
+CANVAS_INSTANCE_URL=https://canvas-test.umich.edu
 # Client for the Canvas Developer Key associated with the application
 CANVAS_API_CLIENT_ID=
 # Secret for the Canvas Developer Key associated with the application


### PR DESCRIPTION
This PR makes two small modifications to fix an incorrect URL in the step-by-step instructions (`/canvas/redirectFromOAuth` => `/canvas/returnFromOAuth`; is already correct under Configuration - Canvas section) and supply a recommended value for `CANVAS_INSTANCE_URL` in `.env.sample` (currently the Canvas test instance, which is consistent with the `LTI_PLATFORM_URL` value provided).