### PR TITLE
Correct `User.canvasToken` type to be `CanvasToken | null` (#149)

### DIFF
--- a/ccm_web/server/src/canvas/canvas.service.ts
+++ b/ccm_web/server/src/canvas/canvas.service.ts
@@ -125,8 +125,7 @@ export class CanvasService {
       logger.error(`User ${userLoginId} is not in the database.`)
       throw new UserNotFoundError(userLoginId)
     }
-    const token = user.canvasToken === undefined ? null : user.canvasToken
-    return token
+    return user.canvasToken
   }
 
   async refreshToken (token: CanvasToken): Promise<CanvasToken> {

--- a/ccm_web/server/src/user/user.model.ts
+++ b/ccm_web/server/src/user/user.model.ts
@@ -45,5 +45,5 @@ export class User extends Model<UserAttributes, UserCreationAttributes> {
   loginId!: string
 
   @HasOne(() => CanvasToken)
-  canvasToken?: CanvasToken
+  canvasToken!: CanvasToken | null
 }


### PR DESCRIPTION
This PR fixes the type for `canvasToken` in `user.model.ts` so that it uses the correct `null` value for when it doesn't exist (previously `undefined`). I also simplified some code in `CanvasService.findToken` to return the token (`null` or not) directly. See the issue for more info on the bug. The PR aims to resolve #149.