### PR TITLE
#152, #88 Create sections backend endpoint

### DIFF
--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -4,7 +4,7 @@ import {
 } from '@nestjs/common'
 import { ApiBearerAuth } from '@nestjs/swagger'
 
-import { HelloData, isAPIErrorData, Globals } from './api.interfaces'
+import { isAPIErrorData, Globals } from './api.interfaces'
 import { APIService } from './api.service'
 import { CourseNameDto } from './dtos/api.course.name.dto'
 import { CanvasCourseBase } from '../canvas/canvas.interfaces'
@@ -14,11 +14,6 @@ import { CreateSectionsDto } from './dtos/api.create.sections.dto'
 @Controller('api')
 export class APIController {
   constructor (private readonly apiService: APIService) {}
-
-  @Get('hello')
-  getHello (): HelloData {
-    return this.apiService.getHello()
-  }
 
   @Get('globals')
   getGlobals (@Session() session: SessionData): Globals {

--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -1,18 +1,24 @@
 import { SessionData } from 'express-session'
 import {
-  Body, Controller, Get, HttpException, Param, ParseIntPipe, Put, Session
+  Body, Controller, Get, HttpException, Param, ParseIntPipe, Post, Put, Session
 } from '@nestjs/common'
 import { ApiBearerAuth } from '@nestjs/swagger'
 
-import { Globals, isAPIErrorData } from './api.interfaces'
+import { HelloData, isAPIErrorData, Globals } from './api.interfaces'
 import { APIService } from './api.service'
 import { CourseNameDto } from './dtos/api.course.name.dto'
 import { CanvasCourseBase } from '../canvas/canvas.interfaces'
+import { CreateSectionsDto } from './dtos/api.create.sections.dto'
 
 @ApiBearerAuth()
 @Controller('api')
 export class APIController {
   constructor (private readonly apiService: APIService) {}
+
+  @Get('hello')
+  getHello (): HelloData {
+    return this.apiService.getHello()
+  }
 
   @Get('globals')
   getGlobals (@Session() session: SessionData): Globals {
@@ -35,6 +41,15 @@ export class APIController {
   ): Promise<CanvasCourseBase> {
     const { userLoginId } = session.data
     const result = await this.apiService.putCourseName(userLoginId, courseId, courseNameDto.newName)
+    if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
+    return result
+  }
+
+  @Post('course/:id/sections')
+  async createSections (@Param('id', ParseIntPipe) courseId: number, @Body() createSectionsDto: CreateSectionsDto, @Session() session: SessionData): Promise<any> {
+    const { userLoginId } = session.data
+    const sections = createSectionsDto.sections
+    const result = await this.apiService.createSections(userLoginId, courseId, sections)
     if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
     return result
   }

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -1,0 +1,59 @@
+import CanvasRequestor from '@kth/canvas-api'
+import baseLogger from '../logger'
+import { CreateSectionResponseData, CreateSectionReturnResponse, CanvasSectionBase, CreateSectionsResponseObject, APIErrorData, handleAPIError } from './api.interfaces'
+
+const logger = baseLogger.child({ filePath: __filename })
+
+export class CreateSectionApiHandler {
+  constructor (private readonly requestor: CanvasRequestor,
+    private readonly sections: string[],
+    private readonly courseId: number) {}
+
+  async apiCreateSection (sectionName: string): Promise<CreateSectionsResponseObject> {
+    try {
+      const fake = `courses/${this.courseId}/sections/ding/dong`
+      const real = `courses/${this.courseId}/sections`
+      const endpoint = Math.random() < 0.5 ? real : fake
+      const method = 'POST'
+      const requestBody = { course_section: { name: sectionName } }
+      logger.debug(`Sending request to Canvas - Endpoint: ${endpoint}; Method: ${method}; Body: ${JSON.stringify(requestBody)}`)
+      const response = await this.requestor.requestUrl<CanvasSectionBase>(endpoint, method, requestBody)
+      return { statusCode: response.statusCode, message: response.statusMessage as string, sectionName: response.body.name }
+    } catch (error) {
+      const errResponse: APIErrorData = handleAPIError(error)
+      logger.error(`Request to create section ${sectionName} failed with StatusCode: ${errResponse.statusCode} and StatusMessage: ${errResponse.message} `)
+      return { statusCode: errResponse.statusCode, message: errResponse.message, sectionName: sectionName }
+    }
+  }
+
+  makeReturnResponseCreateSections (sectionsReturnRes: CreateSectionsResponseObject[]): CreateSectionReturnResponse {
+    const sectionsDataStore: CreateSectionResponseData = { createdSections: 0, givenSections: this.sections.length, statusCode: [], error: {} }
+    for (const section of sectionsReturnRes) {
+      const { statusCode, message, sectionName } = section
+      if (statusCode === 200 || statusCode === 201) {
+        sectionsDataStore.createdSections++
+      } else {
+        sectionsDataStore.error[sectionName] = message
+        sectionsDataStore.statusCode.push(statusCode)
+      }
+    }
+
+    if (sectionsDataStore.createdSections === sectionsDataStore.givenSections) {
+      return { statusCode: 201, message: { section: { success: true } } }
+    } else {
+      return {
+        statusCode: Math.max(...[...new Set(sectionsDataStore.statusCode)]),
+        message: { section: { success: false, error: sectionsDataStore.error } }
+      }
+    }
+  }
+
+  async createSectionBase (): Promise<CreateSectionReturnResponse> {
+    const start = process.hrtime()
+    const apiPromises = this.sections.map(async (section) => await this.apiCreateSection(section))
+    const sectionsOrErrorDataObjs = await Promise.all(apiPromises)
+    const stop = process.hrtime(start)
+    logger.info(`Time Taken to ${this.sections.length} create sections : ${(stop[0] * 1e9 + stop[1]) / 1e9} seconds`)
+    return this.makeReturnResponseCreateSections(sectionsOrErrorDataObjs)
+  }
+}

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -11,9 +11,7 @@ export class CreateSectionApiHandler {
 
   async apiCreateSection (sectionName: string): Promise<CreateSectionsResponseObject> {
     try {
-      const fake = `courses/${this.courseId}/sections/ding/dong`
-      const real = `courses/${this.courseId}/sections`
-      const endpoint = Math.random() < 0.5 ? real : fake
+      const endpoint = `courses/${this.courseId}/sections`
       const method = 'POST'
       const requestBody = { course_section: { name: sectionName } }
       logger.debug(`Sending request to Canvas - Endpoint: ${endpoint}; Method: ${method}; Body: ${JSON.stringify(requestBody)}`)

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -1,4 +1,10 @@
+// import { CanvasService } from '../canvas/canvas.service'
+import { HTTPError } from 'got'
 import { hasKeys } from '../typeUtils'
+
+export interface HelloData {
+  message: string
+}
 
 export interface Globals {
   environment: 'production' | 'development'
@@ -13,7 +19,34 @@ export interface APIErrorData {
   statusCode: number
   message: string
 }
+export interface CreateSectionsResponseObject extends APIErrorData {
+  sectionName: string
+}
+
+export interface CanvasSectionBase {
+  name: string
+}
+
+export interface CreateSectionReturnResponse {
+  statusCode: number
+  message: Record<any, unknown>
+}
+export interface CreateSectionResponseData{
+  givenSections: number
+  createdSections: number
+  statusCode: number[]
+  error: Record<any, unknown>
+}
 
 export function isAPIErrorData (value: unknown): value is APIErrorData {
   return hasKeys(value, ['statusCode', 'message'])
+}
+
+export function handleAPIError (error: unknown): APIErrorData {
+  if (error instanceof HTTPError) {
+    const { statusCode, statusMessage } = error.response
+    return { statusCode, message: `Error(s) from Canvas:  ${statusMessage as string}` }
+  } else {
+    return { statusCode: 500, message: 'A non-HTTP error occurred while communicating with Canvas.' }
+  }
 }

--- a/ccm_web/server/src/api/dtos/api.create.sections.dto.ts
+++ b/ccm_web/server/src/api/dtos/api.create.sections.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, MaxLength } from 'class-validator'
+import { ApiProperty } from '@nestjs/swagger'
+
+export class CreateSectionsDto {
+  @ApiProperty({ type: [String] })
+  @IsNotEmpty({ each: true })
+  @MaxLength(250, { each: true })
+  sections: string[]
+
+  constructor (sections: string[]) {
+    this.sections = sections
+  }
+}

--- a/ccm_web/server/src/canvas/canvas.scopes.ts
+++ b/ccm_web/server/src/canvas/canvas.scopes.ts
@@ -8,7 +8,8 @@ can be found in the API Developer Key interface in Canvas.
 const privilegeLevelOneScopes = [
   // Courses
   'url:GET|/api/v1/courses/:id',
-  'url:PUT|/api/v1/courses/:id'
+  'url:PUT|/api/v1/courses/:id',
+  'url:POST|/api/v1/courses/:course_id/sections'
 ]
 
 export { privilegeLevelOneScopes }

--- a/ccm_web/server/src/canvas/canvas.service.ts
+++ b/ccm_web/server/src/canvas/canvas.service.ts
@@ -3,6 +3,7 @@ import CanvasRequestor from '@kth/canvas-api'
 import { HttpService, Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { InjectModel } from '@nestjs/sequelize'
+import { Options as GotOptions } from 'got'
 
 import { CanvasOAuthAPIError, CanvasTokenNotFoundError } from './canvas.errors'
 import { isCanvasErrorBody, TokenCodeResponseBody, TokenRefreshResponseBody } from './canvas.interfaces'
@@ -181,7 +182,8 @@ export class CanvasService {
       logger.debug('Token for user has expired; refreshing token...')
       token = await this.refreshToken(token)
     }
-    const requestor = new CanvasRequestor(this.url + endpoint, token.accessToken)
+    const options: GotOptions = { retry: { limit: 2, methods: ['POST', 'GET', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE'] } }
+    const requestor = new CanvasRequestor(this.url + endpoint, token.accessToken, options)
     return requestor
   }
 


### PR DESCRIPTION
Fixes #152 as part Epic #17

This PR is creating an endpoint for creating sections. This Endpoint should be able to handle single section and Multiple sections. The Endpoint creates multiple sections concurrently

For creating 60 section it takes about ~2 sec and with retry as well about ~5 sec. I did not see any rating limiting error while working on the issue. So for the max section we could create (60) with CCM shouldn't hit the rate limiting phenomenon. 

I have used Promise.all() approach for triggering concurrent creation of sections.

Some of the articles that I explored
https://www.coreycleary.me/awaiting-multiple-requests-to-finish-using-promise-all
https://www.davidroyer.me/blog/optimized-async-await/