### PR TITLE
Bulk Section Create empty line validator

### DIFF
--- a/ccm_web/client/src/components/BulkSectionCreateValidators.ts
+++ b/ccm_web/client/src/components/BulkSectionCreateValidators.ts
@@ -77,5 +77,17 @@ class DuplicateSectionInFileSectionRowsValidator implements SectionRowsValidator
   }
 }
 
+class EmptySectionNameValidator implements SectionRowsValidator {
+  validate = (sectionNames: string[]): SectionsRowInvalidation[] => {
+    const invalidations: SectionsRowInvalidation[] = []
+    sectionNames.forEach((sectionName, row) => {
+      if (sectionName.trim().length === 0) {
+        invalidations.push({ message: 'Empty section name\'s not allowed', rowNumber: row + 2, type: InvalidationType.Error })
+      }
+    })
+    return invalidations
+  }
+}
+
 export type { SectionsSchemaInvalidation, SectionsRowInvalidation, SectionRowsValidator, SectionsSchemaValidator }
-export { InvalidationType, SectionNameHeaderValidator, DuplicateSectionInFileSectionRowsValidator, hasHeader }
+export { InvalidationType, SectionNameHeaderValidator, DuplicateSectionInFileSectionRowsValidator, EmptySectionNameValidator, hasHeader }

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -190,7 +190,7 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
 
   const parseFile = (file: File): void => {
     file.text().then(t => {
-      let lines = t.split(/[\r\n]+/).map(line => { return line.trim() })
+      let lines = t.replace(/\r\n/, '\n').split(/\n/)
       // An empty file will resultin 1 line
       if (lines.length > 0 && lines[0].length === 0) {
         lines = lines.slice(1)

--- a/ccm_web/client/src/pages/BulkSectionCreate.tsx
+++ b/ccm_web/client/src/pages/BulkSectionCreate.tsx
@@ -333,7 +333,6 @@ function BulkSectionCreate (props: CCMComponentProps): JSX.Element {
       }
       handleParseSuccess(lines)
     }).catch(e => {
-      console.log(e)
       // TODO Not sure how to produce this error in real life
       handleSchemaError([{ error: 'Error processing file', type: InvalidationType.Error }])
     })

--- a/ccm_web/client/src/pages/BulkSectionCreate.tsx
+++ b/ccm_web/client/src/pages/BulkSectionCreate.tsx
@@ -6,7 +6,7 @@ import BulkSectionCreateUploadConfirmationTable, { Section } from '../components
 import FileUpload from '../components/FileUpload'
 import ValidationErrorTable from '../components/ValidationErrorTable'
 import usePromise from '../hooks/usePromise'
-import { DuplicateSectionInFileSectionRowsValidator, hasHeader, InvalidationType, SectionNameHeaderValidator, SectionRowsValidator, SectionsRowInvalidation, SectionsSchemaInvalidation, SectionsSchemaValidator } from '../components/BulkSectionCreateValidators'
+import { DuplicateSectionInFileSectionRowsValidator, EmptySectionNameValidator, hasHeader, InvalidationType, SectionNameHeaderValidator, SectionRowsValidator, SectionsRowInvalidation, SectionsSchemaInvalidation, SectionsSchemaValidator } from '../components/BulkSectionCreateValidators'
 import ExampleFileDownloadHeader, { ExampleFileDownloadHeaderProps } from '../components/ExampleFileDownloadHeader'
 import { CanvasCourseSection } from '../models/canvas'
 import { createSectionsProps } from '../models/feature'
@@ -312,7 +312,7 @@ function BulkSectionCreate (props: CCMComponentProps): JSX.Element {
 
   const parseFile = (file: File): void => {
     file.text().then(t => {
-      let lines = t.split(/[\r\n]+/).map(line => { return line.trim() })
+      let lines = t.replace(/\r\n/, '\n').split(/\n/)
       // An empty file will resultin 1 line
       if (lines.length > 0 && lines[0].length === 0) {
         lines = lines.slice(1)
@@ -333,6 +333,7 @@ function BulkSectionCreate (props: CCMComponentProps): JSX.Element {
       }
       handleParseSuccess(lines)
     }).catch(e => {
+      console.log(e)
       // TODO Not sure how to produce this error in real life
       handleSchemaError([{ error: 'Error processing file', type: InvalidationType.Error }])
     })
@@ -343,6 +344,8 @@ function BulkSectionCreate (props: CCMComponentProps): JSX.Element {
 
     const duplicateNamesInFileValidator: SectionRowsValidator = new DuplicateSectionInFileSectionRowsValidator()
     rowInvalidations.push(...duplicateNamesInFileValidator.validate(sectionNames))
+    const emptyNamesInFileValidator: EmptySectionNameValidator = new EmptySectionNameValidator()
+    rowInvalidations.push(...emptyNamesInFileValidator.validate(sectionNames))
 
     return rowInvalidations
   }


### PR DESCRIPTION
Fixes #160

Add a new empty section validator for bulk section creation
Also fixes an issue where blank lines were being ignored.. functionally ok but messed with line numbers in error messages.  This was present in bulk section create an
[IncludesABlank.csv](https://github.com/tl-its-umich-edu/canvas-course-manager-next/files/7093243/IncludesABlank.csv)
d bulk add UM users.