### PR TITLE
configure Sequelize to log at `debug` level (iss. #91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,22 @@ but as necessary, rebuild the image using Step 1.
 
 Explicit steps for setting up CCM in a development environment.
 
+##### Start local ngrok server
+
 1. Start an ngrok instance for the application, which will run on port 4000.
    `ngrok http 4000`
 2. Make note of the hostname of the ngrok instance for use later.  The hostname may be found in the console output or it can be obtained from the ngrok API.  For example, if `jq` is installed, use the command:
    `curl --silent http://127.0.0.1:4040/api/tunnels | jq -r '.tunnels[0].public_url'`
-   ***Note:*** Get only the hostname, not the `http`/`https` scheme prefix.  
+   ***Note:*** Get only the hostname, not the `http`/`https` scheme prefix.
+
+##### Create LTI configuration file
+
 3. Create an LTI key JSON file, based on the sample provided.
    `cp config/lti_dev_key_sample.json lti_dev_key.json`
 4. Edit the new `lti_dev_key.json` file to add or replace settings from the sample.  Replace all occurrences of `{ccm_app_hostname}` with the ngrok hostname copied in the earlier step.
+
+##### Configure Canvas LTI key
+
 5. Go to Canvas "Developer Keys" management page available from the "Admin" page for your account.  Click the button for "+ Developer Key", then "+ LTI Key".
 6. When the "Key Settings" modal appears, select "Paste JSON" from the "Method" menu in the "Configure" section.  Then copy the contents of `config/lti_dev_key.json` and paste it into the "LTI 1.3 Configuration" field.
 7. *Recommended:* Enter a name for the application in the "Key Name" field and an email address in the "Owner Email" field.
@@ -98,44 +106,53 @@ Explicit steps for setting up CCM in a development environment.
     1. Note:  After saving, using "Paste JSON" under the "Method" menu, will show the corresponding JSON for the LTI Advantage configuration changes.  Enabling the LTI Advantage options adds them to the `scopes` key of the JSON.
 10. Copy the ID number of the LTI key created in Canvas.  The ID is the long number shown in the "Details" column of the "Developer Keys" page.  It usually looks like "`17700000000000nnn`".
 11. Click the "ON" part of the switch in the "State" column of your LTI key, so that it has a green background.
+
+##### Configure Canvas API key
+
 12. Go to Canvas "Developer Keys" management available from the "Admin" page for your account. Click the button for "+ Developer Key", then "+ API Key".
 13. Enter a name in the "Key Name" field, and under "Redirect URIs" enter:
-    `https://{ccm_app_hostname}/canvas/returnFromOAuth`
-    Where `{ccm_app_hostname}` is the ngrok hostname copied earlier (in step 2).
-    ***Note:*** Do ***NOT*** use the "Redirect URI (Legacy)" field.
+     `https://{ccm_app_hostname}/canvas/returnFromOAuth`
+     Where `{ccm_app_hostname}` is the ngrok hostname copied earlier (in step 2).
+     ***Note:*** Do ***NOT*** use the "Redirect URI (Legacy)" field.
 14. Enable the "Enforce Scopes" option, then add all scopes needed by the application (i.e., those listed in `ccm_web/server/src/canvas/canvas.scopes.ts`).
 15. Click the "Save" button.
 16. Copy the ID number of the API key created in Canvas. The ID is the long number shown in the "Details" column of the "Developer Keys" page. It usually looks like "`17700000000000nnn`".
 17. Click the "Show Key" button underneath the ID located in step 15, and copy the secret that appears in the dialog.
 18. Click the "ON" part of the switch in the "State" column of your API key, so that it has a green background.
+
+##### Configure local environment
+
 19. Make a `.env` file for the project, based on the sample provided.
-    `cp config/.env.sample .env`
+     `cp config/.env.sample .env`
 20. Edit the `.env` file.  The keys in the following list must/should be updated.
 
-    1. `DOMAIN` – Hostname of the server hosting the CCM application.
-       For local development purposes with ngrok, use the hostname
-       copied during step 2.
-    2. Verify the `LTI_PLATFORM_URL` variable value is correct for the instance of Canvas used.
-    3. Add to the `LTI_CLIENT_ID` variable value the LTI key ID number copied earlier (in step 10).
-    4. `CANVAS_INSTANCE_URL` – For U-M development/testing, this should
-       be `https://canvas-test.it.umich.edu`.  Note that this is the URL
-       that would be used by the user to access Canvas.  It may be 
-       different from the value of the `LTI_PLATFORM_URL` key.
-    5. Add to the `CANVAS_API_CLIENT_ID` variable value the API key copied earlier (in step 16).
-    6. Add to the `CANVAS_API_SECRET` variable value the secret copied earlier (in step 17).
+     1. `DOMAIN` – Hostname of the server hosting the CCM application.
+        For local development purposes with ngrok, use the hostname
+        copied during step 2.
+     2. Verify the `LTI_PLATFORM_URL` variable value is correct for the instance of Canvas used.
+     3. Add to the `LTI_CLIENT_ID` variable value the LTI key ID number copied earlier (in step 10).
+     4. `CANVAS_INSTANCE_URL` – For U-M development/testing, this should
+        be `https://canvas-test.it.umich.edu`.  Note that this is the URL
+        that would be used by the user to access Canvas.  It may be 
+        different from the value of the `LTI_PLATFORM_URL` key.
+     5. Add to the `CANVAS_API_CLIENT_ID` variable value the API key copied earlier (in step 16).
+     6. Add to the `CANVAS_API_SECRET` variable value the secret copied earlier (in step 17).
+
+##### Build, start, and run application
+
 21. Build and start the application with docker-compose.
 
-    1. `docker-compose build`
-    2. `docker-compose up`
+     1. `docker-compose build`
+     2. `docker-compose up`
 22. Add the CCM LTI tool to a course.  
-    1. Course home page → "Settings" → "Apps" tab → "View App Configurations" button.
-        Alternatively, if working in the Canvas test environment, go to 
-        (https://canvas-test.it.umich.edu/courses/nnnnnn/settings/configurations),
-        where "nnnnnn" is the course ID.
-    2. Click the "+App" button.
-    3. In the "Configuration Type" menu, select "By Client ID".
-    4. In the "Client ID" field, paste in the same ID number that was added to `LTI_CLIENT_ID` in the `.env` file above.
-    5. When prompted to verify the ID for the tool, click the "Install" button.
+     1. Course home page → "Settings" → "Apps" tab → "View App Configurations" button.
+         Alternatively, if working in the Canvas test environment, go to 
+         (https://canvas-test.it.umich.edu/courses/nnnnnn/settings/configurations),
+         where "nnnnnn" is the course ID.
+     2. Click the "+App" button.
+     3. In the "Configuration Type" menu, select "By Client ID".
+     4. In the "Client ID" field, paste in the same ID number that was added to `LTI_CLIENT_ID` in the `.env` file above.
+     5. When prompted to verify the ID for the tool, click the "Install" button.
 
 #### Database Migrations
 
@@ -165,8 +182,9 @@ Developers have to write `up` and `down` migration steps manually.
     environment.
 
 #### Troubleshooting
-   
+
 1. ***Error:***
+   
    ```txt
    ccm_web     | (node:64) UnhandledPromiseRejectionWarning: Error: An error occurred while setting up ltijs: Error: MISSING_PLATFORM_URL_OR_CLIENTID
    ccm_web     |     at /base/server/src/lti/lti.middleware.ts:22:15

--- a/ccm_web/server/src/app.module.ts
+++ b/ccm_web/server/src/app.module.ts
@@ -35,7 +35,7 @@ const logger = baseLogger.child({ filePath: __filename})
         password: configService.get('db.password'),
         database: configService.get('db.name'),
         models: [CanvasToken, User],
-        logging: (message: string) => logger.debug(message),
+        logging: (message: string) => logger.debug(message)
       })
     }),
     UserModule,

--- a/ccm_web/server/src/app.module.ts
+++ b/ccm_web/server/src/app.module.ts
@@ -11,7 +11,7 @@ import { User } from './user/user.model'
 import { UserService } from './user/user.service'
 
 import { validateConfig } from './config'
-import baseLogger from "./logger";
+import baseLogger from './logger';
 
 const logger = baseLogger.child({ filePath: __filename})
 

--- a/ccm_web/server/src/app.module.ts
+++ b/ccm_web/server/src/app.module.ts
@@ -11,6 +11,9 @@ import { User } from './user/user.model'
 import { UserService } from './user/user.service'
 
 import { validateConfig } from './config'
+import baseLogger from "./logger";
+
+const logger = baseLogger.child({ filePath: __filename})
 
 @Module({
   imports: [
@@ -31,7 +34,8 @@ import { validateConfig } from './config'
         username: configService.get('db.user'),
         password: configService.get('db.password'),
         database: configService.get('db.name'),
-        models: [CanvasToken, User]
+        models: [CanvasToken, User],
+        logging: (message: string) => logger.debug(message),
       })
     }),
     UserModule,


### PR DESCRIPTION
As was discussed in an earlier meeting, configured Sequelize to use the winston logger at `debug` level for logging its messages.

CCM's logging level is controlled by the `LOG_LEVEL` directive in `.env`.  If it is not set, the default level is `debug`.  If `LOG_LEVEL` is set to any level higher than `debug` (i.e., `info`, `notice`, `warning`, `error`, etc.), Sequelize's messages will not appear in the output.  (See: https://github.com/winstonjs/winston#logging-levels)

Resolves #91.

This took me longer than expected to implement due to Docker poor performance on my computer.  Having to restart the Docker daemon periodically impacts productivity.