### PR TITLE
Get ready for OpenShift deployment (#42, #175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,12 @@ The file uses the same `.env` configuration file, so adjust any values there as 
 (see **Configuration** above for more info).
 Note that, at minimum, the database host needs to be changed to `ccm_db_prod`
 (since that is the name of the container).
+
+The repository also includes a `ccm_web/Dockerfile.openshift` file that is used
+for OpenShift deployments. It combines the "base" and "build" stages of the other
+`Dockerfile` and pulls base images from the OpenShift namespace, which are not subject
+to Docker Hub pull limits.
+
 ### Notice(s) regarding external code used
 
 This repository contains modified portions of the npm package

--- a/ccm_web/.eslintrc.js
+++ b/ccm_web/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
     node: true,
     jest: true,
   },
-  ignorePatterns: ['.eslintrc.js'],
+  ignorePatterns: ['.eslintrc.js', 'ecosystem.config.js'],
   rules: {
     'no-void': ['error', { 'allowAsStatement': true }],
     '@typescript-eslint/no-floating-promises': ['error', { ignoreVoid: true }]

--- a/ccm_web/Dockerfile
+++ b/ccm_web/Dockerfile
@@ -3,7 +3,7 @@
 # - https://dev.to/chrsgrrtt/dockerising-a-next-js-project-1ck5
 
 # Base stage
-FROM node:14-slim AS ccm-base
+FROM node:14-slim AS base
 WORKDIR /base/
 COPY package*.json ./
 RUN npm install
@@ -13,17 +13,17 @@ ARG PORT
 EXPOSE ${PORT}
 
 # Build stage (build client and compile server to JS)
-FROM ccm-base AS ccm-build
+FROM node:14-slim AS build
 WORKDIR /build/
-COPY --from=ccm-base /base ./
+COPY --from=base /base ./
 RUN npm run build
 
 # Prod stage
-FROM node:14-slim AS ccm-prod
+FROM node:14-slim AS prod
 ENV NODE_ENV=production
 WORKDIR /app
 
-COPY --from=ccm-base /base/package.json \
+COPY --from=base /base/package.json \
     /base/package-lock.json \
     /base/start.sh /base/ecosystem.config.js \
     ./
@@ -31,7 +31,7 @@ RUN npm install --production
 
 RUN npm install pm2@5.1.0 -g
 
-COPY --from=ccm-build /build/dist/ ./
+COPY --from=build /build/dist/ ./
 
 ARG PORT
 EXPOSE ${PORT}

--- a/ccm_web/Dockerfile
+++ b/ccm_web/Dockerfile
@@ -35,6 +35,8 @@ RUN npm install --production
 RUN npm install pm2@5.1.0 -g
 COPY --from=build /build/dist/ ./
 
+# Change HOME so that .pm2 files can be written to file system
+ENV HOME=/app/
 ARG PORT
 EXPOSE ${PORT}
 CMD ["sh", "-c", "./start.sh"]

--- a/ccm_web/Dockerfile
+++ b/ccm_web/Dockerfile
@@ -41,6 +41,6 @@ RUN chmod -R g+rw /app/
 ENV HOME=/app/
 ARG PORT
 EXPOSE ${PORT}
-CMD ["sh", "-c", "./start.sh"]
+ENTRYPOINT ["./start.sh"]
 
 # Done!

--- a/ccm_web/Dockerfile
+++ b/ccm_web/Dockerfile
@@ -23,8 +23,13 @@ FROM node:14-slim AS prod
 ENV NODE_ENV=production
 WORKDIR /app
 
-COPY --from=base /base/package.json /base/package-lock.json /base/start.sh ./
+COPY --from=base /base/package.json \
+    /base/package-lock.json \
+    /base/start.sh /base/ecosystem.config.js \
+    ./
 RUN npm install --production
+
+RUN npm install pm2@5.1.0 -g
 
 COPY --from=build /build/dist/ ./
 

--- a/ccm_web/Dockerfile
+++ b/ccm_web/Dockerfile
@@ -34,11 +34,9 @@ COPY --from=base \
 RUN npm install --production
 RUN npm install pm2@5.1.0 -g
 COPY --from=build /build/dist/ ./
-# Let members of root group write to /app/
-# RUN chmod -R g+rw /app/
 
-# Change HOME so that .pm2 files are written in /app/
-ENV PM2_HOME=/tmp/
+# Set PM2_HOME so that .pm2 files are written in /tmp/
+ENV PM2_HOME=/tmp/.pm2
 ARG PORT
 EXPOSE ${PORT}
 ENTRYPOINT ["./start.sh"]

--- a/ccm_web/Dockerfile
+++ b/ccm_web/Dockerfile
@@ -3,7 +3,7 @@
 # - https://dev.to/chrsgrrtt/dockerising-a-next-js-project-1ck5
 
 # Base stage
-FROM node:14-slim AS base
+FROM node:14-slim AS ccm-base
 WORKDIR /base/
 COPY package*.json ./
 RUN npm install
@@ -13,17 +13,17 @@ ARG PORT
 EXPOSE ${PORT}
 
 # Build stage (build client and compile server to JS)
-FROM base AS build
+FROM ccm-base AS ccm-build
 WORKDIR /build/
-COPY --from=base /base ./
+COPY --from=ccm-base /base ./
 RUN npm run build
 
 # Prod stage
-FROM node:14-slim AS prod
+FROM node:14-slim AS ccm-prod
 ENV NODE_ENV=production
 WORKDIR /app
 
-COPY --from=base /base/package.json \
+COPY --from=ccm-base /base/package.json \
     /base/package-lock.json \
     /base/start.sh /base/ecosystem.config.js \
     ./
@@ -31,7 +31,7 @@ RUN npm install --production
 
 RUN npm install pm2@5.1.0 -g
 
-COPY --from=build /build/dist/ ./
+COPY --from=ccm-build /build/dist/ ./
 
 ARG PORT
 EXPOSE ${PORT}

--- a/ccm_web/Dockerfile
+++ b/ccm_web/Dockerfile
@@ -5,6 +5,7 @@
 # Base stage
 FROM node:14-slim AS base
 WORKDIR /base/
+
 COPY package*.json ./
 RUN npm install
 COPY . .
@@ -15,6 +16,7 @@ EXPOSE ${PORT}
 # Build stage (build client and compile server to JS)
 FROM node:14-slim AS build
 WORKDIR /build/
+
 COPY --from=base /base ./
 RUN npm run build
 
@@ -23,14 +25,14 @@ FROM node:14-slim AS prod
 ENV NODE_ENV=production
 WORKDIR /app
 
-COPY --from=base /base/package.json \
+COPY --from=base \
+    /base/package.json \
     /base/package-lock.json \
-    /base/start.sh /base/ecosystem.config.js \
+    /base/start.sh \
+    /base/ecosystem.config.js \
     ./
 RUN npm install --production
-
 RUN npm install pm2@5.1.0 -g
-
 COPY --from=build /build/dist/ ./
 
 ARG PORT

--- a/ccm_web/Dockerfile
+++ b/ccm_web/Dockerfile
@@ -35,10 +35,10 @@ RUN npm install --production
 RUN npm install pm2@5.1.0 -g
 COPY --from=build /build/dist/ ./
 # Let members of root group write to /app/
-RUN chmod -R g+rw /app/
+# RUN chmod -R g+rw /app/
 
 # Change HOME so that .pm2 files are written in /app/
-ENV HOME=/app/
+# ENV HOME=/app/
 ARG PORT
 EXPOSE ${PORT}
 ENTRYPOINT ["./start.sh"]

--- a/ccm_web/Dockerfile
+++ b/ccm_web/Dockerfile
@@ -34,8 +34,10 @@ COPY --from=base \
 RUN npm install --production
 RUN npm install pm2@5.1.0 -g
 COPY --from=build /build/dist/ ./
+# Let members of root group write to /app/
+RUN chmod -R g+rw /app/
 
-# Change HOME so that .pm2 files can be written to file system
+# Change HOME so that .pm2 files are written in /app/
 ENV HOME=/app/
 ARG PORT
 EXPOSE ${PORT}

--- a/ccm_web/Dockerfile
+++ b/ccm_web/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=build /build/dist/ ./
 # RUN chmod -R g+rw /app/
 
 # Change HOME so that .pm2 files are written in /app/
-# ENV HOME=/app/
+ENV PM2_HOME=/tmp/
 ARG PORT
 EXPOSE ${PORT}
 ENTRYPOINT ["./start.sh"]

--- a/ccm_web/Dockerfile.openshift
+++ b/ccm_web/Dockerfile.openshift
@@ -29,6 +29,6 @@ RUN chmod -R g+rw /app/
 ENV HOME=/app/
 ARG PORT
 EXPOSE ${PORT}
-CMD ["sh", "-c", "./start.sh"]
+ENTRYPOINT ["./start.sh"]
 
 # Done!

--- a/ccm_web/Dockerfile.openshift
+++ b/ccm_web/Dockerfile.openshift
@@ -22,8 +22,10 @@ COPY --from=build \
 RUN npm install --production
 RUN npm install pm2@5.1.0 -g
 COPY --from=build /build/dist/ ./
+# Let members of root group write to /app/
+RUN chmod -R g+rw /app/
 
-# Change HOME so that .pm2 files can be written to file system
+# Change HOME so that .pm2 files are written in /app/
 ENV HOME=/app/
 ARG PORT
 EXPOSE ${PORT}

--- a/ccm_web/Dockerfile.openshift
+++ b/ccm_web/Dockerfile.openshift
@@ -22,11 +22,9 @@ COPY --from=build \
 RUN npm install --production
 RUN npm install pm2@5.1.0 -g
 COPY --from=build /build/dist/ ./
-# Let members of root group write to /app/
-# RUN chmod -R g+rw /app/
 
-# Change HOME so that .pm2 files are written in /app/
-ENV PM2_HOME=/tmp/
+# Set PM2_HOME so that .pm2 files are written in /tmp/
+ENV PM2_HOME=/tmp/.pm2
 ARG PORT
 EXPOSE ${PORT}
 ENTRYPOINT ["./start.sh"]

--- a/ccm_web/Dockerfile.openshift
+++ b/ccm_web/Dockerfile.openshift
@@ -23,6 +23,8 @@ RUN npm install --production
 RUN npm install pm2@5.1.0 -g
 COPY --from=build /build/dist/ ./
 
+# Change HOME so that .pm2 files can be written to file system
+ENV HOME=/app/
 ARG PORT
 EXPOSE ${PORT}
 CMD ["sh", "-c", "./start.sh"]

--- a/ccm_web/Dockerfile.openshift
+++ b/ccm_web/Dockerfile.openshift
@@ -20,14 +20,11 @@ COPY --from=build \
     /build/ecosystem.config.js \
     ./
 RUN npm install --production
-
 RUN npm install pm2@5.1.0 -g
-
 COPY --from=build /build/dist/ ./
 
 ARG PORT
 EXPOSE ${PORT}
-
 CMD ["sh", "-c", "./start.sh"]
 
 # Done!

--- a/ccm_web/Dockerfile.openshift
+++ b/ccm_web/Dockerfile.openshift
@@ -23,10 +23,10 @@ RUN npm install --production
 RUN npm install pm2@5.1.0 -g
 COPY --from=build /build/dist/ ./
 # Let members of root group write to /app/
-RUN chmod -R g+rw /app/
+# RUN chmod -R g+rw /app/
 
 # Change HOME so that .pm2 files are written in /app/
-ENV HOME=/app/
+# ENV HOME=/app/
 ARG PORT
 EXPOSE ${PORT}
 ENTRYPOINT ["./start.sh"]

--- a/ccm_web/Dockerfile.openshift
+++ b/ccm_web/Dockerfile.openshift
@@ -26,7 +26,7 @@ COPY --from=build /build/dist/ ./
 # RUN chmod -R g+rw /app/
 
 # Change HOME so that .pm2 files are written in /app/
-# ENV HOME=/app/
+ENV PM2_HOME=/tmp/
 ARG PORT
 EXPOSE ${PORT}
 ENTRYPOINT ["./start.sh"]

--- a/ccm_web/Dockerfile.openshift
+++ b/ccm_web/Dockerfile.openshift
@@ -1,0 +1,33 @@
+# Build stage (build client and compile server to JS)
+FROM docker-registry.default.svc:5000/openshift/node:14-slim AS build
+WORKDIR /build/
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+# Prod stage
+FROM docker-registry.default.svc:5000/openshift/node:14-slim AS prod
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY --from=build \
+    /build/package.json \
+    /build/package-lock.json \
+    /build/start.sh \
+    /build/ecosystem.config.js \
+    ./
+RUN npm install --production
+
+RUN npm install pm2@5.1.0 -g
+
+COPY --from=build /build/dist/ ./
+
+ARG PORT
+EXPOSE ${PORT}
+
+CMD ["sh", "-c", "./start.sh"]
+
+# Done!

--- a/ccm_web/ecosystem.config.js
+++ b/ccm_web/ecosystem.config.js
@@ -10,7 +10,7 @@ module.exports = {
     exec_mode: 'cluster',
     instances: 'max',
     autorestart: true,
-    max_memory_restart: '1G',
+    max_memory_restart: process.env.PM2_MEM_LIMIT || '1G',
     out_file: '/dev/null',
     error_file: '/dev/null'
   }]

--- a/ccm_web/ecosystem.config.js
+++ b/ccm_web/ecosystem.config.js
@@ -9,7 +9,6 @@ module.exports = {
     autorestart: true,
     max_memory_restart: '1G',
     out_file: '/dev/null',
-    error_file: '/dev/null',
-    pid_file: '/tmp/app.pid'
+    error_file: '/dev/null'
   }
 }

--- a/ccm_web/ecosystem.config.js
+++ b/ccm_web/ecosystem.config.js
@@ -9,6 +9,7 @@ module.exports = {
     autorestart: true,
     max_memory_restart: '1G',
     out_file: '/dev/null',
-    error_file: '/dev/null'
+    error_file: '/dev/null',
+    pid_file: '/tmp/app.pid'
   }
 }

--- a/ccm_web/ecosystem.config.js
+++ b/ccm_web/ecosystem.config.js
@@ -1,0 +1,14 @@
+// https://pm2.keymetrics.io/docs/usage/docker-pm2-nodejs/
+
+module.exports = {
+  apps: {
+    name: 'CCM - NestJS app',
+    script: 'server/src/main.js',
+    exec_mode: 'cluster',
+    instances: 'max',
+    autorestart: true,
+    max_memory_restart: '1G',
+    out_file: '/dev/null',
+    error_file: '/dev/null'
+  }
+}

--- a/ccm_web/ecosystem.config.js
+++ b/ccm_web/ecosystem.config.js
@@ -1,7 +1,10 @@
-// https://pm2.keymetrics.io/docs/usage/docker-pm2-nodejs/
+/*
+https://pm2.keymetrics.io/docs/usage/application-declaration/
+https://pm2.keymetrics.io/docs/usage/docker-pm2-nodejs/
+*/
 
 module.exports = {
-  apps: {
+  apps: [{
     name: 'CCM - NestJS app',
     script: 'server/src/main.js',
     exec_mode: 'cluster',
@@ -10,5 +13,5 @@ module.exports = {
     max_memory_restart: '1G',
     out_file: '/dev/null',
     error_file: '/dev/null'
-  }
+  }]
 }

--- a/ccm_web/server/src/app.module.ts
+++ b/ccm_web/server/src/app.module.ts
@@ -20,7 +20,7 @@ const logger = baseLogger.child({ filePath: __filename })
 @Module({
   imports: [
     ConfigModule.forRoot({
-      validate: validateConfig,
+      load: [validateConfig],
       ignoreEnvFile: true,
       isGlobal: true
     }),

--- a/ccm_web/server/src/config.ts
+++ b/ccm_web/server/src/config.ts
@@ -54,8 +54,9 @@ const isLogLevel = (v: unknown): v is LogLevel => {
   return isString(v) && ['debug', 'info', 'warn', 'error'].includes(v)
 }
 
-const prepNumber = (value: string | undefined): number | undefined => {
-  return (value === undefined) ? undefined : Number(value)
+// Handles some edge cases and casts all other values using Number
+const prepNumber = (value: string | undefined): string | number | undefined => {
+  return (value === undefined) ? undefined : value.trim() === '' ? value : Number(value)
 }
 
 function validate<T> (

--- a/ccm_web/server/src/config.ts
+++ b/ccm_web/server/src/config.ts
@@ -43,11 +43,11 @@ export interface Config {
 
 const logger = baseLogger.child({ filePath: __filename })
 
-// Tests if an unknown value is a non-empty string
-const isString = (v: unknown): v is string => typeof v === 'string' && v.length > 0
+const isString = (v: unknown): v is string => typeof v === 'string'
+const isNotEmpty = (v: string): boolean => v.length > 0
 
-// Tests if an unknown value is a number and not NaN
-const isNumber = (v: unknown): v is number => typeof v === 'number' && !isNaN(v)
+const isNumber = (v: unknown): v is number => typeof v === 'number'
+const isNotNan = (v: number): boolean => !isNaN(v)
 
 // Tests if an unknown value is one of four allowed string log levels
 const isLogLevel = (v: unknown): v is LogLevel => {
@@ -61,16 +61,27 @@ const prepNumber = (value: string | undefined): number | undefined => {
 function validate<T> (
   key: string,
   value: unknown,
-  check: (v: unknown) => v is T,
+  checkType: (v: unknown) => v is T,
+  extraChecks: Array<(v: T) => boolean>,
   fallback?: T
 ): T {
   const errorBase = 'Exception while loading configuration: '
-  if (check(value)) return value
+  const runExtraChecks = (v: T): boolean => extraChecks.map(c => c(v)).every(r => r)
   if (value === undefined && fallback !== undefined) {
-    logger.info(`Value for ${key} was undefined; using fallback ${String(fallback)}`)
+    const fallbackBase = `Value for ${key} was undefined; `
+    if (extraChecks.length > 0) {
+      if (!runExtraChecks(fallback)) {
+        throw new Error(errorBase + fallbackBase + `fallback "${String(fallback)}" did not pass extra checks.`)
+      }
+    }
+    logger.info(fallbackBase + `using fallback ${String(fallback)}`)
     return fallback
   }
-  throw (Error(errorBase + `Value ${String(value)} for ${key} is not valid`))
+  if (checkType(value)) {
+    if (extraChecks.length === 0) return value
+    if (runExtraChecks(value)) return value
+  }
+  throw new Error(errorBase + `Value "${String(value)}" for ${key} is not valid`)
 }
 
 export function validateConfig (): Config {
@@ -83,32 +94,32 @@ export function validateConfig (): Config {
 
   try {
     server = {
-      port: validate<number>('PORT', prepNumber(env.PORT), isNumber, 4000),
-      domain: validate<string>('DOMAIN', env.DOMAIN, isString),
-      logLevel: validate<LogLevel>('LOG_LEVEL', env.LOG_LEVEL, isLogLevel, 'debug'),
-      tokenSecret: validate<string>('TOKEN_SECRET', env.TOKEN_SECRET, isString, 'TOKENSECRET'),
-      cookieSecret: validate<string>('COOKIE_SECRET', env.COOKIE_SECRET, isString, 'COOKIESECRET'),
-      maxAgeInSec: validate<number>('MAX_AGE_IN_SEC', prepNumber(env.MAX_AGE_IN_SEC), isNumber, (24 * 60 * 60))
+      port: validate<number>('PORT', prepNumber(env.PORT), isNumber, [isNotNan], 4000),
+      domain: validate<string>('DOMAIN', env.DOMAIN, isString, [isNotEmpty]),
+      logLevel: validate<LogLevel>('LOG_LEVEL', env.LOG_LEVEL, isLogLevel, [], 'debug'),
+      tokenSecret: validate<string>('TOKEN_SECRET', env.TOKEN_SECRET, isString, [isNotEmpty], 'TOKENSECRET'),
+      cookieSecret: validate<string>('COOKIE_SECRET', env.COOKIE_SECRET, isString, [isNotEmpty], 'COOKIESECRET'),
+      maxAgeInSec: validate<number>('MAX_AGE_IN_SEC', prepNumber(env.MAX_AGE_IN_SEC), isNumber, [isNotNan], (24 * 60 * 60))
     }
     lti = {
-      encryptionKey: validate<string>('LTI_ENCRYPTION_KEY', env.LTI_ENCRYPTION_KEY, isString, 'LTIKEY'),
-      clientID: validate<string>('LTI_CLIENT_ID', env.LTI_CLIENT_ID, isString),
-      platformURL: validate<string>('LTI_PLATFORM_URL', env.LTI_PLATFORM_URL, isString),
-      authEnding: validate<string>('LTI_AUTH_ENDING', env.LTI_AUTH_ENDING, isString),
-      tokenEnding: validate<string>('LTI_TOKEN_ENDING', env.LTI_TOKEN_ENDING, isString),
-      keysetEnding: validate<string>('LTI_KEYSET_ENDING', env.LTI_KEYSET_ENDING, isString)
+      encryptionKey: validate<string>('LTI_ENCRYPTION_KEY', env.LTI_ENCRYPTION_KEY, isString, [isNotEmpty], 'LTIKEY'),
+      clientID: validate<string>('LTI_CLIENT_ID', env.LTI_CLIENT_ID, isString, [isNotEmpty]),
+      platformURL: validate<string>('LTI_PLATFORM_URL', env.LTI_PLATFORM_URL, isString, [isNotEmpty]),
+      authEnding: validate<string>('LTI_AUTH_ENDING', env.LTI_AUTH_ENDING, isString, [isNotEmpty]),
+      tokenEnding: validate<string>('LTI_TOKEN_ENDING', env.LTI_TOKEN_ENDING, isString, [isNotEmpty]),
+      keysetEnding: validate<string>('LTI_KEYSET_ENDING', env.LTI_KEYSET_ENDING, isString, [isNotEmpty])
     }
     canvas = {
-      instanceURL: validate<string>('CANVAS_INSTANCE_URL', env.CANVAS_INSTANCE_URL, isString),
-      apiClientId: validate<string>('CANVAS_API_CLIENT_ID', env.CANVAS_API_CLIENT_ID, isString),
-      apiSecret: validate<string>('CANVAS_API_SECRET', env.CANVAS_API_SECRET, isString)
+      instanceURL: validate<string>('CANVAS_INSTANCE_URL', env.CANVAS_INSTANCE_URL, isString, [isNotEmpty]),
+      apiClientId: validate<string>('CANVAS_API_CLIENT_ID', env.CANVAS_API_CLIENT_ID, isString, [isNotEmpty]),
+      apiSecret: validate<string>('CANVAS_API_SECRET', env.CANVAS_API_SECRET, isString, [isNotEmpty])
     }
     db = {
-      host: validate<string>('DB_HOST', env.DB_HOST, isString),
-      port: validate<number>('DB_PORT', prepNumber(env.DB_PORT), isNumber, 3306),
-      name: validate<string>('DB_NAME', env.DB_NAME, isString),
-      user: validate<string>('DB_USER', env.DB_USER, isString),
-      password: validate<string>('DB_PASSWORD', env.DB_PASSWORD, isString)
+      host: validate<string>('DB_HOST', env.DB_HOST, isString, [isNotEmpty]),
+      port: validate<number>('DB_PORT', prepNumber(env.DB_PORT), isNumber, [isNotNan], 3306),
+      name: validate<string>('DB_NAME', env.DB_NAME, isString, [isNotEmpty]),
+      user: validate<string>('DB_USER', env.DB_USER, isString, [isNotEmpty]),
+      password: validate<string>('DB_PASSWORD', env.DB_PASSWORD, isString, [isNotEmpty])
     }
   } catch (error) {
     logger.error(error)

--- a/ccm_web/server/src/init.ts
+++ b/ccm_web/server/src/init.ts
@@ -1,0 +1,22 @@
+import { NestFactory } from '@nestjs/core'
+
+import { AppModule } from './app.module'
+
+import baseLogger from './logger'
+
+const logger = baseLogger.child({ filePath: __filename })
+
+/*
+Running this before clustering ensures that ltijs database tables have been set up initially
+and that the configuration is valid.
+*/
+async function bootstrap (): Promise<void> {
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn']
+  })
+  await app.close()
+}
+
+bootstrap()
+  .then(() => logger.info('ltijs has been initialized and configuration is valid.'))
+  .catch((e) => logger.error('An error occurred while initializing: ', e))

--- a/ccm_web/server/src/main.ts
+++ b/ccm_web/server/src/main.ts
@@ -87,18 +87,21 @@ async function bootstrap (): Promise<void> {
 
   if (!isDev) {
     process.on('SIGINT', function () {
+      logger.info('SIGINT signal received; shutting down...')
       app.close()
         .then(() => logger.info('The application shut down gracefully.'))
         .catch(() => logger.error('The application failed to shut down gracefully.'))
     })
   }
 
-  const hostname = isDev ? 'localhost' : serverConfig.domain
+  const hostname = '0.0.0.0'
 
   await app.listen(
-    serverConfig.port,
+    serverConfig.port, hostname,
     () => logger.info(`Server started on ${hostname} and port ${serverConfig.port}`)
   )
+  logger.info('ip?')
+  logger.info(await app.getUrl())
 }
 
 bootstrap()

--- a/ccm_web/server/src/main.ts
+++ b/ccm_web/server/src/main.ts
@@ -85,7 +85,7 @@ async function bootstrap (): Promise<void> {
     SwaggerModule.setup('swagger', app, document)
   }
 
-  app.enableShutdownHooks(['SIGINT'])
+  if (!isDev) app.enableShutdownHooks(['SIGINT'])
 
   await app.listen(
     serverConfig.port,

--- a/ccm_web/server/src/main.ts
+++ b/ccm_web/server/src/main.ts
@@ -85,23 +85,12 @@ async function bootstrap (): Promise<void> {
     SwaggerModule.setup('swagger', app, document)
   }
 
-  if (!isDev) {
-    process.on('SIGINT', function () {
-      logger.info('SIGINT signal received; shutting down...')
-      app.close()
-        .then(() => logger.info('The application shut down gracefully.'))
-        .catch(() => logger.error('The application failed to shut down gracefully.'))
-    })
-  }
-
-  const hostname = '0.0.0.0'
+  app.enableShutdownHooks(['SIGINT'])
 
   await app.listen(
-    serverConfig.port, hostname,
-    () => logger.info(`Server started on ${hostname} and port ${serverConfig.port}`)
+    serverConfig.port,
+    () => logger.info(`Server started on 0.0.0.0 and port ${serverConfig.port}`)
   )
-  logger.info('ip?')
-  logger.info(await app.getUrl())
 }
 
 bootstrap()

--- a/ccm_web/server/src/migrator.ts
+++ b/ccm_web/server/src/migrator.ts
@@ -5,7 +5,7 @@ import baseLogger from './logger'
 
 const logger = baseLogger.child({ filePath: __filename })
 
-const databaseConfig = validateConfig(process.env).db
+const databaseConfig = validateConfig().db
 
 const sequelize = new Sequelize(
   databaseConfig.name,

--- a/ccm_web/start.sh
+++ b/ccm_web/start.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
+set -e
+
 echo "Running any un-applied migrations"
 node server/src/migrator up
-echo "Starting up the server"
-node server/src/main.js
+
+echo "Checking initialization and config before clustering"
+node server/src/init.js
+
+echo "Starting pm2 cluster"
+pm2-runtime ecosystem.config.js

--- a/ccm_web/start.sh
+++ b/ccm_web/start.sh
@@ -8,4 +8,4 @@ echo "Checking initialization and config before clustering"
 node server/src/init.js
 
 echo "Starting pm2 cluster"
-pm2-runtime ecosystem.config.js
+exec pm2-runtime ecosystem.config.js

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -1,20 +1,27 @@
-# If comment indicates the key is optional, the value provided is the fallback.
+# CCM .env template
+# If the explanatory comment indicates the key is optional,
+# the value provided in the following commented line is the fallback.
+# Values provided on un-commented lines are recommended for development.
+# Fallback secrets and keys are sometimes provided for convenience in development,
+# but they should NOT be used with deployments.
 
-# Port that the server should listen on within the container (Optional)
+# Server variables
+# Port that the server should listen on within the container (optional)
 # PORT=4000
 # This app server's hostname. For session configuration and OAuth redirects
 # Note: Use xxxxxxxxxxxx.ngrok.io for local development.
 DOMAIN=
-# One of the following npm log levels: debug, info, warn, error
+# One of the following npm log levels: debug, info, warn, error (optional)
 # LOG_LEVEL=debug
-# Secret for securing JWT tokens
+# Secret for securing JWT tokens (optional)
 # TOKEN_SECRET=TOKENSECRET
-# Secret for securing sessions and cookies
+# Secret for securing sessions and cookies (optional)
 # COOKIE_SECRET=COOKIESECRET
-# Maximum age in seconds for cookies and tokens (default is 24 hours)
+# Maximum age in seconds for cookies and tokens (default is 24 hours) (optional)
 # MAX_AGE_IN_SEC=86400
 
-# Key used by ltijs for cookie signing and data encryption
+# LTI variables
+# Key used by ltijs for cookie signing and data encryption (optional)
 # LTI_ENCRYPTION_KEY=LTIKEY
 # Base URL pointing to the Canvas LMS platform
 LTI_PLATFORM_URL=https://canvas.test.instructure.com
@@ -27,6 +34,10 @@ LTI_TOKEN_ENDING=/login/oauth2/token
 # Canvas JWKS endpoint (used with the LTI PLATFORM URL)
 LTI_KEYSET_ENDING=/api/lti/security/jwks
 
+# Uncomment the following line for debugging output from ltijs
+# DEBUG=provider:*
+
+# Canvas variables
 # Base Canvas URL for all requests, including those for OAuth and API.
 # Use BASE URL ONLY.  Do NOT include "/api/v1" or other paths.
 CANVAS_INSTANCE_URL=https://canvas-test.it.umich.edu
@@ -35,8 +46,9 @@ CANVAS_API_CLIENT_ID=
 # Secret for the Canvas Developer Key associated with the application
 CANVAS_API_SECRET=
 
-# Parameters for connecting to the MySQL database
-# Values provided are the parameters for databases started using docker-compose.yml
+# Database variables
+# Parameters for connecting to the MySQL database (port is optional)
+# Values provided are the parameters for databases started using docker-compose.yml.
 # When using docker-compose-prod.yml, you will need to add _prod to the host name.
 DB_HOST=ccm_db
 # DB_PORT=3306
@@ -44,5 +56,8 @@ DB_NAME=ccm
 DB_USER=admin
 DB_PASSWORD=admin
 
-# Uncomment the following line for debugging output from ltijs
-# DEBUG=provider:*
+# Deployment variables
+# These are only used with docker-compose-prod.yml and in OpenShift.
+# Memory limit for pm2 processes (optional)
+# See ecosystem.config.js for usage and doc links; don't use decimals (i.e. use 1800M over 1.8G).
+# PM2_MEM_LIMIT=1G

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -5,6 +5,7 @@ services:
   web:
     build:
       context: ./ccm_web/
+      dockerfile: ./Dockerfile
       args:
         - PORT=4000
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   web:
     build:
       context: ./ccm_web/
+      dockerfile: ./Dockerfile
       args:
         - PORT=4000
       target: base


### PR DESCRIPTION
This PR prepares the project for OpenShift deployments by doing the following:
- Implementing the `pm2` process manager (in `cluster` mode) for production builds so we can utilize all cores in OpenShift pods, improving performance and resiliency in case of errors
- Creating an `init` script that starts and stops the NestJS application to ensure the configuration is valid and the `ltijs` database tables are initialized before the application is clustered (might be a better way to do this, still thinking about it)
- Working around an issue in OpenShift 3 for deployments by pulling from `node:14-slim` in `build` `Dockerfile` stage (instead of from the `base` stage)
- Working around Docker rate limits by creating an alternate `Dockerfile.openshift` (hopefully we can remove this when we migrate to OpenShift 4)
- Hardening configuration logic so that the `fallback` (read default) is only used if the variable is `undefined`; only non-`undefined` candidate `isNumber` values are cast using `Number()`; empty strings are considered invalid; and extra runtime checks are separated from type guards (#175).
- Enabled graceful shutdown in production by ensuring `SIGTERM` signals are passed from OpenShift to `start.sh` to `pm2-runtime`, and that `SIGINT` signals are passed from `pm2` to each child thread.

The PR aims to resolve #42 and #175.
