### PR TITLE
#152, #88 Create sections backend endpoint

### DIFF
--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -4,7 +4,7 @@ import {
 } from '@nestjs/common'
 import { ApiBearerAuth } from '@nestjs/swagger'
 
-import { HelloData, isAPIErrorData, Globals } from './api.interfaces'
+import { isAPIErrorData, Globals } from './api.interfaces'
 import { APIService } from './api.service'
 import { CourseNameDto } from './dtos/api.course.name.dto'
 import { CanvasCourseBase, CanvasCourseSection } from '../canvas/canvas.interfaces'
@@ -14,11 +14,6 @@ import { CreateSectionsDto } from './dtos/api.create.sections.dto'
 @Controller('api')
 export class APIController {
   constructor (private readonly apiService: APIService) {}
-
-  @Get('hello')
-  getHello (): HelloData {
-    return this.apiService.getHello()
-  }
 
   @Get('globals')
   getGlobals (@Session() session: SessionData): Globals {

--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -4,15 +4,11 @@ import {
 } from '@nestjs/common'
 import { ApiBearerAuth } from '@nestjs/swagger'
 
-import { CanvasSectionBase, CreateSectionsAPIErrorData, Globals, isAPICreateSectionErrorData, isAPIErrorData } from './api.interfaces'
+import { Globals, isAPIErrorData } from './api.interfaces'
 import { APIService } from './api.service'
 import { CourseNameDto } from './dtos/api.course.name.dto'
-<<<<<<< HEAD
 import { CanvasCourseBase, CanvasCourseSection } from '../canvas/canvas.interfaces'
-=======
->>>>>>> Refactoring based on review comments
 import { CreateSectionsDto } from './dtos/api.create.sections.dto'
-import { CanvasCourseBase } from '../canvas/canvas.interfaces'
 
 @ApiBearerAuth()
 @Controller('api')
@@ -55,11 +51,11 @@ export class APIController {
   }
 
   @Post('course/:id/sections')
-  async createSections (@Param('id', ParseIntPipe) courseId: number, @Body() createSectionsDto: CreateSectionsDto, @Session() session: SessionData): Promise<CanvasSectionBase[] | CreateSectionsAPIErrorData> {
+  async createSections (@Param('id', ParseIntPipe) courseId: number, @Body() createSectionsDto: CreateSectionsDto, @Session() session: SessionData): Promise<CanvasCourseSection[]> {
     const { userLoginId } = session.data
     const sections = createSectionsDto.sections
     const result = await this.apiService.createSections(userLoginId, courseId, sections)
-    if (isAPICreateSectionErrorData(result)) throw new HttpException(result, result.statusCode)
+    if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
     return result
   }
 }

--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -1,18 +1,24 @@
 import { SessionData } from 'express-session'
 import {
-  Body, Controller, Get, HttpException, Param, ParseIntPipe, Put, Session
+  Body, Controller, Get, HttpException, Param, ParseIntPipe, Post, Put, Session
 } from '@nestjs/common'
 import { ApiBearerAuth } from '@nestjs/swagger'
 
-import { Globals, isAPIErrorData } from './api.interfaces'
+import { HelloData, isAPIErrorData, Globals } from './api.interfaces'
 import { APIService } from './api.service'
 import { CourseNameDto } from './dtos/api.course.name.dto'
 import { CanvasCourseBase, CanvasCourseSection } from '../canvas/canvas.interfaces'
+import { CreateSectionsDto } from './dtos/api.create.sections.dto'
 
 @ApiBearerAuth()
 @Controller('api')
 export class APIController {
   constructor (private readonly apiService: APIService) {}
+
+  @Get('hello')
+  getHello (): HelloData {
+    return this.apiService.getHello()
+  }
 
   @Get('globals')
   getGlobals (@Session() session: SessionData): Globals {
@@ -45,6 +51,15 @@ export class APIController {
   ): Promise<CanvasCourseBase> {
     const { userLoginId } = session.data
     const result = await this.apiService.putCourseName(userLoginId, courseId, courseNameDto.newName)
+    if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
+    return result
+  }
+
+  @Post('course/:id/sections')
+  async createSections (@Param('id', ParseIntPipe) courseId: number, @Body() createSectionsDto: CreateSectionsDto, @Session() session: SessionData): Promise<any> {
+    const { userLoginId } = session.data
+    const sections = createSectionsDto.sections
+    const result = await this.apiService.createSections(userLoginId, courseId, sections)
     if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
     return result
   }

--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -4,7 +4,7 @@ import {
 } from '@nestjs/common'
 import { ApiBearerAuth } from '@nestjs/swagger'
 
-import { isAPIErrorData, Globals } from './api.interfaces'
+import { Globals, isAPIErrorData } from './api.interfaces'
 import { APIService } from './api.service'
 import { CourseNameDto } from './dtos/api.course.name.dto'
 import { CanvasCourseBase, CanvasCourseSection } from '../canvas/canvas.interfaces'

--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -4,11 +4,15 @@ import {
 } from '@nestjs/common'
 import { ApiBearerAuth } from '@nestjs/swagger'
 
-import { Globals, isAPIErrorData } from './api.interfaces'
+import { CanvasSectionBase, CreateSectionsAPIErrorData, Globals, isAPICreateSectionErrorData, isAPIErrorData } from './api.interfaces'
 import { APIService } from './api.service'
 import { CourseNameDto } from './dtos/api.course.name.dto'
+<<<<<<< HEAD
 import { CanvasCourseBase, CanvasCourseSection } from '../canvas/canvas.interfaces'
+=======
+>>>>>>> Refactoring based on review comments
 import { CreateSectionsDto } from './dtos/api.create.sections.dto'
+import { CanvasCourseBase } from '../canvas/canvas.interfaces'
 
 @ApiBearerAuth()
 @Controller('api')
@@ -51,11 +55,11 @@ export class APIController {
   }
 
   @Post('course/:id/sections')
-  async createSections (@Param('id', ParseIntPipe) courseId: number, @Body() createSectionsDto: CreateSectionsDto, @Session() session: SessionData): Promise<any> {
+  async createSections (@Param('id', ParseIntPipe) courseId: number, @Body() createSectionsDto: CreateSectionsDto, @Session() session: SessionData): Promise<CanvasSectionBase[] | CreateSectionsAPIErrorData> {
     const { userLoginId } = session.data
     const sections = createSectionsDto.sections
     const result = await this.apiService.createSections(userLoginId, courseId, sections)
-    if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
+    if (isAPICreateSectionErrorData(result)) throw new HttpException(result, result.statusCode)
     return result
   }
 }

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -23,7 +23,7 @@ export class CreateSectionApiHandler {
       const endpoint = `courses/${this.courseId}/sections`
       const method = 'POST'
       const requestBody = { course_section: { name: sectionName } }
-      logger.debug(`Sendings request to Canvas - Endpoint: ${endpoint}; Method: ${method}; Body: ${JSON.stringify(requestBody)}`)
+      logger.debug(`Sending request to Canvas - Endpoint: ${endpoint}; Method: ${method}; Body: ${JSON.stringify(requestBody)}`)
       const response = await this.requestor.requestUrl<CanvasSectionBase>(endpoint, method, requestBody)
       const { id, name } = response.body
       return { id, name }

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -1,7 +1,9 @@
 import CanvasRequestor from '@kth/canvas-api'
-import baseLogger from '../logger'
+
 import { CreateSectionTempDataStore, CanvasSectionBase, CreateSectionsAPIErrorData, APIErrorData, isAPICreateSectionErrorData } from './api.interfaces'
 import { handleAPIError } from './api.utils'
+
+import baseLogger from '../logger'
 
 const logger = baseLogger.child({ filePath: __filename })
 

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -1,0 +1,59 @@
+import CanvasRequestor from '@kth/canvas-api'
+import baseLogger from '../logger'
+import { CreateSectionResponseData, CreateSectionReturnResponse, CanvasSectionBase, CreateSectionsResponseObject, APIErrorData, handleAPIError } from './api.interfaces'
+
+const logger = baseLogger.child({ filePath: __filename })
+
+export class CreateSectionApiHandler {
+  constructor (private readonly requestor: CanvasRequestor,
+    private readonly sections: string[],
+    private readonly courseId: number) {}
+
+  async apiCreateSection (sectionName: string): Promise<CreateSectionsResponseObject> {
+    try {
+      const fake = `courses/${this.courseId}/sections/ding/dong`
+      const real = `courses/${this.courseId}/sections`
+      const endpoint = Math.random() < 0.5 ? real : fake
+      const method = 'POST'
+      const requestBody = { course_section: { name: sectionName } }
+      logger.debug(`Sending request to Canvas - Endpoint: ${endpoint}; Method: ${method}; Body: ${JSON.stringify(requestBody)}`)
+      const response = await this.requestor.requestUrl<CanvasSectionBase>(endpoint, method, requestBody)
+      return { statusCode: response.statusCode, message: response.statusMessage as string, sectionName: response.body.name }
+    } catch (error) {
+      const errResponse: APIErrorData = handleAPIError(error)
+      logger.error(`Request to create section ${sectionName} failed with StatusCode: ${errResponse.statusCode} and StatusMessage: ${errResponse.message} `)
+      return { statusCode: errResponse.statusCode, message: errResponse.message, sectionName: sectionName }
+    }
+  }
+
+  makeReturnResponseCreateSections (sectionsReturnRes: CreateSectionsResponseObject[]): CreateSectionReturnResponse {
+    const sectionsDataStore: CreateSectionResponseData = { createdSections: 0, givenSections: this.sections.length, statusCode: [], error: {} }
+    for (const section of sectionsReturnRes) {
+      const { statusCode, message, sectionName } = section
+      if (statusCode === 200 || statusCode === 201) {
+        sectionsDataStore.createdSections++
+      } else {
+        sectionsDataStore.error[sectionName] = message
+        sectionsDataStore.statusCode.push(statusCode)
+      }
+    }
+
+    if (sectionsDataStore.createdSections === sectionsDataStore.givenSections) {
+      return { statusCode: 201, message: { section: { success: true } } }
+    } else {
+      return {
+        statusCode: Math.max(...[...new Set(sectionsDataStore.statusCode)]),
+        message: { section: { success: false, error: sectionsDataStore.error } }
+      }
+    }
+  }
+
+  async createSectionBase (): Promise<CreateSectionReturnResponse> {
+    const start = process.hrtime()
+    const apiPromises = this.sections.map(async (section) => await this.apiCreateSection(section))
+    const sectionsOrErrorDataObjs = await Promise.all(apiPromises)
+    const stop = process.hrtime(start)
+    logger.info(`Time Taken to ${this.sections.length} create sections : ${(stop[0] * 1e9 + stop[1]) / 1e9} seconds`)
+    return this.makeReturnResponseCreateSections(sectionsOrErrorDataObjs)
+  }
+}

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -18,7 +18,7 @@ export class CreateSectionApiHandler {
     this.courseId = courseId
   }
 
-  async apiCreateSection (sectionName: string): Promise<CanvasSectionBase | CreateSectionsAPIErrorData> {
+  async createSection (sectionName: string): Promise<CanvasSectionBase | CreateSectionsAPIErrorData> {
     try {
       const endpoint = `courses/${this.courseId}/sections`
       const method = 'POST'
@@ -56,10 +56,11 @@ export class CreateSectionApiHandler {
     }
   }
 
-  async createSectionBase (): Promise<CanvasSectionBase[] | CreateSectionsAPIErrorData> {
+  async createSections (): Promise<CanvasSectionBase[] | CreateSectionsAPIErrorData> {
     const start = process.hrtime()
-    const apiPromises = this.sections.map(async (section) => await this.apiCreateSection(section))
+    const apiPromises = this.sections.map(async (section) => await this.createSection(section))
     const sectionsOrErrorDataObjs = await Promise.all(apiPromises)
+    // https://codezup.com/measure-execution-time-javascript-node-js/
     const stop = process.hrtime(start)
     logger.debug(`Time taken to create ${this.sections.length} sections: ${(stop[0] * 1e9 + stop[1]) / 1e9} seconds`)
     return this.makeReturnResponseCreateSections(sectionsOrErrorDataObjs)

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -18,9 +18,7 @@ export class CreateSectionApiHandler {
 
   async apiCreateSection (sectionName: string): Promise<CanvasSectionBase | CreateSectionsAPIErrorData> {
     try {
-      const fake = `courses/${this.courseId}/sections/dig/`
-      const real = `courses/${this.courseId}/sections`
-      const endpoint = Math.random() < 0.5 ? fake : real
+      const endpoint = `courses/${this.courseId}/sections`
       const method = 'POST'
       const requestBody = { course_section: { name: sectionName } }
       logger.debug(`Sendings request to Canvas - Endpoint: ${endpoint}; Method: ${method}; Body: ${JSON.stringify(requestBody)}`)
@@ -34,19 +32,18 @@ export class CreateSectionApiHandler {
   }
 
   makeReturnResponseCreateSections (sectionsReturnRes: Array<CreateSectionsAPIErrorData | CanvasSectionBase>): CanvasSectionBase[] | CreateSectionsAPIErrorData {
-    const sectionsDataStore: CreateSectionTempDataStore = { createdSections: 0, givenSections: this.sections.length, allSuccess: [], statusCode: [], errors: [] }
+    const sectionsDataStore: CreateSectionTempDataStore = { allSuccess: [], statusCode: [], errors: [] }
     for (const section of sectionsReturnRes) {
       if (isAPICreateSectionErrorData(section)) {
         const { statusCode, errors } = section
         sectionsDataStore.errors.push(errors[0])
         sectionsDataStore.statusCode.push(statusCode)
       } else {
-        sectionsDataStore.createdSections++
         sectionsDataStore.allSuccess.push(section)
       }
     }
 
-    if (sectionsDataStore.createdSections === sectionsDataStore.givenSections) {
+    if (sectionsDataStore.allSuccess.length === this.sections.length) {
       return sectionsDataStore.allSuccess
     } else {
       const statusCodes = [...new Set(sectionsDataStore.statusCode)]

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -18,7 +18,7 @@ export class CreateSectionApiHandler {
 
   async apiCreateSection (sectionName: string): Promise<CanvasSectionBase | CreateSectionsAPIErrorData> {
     try {
-      const endpoint = `courses/${this.courseId}/sections`
+      const endpoint = `courses/${this.courseId}/sections/ding`
       const method = 'POST'
       const requestBody = { course_section: { name: sectionName } }
       logger.debug(`Sendings request to Canvas - Endpoint: ${endpoint}; Method: ${method}; Body: ${JSON.stringify(requestBody)}`)
@@ -27,7 +27,7 @@ export class CreateSectionApiHandler {
       return { id, name }
     } catch (error) {
       const errResponse: APIErrorData = handleAPIError(error)
-      return { statusCode: errResponse.statusCode, errors: [{ message: errResponse.message, sectionName: sectionName }] }
+      return { statusCode: errResponse.statusCode, errors: [{ message: errResponse.message, failedInput: sectionName }] }
     }
   }
 
@@ -47,7 +47,7 @@ export class CreateSectionApiHandler {
       return sectionsDataStore.allSuccess
     } else {
       const statusCodes = [...new Set(sectionsDataStore.statusCode)]
-      const statusCode = statusCodes.length > 1 ? 400 : statusCodes[0]
+      const statusCode = [...new Set(sectionsDataStore.statusCode)].length > 1 ? 400 : statusCodes[0]
       return {
         statusCode: statusCode,
         errors: sectionsDataStore.errors

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -11,9 +11,7 @@ export class CreateSectionApiHandler {
 
   async apiCreateSection (sectionName: string): Promise<CreateSectionsResponseObject> {
     try {
-      const fake = `courses/${this.courseId}/sections/ding/dong`
-      const real = `courses/${this.courseId}/sections`
-      const endpoint = Math.random() < 0.5 ? real : fake
+      const endpoint = `courses/${this.courseId}/sections`
       const method = 'POST'
       const requestBody = { course_section: { name: sectionName } }
       logger.debug(`Sending request to Canvas - Endpoint: ${endpoint}; Method: ${method}; Body: ${JSON.stringify(requestBody)}`)

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -1,6 +1,6 @@
 import CanvasRequestor from '@kth/canvas-api'
 
-import { CreateSectionTempDataStore, CanvasSectionBase, CreateSectionsAPIErrorData, APIErrorData, isAPICreateSectionErrorData } from './api.interfaces'
+import { CanvasSectionBase, CreateSectionsAPIErrorData, APIErrorData, isAPICreateSectionErrorData } from './api.interfaces'
 import { handleAPIError } from './api.utils'
 
 import baseLogger from '../logger'
@@ -34,25 +34,24 @@ export class CreateSectionApiHandler {
   }
 
   makeReturnResponseCreateSections (sectionsReturnRes: Array<CreateSectionsAPIErrorData | CanvasSectionBase>): CanvasSectionBase[] | CreateSectionsAPIErrorData {
-    const sectionsDataStore: CreateSectionTempDataStore = { successes: [], statusCodes: [], errors: [] }
+    const successes = []; const statusCodes = []; const errorsList = []
     for (const section of sectionsReturnRes) {
       if (isAPICreateSectionErrorData(section)) {
         const { statusCode, errors } = section
-        sectionsDataStore.errors.push(...errors)
-        sectionsDataStore.statusCodes.push(statusCode)
+        errorsList.push(...errors)
+        statusCodes.push(statusCode)
       } else {
-        sectionsDataStore.successes.push(section)
+        successes.push(section)
       }
     }
 
-    if (sectionsDataStore.successes.length === this.sections.length) {
-      return sectionsDataStore.successes
+    if (successes.length === this.sections.length) {
+      return successes
     } else {
-      const statusCodes = [...new Set(sectionsDataStore.statusCodes)]
-      const statusCode = [...new Set(sectionsDataStore.statusCodes)].length > 1 ? 400 : statusCodes[0]
+      const uniqueStatusCodes = [...new Set(statusCodes)]
       return {
-        statusCode: statusCode,
-        errors: sectionsDataStore.errors
+        statusCode: uniqueStatusCodes.length > 1 ? 400 : uniqueStatusCodes[0],
+        errors: errorsList
       }
     }
   }

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -51,7 +51,7 @@ export class CreateSectionApiHandler {
     const apiPromises = this.sections.map(async (section) => await this.apiCreateSection(section))
     const sectionsOrErrorDataObjs = await Promise.all(apiPromises)
     const stop = process.hrtime(start)
-    logger.info(`Time Taken to ${this.sections.length} create sections : ${(stop[0] * 1e9 + stop[1]) / 1e9} seconds`)
+    logger.debug(`Time taken to create ${this.sections.length} sections : ${(stop[0] * 1e9 + stop[1]) / 1e9} seconds`)
     return this.makeReturnResponseCreateSections(sectionsOrErrorDataObjs)
   }
 }

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -38,7 +38,7 @@ export class CreateSectionApiHandler {
     for (const section of sectionsReturnRes) {
       if (isAPICreateSectionErrorData(section)) {
         const { statusCode, errors } = section
-        sectionsDataStore.errors.push(errors[0])
+        sectionsDataStore.errors.push(...errors)
         sectionsDataStore.statusCodes.push(statusCode)
       } else {
         sectionsDataStore.successes.push(section)

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -62,7 +62,7 @@ export class CreateSectionApiHandler {
     const apiPromises = this.sections.map(async (section) => await this.apiCreateSection(section))
     const sectionsOrErrorDataObjs = await Promise.all(apiPromises)
     const stop = process.hrtime(start)
-    logger.debug(`Time taken to create ${this.sections.length} sections : ${(stop[0] * 1e9 + stop[1]) / 1e9} seconds`)
+    logger.debug(`Time taken to create ${this.sections.length} sections: ${(stop[0] * 1e9 + stop[1]) / 1e9} seconds`)
     return this.makeReturnResponseCreateSections(sectionsOrErrorDataObjs)
   }
 }

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -34,22 +34,22 @@ export class CreateSectionApiHandler {
   }
 
   makeReturnResponseCreateSections (sectionsReturnRes: Array<CreateSectionsAPIErrorData | CanvasSectionBase>): CanvasSectionBase[] | CreateSectionsAPIErrorData {
-    const sectionsDataStore: CreateSectionTempDataStore = { allSuccess: [], statusCode: [], errors: [] }
+    const sectionsDataStore: CreateSectionTempDataStore = { successes: [], statusCodes: [], errors: [] }
     for (const section of sectionsReturnRes) {
       if (isAPICreateSectionErrorData(section)) {
         const { statusCode, errors } = section
         sectionsDataStore.errors.push(errors[0])
-        sectionsDataStore.statusCode.push(statusCode)
+        sectionsDataStore.statusCodes.push(statusCode)
       } else {
-        sectionsDataStore.allSuccess.push(section)
+        sectionsDataStore.successes.push(section)
       }
     }
 
-    if (sectionsDataStore.allSuccess.length === this.sections.length) {
-      return sectionsDataStore.allSuccess
+    if (sectionsDataStore.successes.length === this.sections.length) {
+      return sectionsDataStore.successes
     } else {
-      const statusCodes = [...new Set(sectionsDataStore.statusCode)]
-      const statusCode = [...new Set(sectionsDataStore.statusCode)].length > 1 ? 400 : statusCodes[0]
+      const statusCodes = [...new Set(sectionsDataStore.statusCodes)]
+      const statusCode = [...new Set(sectionsDataStore.statusCodes)].length > 1 ? 400 : statusCodes[0]
       return {
         statusCode: statusCode,
         errors: sectionsDataStore.errors

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -1,9 +1,10 @@
 import CanvasRequestor from '@kth/canvas-api'
 
-import { APIErrorData, CanvasCourseSection, isAPIErrorData } from './api.interfaces'
+import { APIErrorData, isAPIErrorData } from './api.interfaces'
 import { handleAPIError } from './api.utils'
 
 import baseLogger from '../logger'
+import { CanvasCourseSection } from '../canvas/canvas.interfaces'
 
 const logger = baseLogger.child({ filePath: __filename })
 

--- a/ccm_web/server/src/api/api.create.section.handler.ts
+++ b/ccm_web/server/src/api/api.create.section.handler.ts
@@ -20,7 +20,7 @@ export class CreateSectionApiHandler {
 
   async apiCreateSection (sectionName: string): Promise<CanvasSectionBase | CreateSectionsAPIErrorData> {
     try {
-      const endpoint = `courses/${this.courseId}/sections/ding`
+      const endpoint = `courses/${this.courseId}/sections`
       const method = 'POST'
       const requestBody = { course_section: { name: sectionName } }
       logger.debug(`Sendings request to Canvas - Endpoint: ${endpoint}; Method: ${method}; Body: ${JSON.stringify(requestBody)}`)

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -34,5 +34,5 @@ export interface CreateSectionsAPIErrorData {
 }
 
 export function isAPIErrorData (value: unknown): value is APIErrorData {
-  return hasKeys(value, ['statusCode', 'errors'])
+  return hasKeys(value, ['statusCode', 'message'])
 }

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -18,10 +18,6 @@ export interface APIErrorData {
   statusCode: number
   errors: APIErrorPayload[]
 }
-export interface CanvasCourseSection {
-  id: number
-  name: string
-}
 
 export function isAPIErrorData (value: unknown): value is APIErrorData {
   return hasKeys(value, ['statusCode', 'errors'])

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -35,7 +35,7 @@ export interface CreateSectionReturnResponse {
   message: Record<any, unknown>
 }
 
-export interface CreateSectionResponseData{
+export interface CreateSectionResponseData {
   givenSections: number
   createdSections: number
   statusCode: number[]

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -22,7 +22,8 @@ export interface CanvasSectionBase {
   id: number
   name: string
 }
-export interface createSectionError {
+
+export interface CreateSectionError {
   failedInput: string
   message: string
 }

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -18,21 +18,11 @@ export interface APIErrorData {
   statusCode: number
   errors: APIErrorPayload[]
 }
-export interface CanvasSectionBase {
+export interface CanvasCourseSection {
   id: number
   name: string
 }
 
-export interface CreateSectionError {
-  failedInput: string
-  message: string
-}
-
-export interface CreateSectionsAPIErrorData {
-  statusCode: number
-  errors: CreateSectionError[]
-}
-
 export function isAPIErrorData (value: unknown): value is APIErrorData {
-  return hasKeys(value, ['statusCode', 'message'])
+  return hasKeys(value, ['statusCode', 'errors'])
 }

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -23,7 +23,7 @@ export interface CanvasSectionBase {
   name: string
 }
 export interface createSectionError {
-  sectionName: string
+  failedInput: string
   message: string
 }
 

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -30,12 +30,12 @@ export interface CreateSectionError {
 
 export interface CreateSectionsAPIErrorData {
   statusCode: number
-  errors: createSectionError[]
+  errors: CreateSectionError[]
 }
 export interface CreateSectionTempDataStore {
   allSuccess: CanvasSectionBase[]
   statusCode: number[]
-  errors: createSectionError[]
+  errors: CreateSectionError[]
 }
 
 export function isAPIErrorData (value: unknown): value is APIErrorData {

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -34,6 +34,7 @@ export interface CreateSectionReturnResponse {
   statusCode: number
   message: Record<any, unknown>
 }
+
 export interface CreateSectionResponseData{
   givenSections: number
   createdSections: number

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -33,8 +33,8 @@ export interface CreateSectionsAPIErrorData {
   errors: CreateSectionError[]
 }
 export interface CreateSectionTempDataStore {
-  allSuccess: CanvasSectionBase[]
-  statusCode: number[]
+  successes: CanvasSectionBase[]
+  statusCodes: number[]
   errors: CreateSectionError[]
 }
 

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -32,8 +32,6 @@ export interface CreateSectionsAPIErrorData {
   errors: createSectionError[]
 }
 export interface CreateSectionTempDataStore {
-  givenSections: number
-  createdSections: number
   allSuccess: CanvasSectionBase[]
   statusCode: number[]
   errors: createSectionError[]

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -32,11 +32,6 @@ export interface CreateSectionsAPIErrorData {
   statusCode: number
   errors: CreateSectionError[]
 }
-export interface CreateSectionTempDataStore {
-  successes: CanvasSectionBase[]
-  statusCodes: number[]
-  errors: CreateSectionError[]
-}
 
 export function isAPIErrorData (value: unknown): value is APIErrorData {
   return hasKeys(value, ['statusCode', 'errors'])

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -1,9 +1,5 @@
 import { hasKeys } from '../typeUtils'
 
-export interface HelloData {
-  message: string
-}
-
 export interface Globals {
   environment: 'production' | 'development'
   userLoginId: string
@@ -22,24 +18,25 @@ export interface APIErrorData {
   statusCode: number
   errors: APIErrorPayload[]
 }
-export interface CreateSectionsResponseObject extends APIErrorData {
-  sectionName: string
-}
-
 export interface CanvasSectionBase {
+  id: number
   name: string
 }
-
-export interface CreateSectionReturnResponse {
-  statusCode: number
-  message: Record<any, unknown>
+export interface createSectionError {
+  sectionName: string
+  message: string
 }
 
-export interface CreateSectionResponseData {
+export interface CreateSectionsAPIErrorData {
+  statusCode: number
+  errors: createSectionError[]
+}
+export interface CreateSectionTempDataStore {
   givenSections: number
   createdSections: number
+  allSuccess: CanvasSectionBase[]
   statusCode: number[]
-  error: Record<any, unknown>
+  errors: createSectionError[]
 }
 
 export function isAPIErrorData (value: unknown): value is APIErrorData {

--- a/ccm_web/server/src/api/api.interfaces.ts
+++ b/ccm_web/server/src/api/api.interfaces.ts
@@ -1,5 +1,9 @@
 import { hasKeys } from '../typeUtils'
 
+export interface HelloData {
+  message: string
+}
+
 export interface Globals {
   environment: 'production' | 'development'
   userLoginId: string
@@ -18,6 +22,25 @@ export interface APIErrorData {
   statusCode: number
   errors: APIErrorPayload[]
 }
+export interface CreateSectionsResponseObject extends APIErrorData {
+  sectionName: string
+}
+
+export interface CanvasSectionBase {
+  name: string
+}
+
+export interface CreateSectionReturnResponse {
+  statusCode: number
+  message: Record<any, unknown>
+}
+export interface CreateSectionResponseData{
+  givenSections: number
+  createdSections: number
+  statusCode: number[]
+  error: Record<any, unknown>
+}
+
 export function isAPIErrorData (value: unknown): value is APIErrorData {
   return hasKeys(value, ['statusCode', 'errors'])
 }

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -13,9 +13,7 @@ const logger = baseLogger.child({ filePath: __filename })
 
 @Injectable()
 export class APIService {
-  constructor (private readonly canvasService: CanvasService) {
-
-  }
+  constructor (private readonly canvasService: CanvasService) {}
 
   getGlobals (sessionData: SessionData): Globals {
     return {

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -86,6 +86,6 @@ export class APIService {
   async createSections (userLoginId: string, course: number, sections: string[]): Promise<CanvasSectionBase[] | CreateSectionsAPIErrorData> {
     const requestor = await this.canvasService.createRequestorForUser(userLoginId, '/api/v1/')
     const createSectionsApiHandler = new CreateSectionApiHandler(requestor, sections, course)
-    return await createSectionsApiHandler.createSectionBase()
+    return await createSectionsApiHandler.createSections()
   }
 }

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common'
 
 import { handleAPIError } from './api.utils'
 import { CanvasCourse, CanvasCourseBase, CanvasCourseSection } from '../canvas/canvas.interfaces'
-import { APIErrorData, CanvasSectionBase, CreateSectionsAPIErrorData, Globals } from './api.interfaces'
+import { APIErrorData, Globals } from './api.interfaces'
 import { CreateSectionApiHandler } from './api.create.section.handler'
 import { CanvasService } from '../canvas/canvas.service'
 
@@ -26,11 +26,11 @@ export class APIService {
     }
   }
 
-  async getCourseSections(userLoginId: string, courseId: number): Promise<CanvasCourseSection[] | APIErrorData> {
+  async getCourseSections (userLoginId: string, courseId: number): Promise<CanvasCourseSection[] | APIErrorData> {
     const requestor = await this.canvasService.createRequestorForUser(userLoginId, '/api/v1/')
     try {
       const endpoint = `courses/${courseId}/sections`
-      const queryParams = { 'include': ['total_students'] } // use list for "include" values
+      const queryParams = { include: ['total_students'] } // use list for "include" values
       logger.debug(`Sending request to Canvas (get all pages) - Endpoint: ${endpoint}; Method: GET`)
       // FIXME: list() should return promise, toArray() should be callable later
       const sectionsFull = await requestor.list<CanvasCourseSection>(endpoint, queryParams).toArray()
@@ -83,7 +83,7 @@ export class APIService {
     }
   }
 
-  async createSections (userLoginId: string, course: number, sections: string[]): Promise<CanvasSectionBase[] | CreateSectionsAPIErrorData> {
+  async createSections (userLoginId: string, course: number, sections: string[]): Promise<CanvasCourseSection[] | APIErrorData> {
     const requestor = await this.canvasService.createRequestorForUser(userLoginId, '/api/v1/')
     const createSectionsApiHandler = new CreateSectionApiHandler(requestor, sections, course)
     return await createSectionsApiHandler.createSections()

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -2,12 +2,12 @@ import { SessionData } from 'express-session'
 import { Injectable } from '@nestjs/common'
 
 import { handleAPIError } from './api.utils'
-import { APIErrorData, CreateSectionReturnResponse, Globals } from './api.interfaces'
 import { CanvasCourse, CanvasCourseBase, CanvasCourseSection } from '../canvas/canvas.interfaces'
+import { APIErrorData, CanvasSectionBase, CreateSectionsAPIErrorData, Globals } from './api.interfaces'
+import { CreateSectionApiHandler } from './api.create.section.handler'
 import { CanvasService } from '../canvas/canvas.service'
 
 import baseLogger from '../logger'
-import { CreateSectionApiHandler } from './api.create.section.handler'
 
 const logger = baseLogger.child({ filePath: __filename })
 
@@ -83,7 +83,7 @@ export class APIService {
     }
   }
 
-  async createSections (userLoginId: string, course: number, sections: string[]): Promise<CreateSectionReturnResponse> {
+  async createSections (userLoginId: string, course: number, sections: string[]): Promise<CanvasSectionBase[] | CreateSectionsAPIErrorData> {
     const requestor = await this.canvasService.createRequestorForUser(userLoginId, '/api/v1/')
     const createSectionsApiHandler = new CreateSectionApiHandler(requestor, sections, course)
     return await createSectionsApiHandler.createSectionBase()

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -1,18 +1,21 @@
 import { SessionData } from 'express-session'
 import { Injectable } from '@nestjs/common'
 
-import { APIErrorData, Globals } from './api.interfaces'
-import { CanvasCourse, CanvasCourseBase, CanvasCourseSection } from '../canvas/canvas.interfaces'
 import { handleAPIError } from './api.utils'
+import { APIErrorData, CreateSectionReturnResponse, Globals } from './api.interfaces'
+import { CanvasCourse, CanvasCourseBase, CanvasCourseSection } from '../canvas/canvas.interfaces'
 import { CanvasService } from '../canvas/canvas.service'
 
 import baseLogger from '../logger'
+import { CreateSectionApiHandler } from './api.create.section.handler'
 
 const logger = baseLogger.child({ filePath: __filename })
 
 @Injectable()
 export class APIService {
-  constructor (private readonly canvasService: CanvasService) {}
+  constructor (private readonly canvasService: CanvasService) {
+
+  }
 
   getGlobals (sessionData: SessionData): Globals {
     return {
@@ -80,5 +83,11 @@ export class APIService {
       const errResponse = handleAPIError(error, newName)
       return { statusCode: errResponse.canvasStatusCode, errors: [errResponse] }
     }
+  }
+
+  async createSections (userLoginId: string, course: number, sections: string[]): Promise<CreateSectionReturnResponse> {
+    const requestor = await this.canvasService.createRequestorForUser(userLoginId, '/api/v1/')
+    const createSectionsApiHandler = new CreateSectionApiHandler(requestor, sections, course)
+    return await createSectionsApiHandler.createSectionBase()
   }
 }

--- a/ccm_web/server/src/api/dtos/api.create.sections.dto.ts
+++ b/ccm_web/server/src/api/dtos/api.create.sections.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, MaxLength } from 'class-validator'
+import { ApiProperty } from '@nestjs/swagger'
+
+export class CreateSectionsDto {
+  @ApiProperty({ type: [String] })
+  @IsNotEmpty({ each: true })
+  @MaxLength(250, { each: true })
+  sections: string[]
+
+  constructor (sections: string[]) {
+    this.sections = sections
+  }
+}

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -43,7 +43,7 @@ export interface CanvasCourse extends CanvasCourseBase {
 export interface CanvasCourseSection {
   id: number
   name: string
-  total_students: number
+  total_students?: number
 }
 
 // Errors

--- a/ccm_web/server/src/canvas/canvas.scopes.ts
+++ b/ccm_web/server/src/canvas/canvas.scopes.ts
@@ -10,7 +10,8 @@ const privilegeLevelOneScopes = [
   'url:GET|/api/v1/courses/:id',
   'url:PUT|/api/v1/courses/:id',
   // Sections
-  'url:GET|/api/v1/courses/:course_id/sections'
+  'url:GET|/api/v1/courses/:course_id/sections',
+  'url:POST|/api/v1/courses/:course_id/sections'
 ]
 
 export { privilegeLevelOneScopes }

--- a/ccm_web/server/src/canvas/canvas.service.ts
+++ b/ccm_web/server/src/canvas/canvas.service.ts
@@ -3,6 +3,7 @@ import CanvasRequestor from '@kth/canvas-api'
 import { HttpService, Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { InjectModel } from '@nestjs/sequelize'
+import { Options as GotOptions } from 'got'
 
 import { CanvasOAuthAPIError, CanvasTokenNotFoundError } from './canvas.errors'
 import { TokenCodeResponseBody, TokenRefreshResponseBody } from './canvas.interfaces'
@@ -180,7 +181,8 @@ export class CanvasService {
       logger.debug('Token for user has expired; refreshing token...')
       token = await this.refreshToken(token)
     }
-    const requestor = new CanvasRequestor(this.url + endpoint, token.accessToken)
+    const options: GotOptions = { retry: { limit: 2, methods: ['POST', 'GET', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE'] } }
+    const requestor = new CanvasRequestor(this.url + endpoint, token.accessToken, options)
     return requestor
   }
 }

--- a/ccm_web/server/src/canvas/canvas.service.ts
+++ b/ccm_web/server/src/canvas/canvas.service.ts
@@ -19,7 +19,7 @@ import baseLogger from '../logger'
 const logger = baseLogger.child({ filePath: __filename })
 
 type SupportedAPIEndpoint = '/api/v1/' | '/api/graphql/'
-const options: GotOptions = { retry: { limit: 2, methods: ['POST', 'GET', 'PUT', 'DELETE'] } }
+const requestorOptions: GotOptions = { retry: { limit: 2, methods: ['POST', 'GET', 'PUT', 'DELETE'] } }
 
 @Injectable()
 export class CanvasService {
@@ -182,7 +182,7 @@ export class CanvasService {
       logger.debug('Token for user has expired; refreshing token...')
       token = await this.refreshToken(token)
     }
-    const requestor = new CanvasRequestor(this.url + endpoint, token.accessToken, options)
+    const requestor = new CanvasRequestor(this.url + endpoint, token.accessToken, requestorOptions)
     return requestor
   }
 }

--- a/ccm_web/server/src/canvas/canvas.service.ts
+++ b/ccm_web/server/src/canvas/canvas.service.ts
@@ -19,6 +19,7 @@ import baseLogger from '../logger'
 const logger = baseLogger.child({ filePath: __filename })
 
 type SupportedAPIEndpoint = '/api/v1/' | '/api/graphql/'
+const options: GotOptions = { retry: { limit: 2, methods: ['POST', 'GET', 'PUT', 'DELETE'] } }
 
 @Injectable()
 export class CanvasService {
@@ -181,7 +182,6 @@ export class CanvasService {
       logger.debug('Token for user has expired; refreshing token...')
       token = await this.refreshToken(token)
     }
-    const options: GotOptions = { retry: { limit: 2, methods: ['POST', 'GET', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE'] } }
     const requestor = new CanvasRequestor(this.url + endpoint, token.accessToken, options)
     return requestor
   }


### PR DESCRIPTION
Fixes #152 as part Epic #17

This PR is creating an endpoint for creating sections. This Endpoint should be able to handle single section and Multiple sections. The Endpoint creates multiple sections concurrently

**Add the new Scope in the API Developer Key** `url:POST|/api/v1/courses/:course_id/sections`

For creating 60 section it takes about ~2 sec and with retry as well about ~5 sec. I did not see any rating limiting error while working on the issue. So for the max section we could create (60) with CCM shouldn't hit the rate limiting phenomenon.

I have used Promise.all() approach for triggering concurrent creation of sections.

Some of the articles that I explored
coreycleary.me/awaiting-multiple-requests-to-finish-using-promise-all
davidroyer.me/blog/optimized-async-await
https://github.com/sindresorhus/got#retry