### PR TITLE
Switch to using underscored table and field names (#126)

### DIFF
--- a/ccm_web/server/src/app.module.ts
+++ b/ccm_web/server/src/app.module.ts
@@ -35,7 +35,8 @@ const logger = baseLogger.child({ filePath: __filename})
         password: configService.get('db.password'),
         database: configService.get('db.name'),
         models: [CanvasToken, User],
-        logging: (message: string) => logger.debug(message)
+        logging: (message: string) => logger.debug(message),
+        define: { underscored: true }
       })
     }),
     UserModule,

--- a/ccm_web/server/src/app.module.ts
+++ b/ccm_web/server/src/app.module.ts
@@ -36,7 +36,7 @@ const logger = baseLogger.child({ filePath: __filename})
         database: configService.get('db.name'),
         models: [CanvasToken, User],
         logging: (message: string) => logger.debug(message),
-        define: { underscored: true }
+        define: { underscored: true } // Included here to ensure session table uses snake_case
       })
     }),
     UserModule,

--- a/ccm_web/server/src/canvas/canvas.model.ts
+++ b/ccm_web/server/src/canvas/canvas.model.ts
@@ -15,7 +15,6 @@ interface CanvasTokenCreationAttributes extends Optional<CanvasTokenAttributes, 
 @Table({
   tableName: 'canvas_token',
   freezeTableName: true,
-  underscored: true,
   timestamps: false
 })
 export class CanvasToken extends Model<CanvasTokenAttributes, CanvasTokenCreationAttributes> {

--- a/ccm_web/server/src/canvas/canvas.model.ts
+++ b/ccm_web/server/src/canvas/canvas.model.ts
@@ -13,8 +13,9 @@ interface CanvasTokenAttributes {
 interface CanvasTokenCreationAttributes extends Optional<CanvasTokenAttributes, 'id'> {}
 
 @Table({
-  tableName: 'canvasToken',
+  tableName: 'canvas_token',
   freezeTableName: true,
+  underscored: true,
   timestamps: false
 })
 export class CanvasToken extends Model<CanvasTokenAttributes, CanvasTokenCreationAttributes> {

--- a/ccm_web/server/src/migrations/2021.06.16T19.36.19.create-user.ts
+++ b/ccm_web/server/src/migrations/2021.06.16T19.36.19.create-user.ts
@@ -11,11 +11,13 @@ export const up: Migration = async ({ context: sequelize }) => {
     },
     firstName: {
       allowNull: true,
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      field: 'first_name'
     },
     lastName: {
       allowNull: true,
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      field: 'last_name'
     },
     email: {
       allowNull: true,
@@ -24,15 +26,18 @@ export const up: Migration = async ({ context: sequelize }) => {
     loginId: {
       allowNull: false,
       unique: true,
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      field: 'login_id'
     },
     createdAt: {
       allowNull: false,
-      type: DataTypes.DATE
+      type: DataTypes.DATE,
+      field: 'created_at'
     },
     updatedAt: {
       allowNull: false,
-      type: DataTypes.DATE
+      type: DataTypes.DATE,
+      field: 'updated_at'
     }
   })
 }

--- a/ccm_web/server/src/migrations/2021.06.16T19.36.43.create-canvas-token.ts
+++ b/ccm_web/server/src/migrations/2021.06.16T19.36.43.create-canvas-token.ts
@@ -2,7 +2,7 @@ import { DataTypes } from 'sequelize'
 import { Migration } from '../migrator'
 
 export const up: Migration = async ({ context: sequelize }) => {
-  await sequelize.getQueryInterface().createTable('canvasToken', {
+  await sequelize.getQueryInterface().createTable('canvas_token', {
     id: {
       allowNull: false,
       autoIncrement: true,
@@ -12,19 +12,22 @@ export const up: Migration = async ({ context: sequelize }) => {
     userId: {
       allowNull: false,
       type: DataTypes.BIGINT,
-      references: { model: 'user', key: 'id' }
+      references: { model: 'user', key: 'id' },
+      field: 'user_id'
     },
     accessToken: {
       allowNull: false,
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      field: 'access_token'
     },
     refreshToken: {
       allowNull: false,
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      field: 'refresh_token'
     }
   })
 }
 
 export const down: Migration = async ({ context: sequelize }) => {
-  await sequelize.getQueryInterface().dropTable('canvasToken')
+  await sequelize.getQueryInterface().dropTable('canvas_token')
 }

--- a/ccm_web/server/src/migrator.ts
+++ b/ccm_web/server/src/migrator.ts
@@ -25,7 +25,7 @@ export const umzug = new Umzug({
     }
   },
   context: sequelize,
-  storage: new SequelizeStorage({ sequelize, tableName: 'app_sequelize_meta' }),
+  storage: new SequelizeStorage({ sequelize, tableName: 'ccm_sequelize_meta' }),
   logger: logger
 })
 

--- a/ccm_web/server/src/migrator.ts
+++ b/ccm_web/server/src/migrator.ts
@@ -25,7 +25,7 @@ export const umzug = new Umzug({
     }
   },
   context: sequelize,
-  storage: new SequelizeStorage({ sequelize }),
+  storage: new SequelizeStorage({ sequelize, tableName: 'app_sequelize_meta' }),
   logger: logger
 })
 

--- a/ccm_web/server/src/user/user.model.ts
+++ b/ccm_web/server/src/user/user.model.ts
@@ -20,8 +20,7 @@ interface UserCreationAttributes extends Optional<UserAttributes, 'id'> {
 // Sequelize Datatypes mapping with Mysql https://sequelize.org/master/manual/model-basics.html#data-types
 @Table({
   tableName: 'user',
-  freezeTableName: true,
-  underscored: true
+  freezeTableName: true
 })
 export class User extends Model<UserAttributes, UserCreationAttributes> {
   @Column({

--- a/ccm_web/server/src/user/user.model.ts
+++ b/ccm_web/server/src/user/user.model.ts
@@ -20,7 +20,8 @@ interface UserCreationAttributes extends Optional<UserAttributes, 'id'> {
 // Sequelize Datatypes mapping with Mysql https://sequelize.org/master/manual/model-basics.html#data-types
 @Table({
   tableName: 'user',
-  freezeTableName: true
+  freezeTableName: true,
+  underscored: true
 })
 export class User extends Model<UserAttributes, UserCreationAttributes> {
   @Column({


### PR DESCRIPTION
This PR modifies existing migrations and model definitions so table name and field names use `snake_case`, with the goal of avoiding case-related issues. Modifying migrations was deemed safe by the team, because we have no deployments; timestamps have been updated. Model and attribute names in TS-code still use `[cC]amelCase`, to be consistent with JS best practices. The PR aims to resolve #126.

**Note: you will need to delete your database volume (`.mysql_data`) before running this locally, and if/when it is merged.**