### PR TITLE
Add `AuthorizePrompt` component, extract `Breadcrumbs` (#189)

### DIFF
--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -1,35 +1,24 @@
 import React, { useEffect, useState } from 'react'
-import { BrowserRouter as Router, Link as RouterLink, Route, Switch } from 'react-router-dom'
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
+import { Link, makeStyles } from '@material-ui/core'
 import { SnackbarProvider } from 'notistack'
-import { Breadcrumbs, Link, makeStyles, Typography } from '@material-ui/core'
-import NavigateNextIcon from '@material-ui/icons/NavigateNext'
 
 import { getCourse, getCSRFToken } from './api'
+import AuthorizePrompt from './components/AuthorizePrompt'
+import Breadcrumbs from './components/Breadcrumbs'
 import useGlobals from './hooks/useGlobals'
 import usePromise from './hooks/usePromise'
 import { CanvasCourseBase } from './models/canvas'
 import allFeatures from './models/FeatureUIData'
 import Home from './pages/Home'
-import redirect from './utils/redirect'
 import './App.css'
 
 const useStyles = makeStyles((theme) => ({
-  breadcrumbs: {
-    fontSize: '1.125rem'
-  },
-  breadcrumbContainer: {
-    paddingLeft: 25,
-    paddingTop: 25
-  },
   swaggerLink: {
     display: 'block',
     clear: 'both'
   }
 }))
-
-interface TitleTypographyProps {
-  to?: string
-}
 
 function App (): JSX.Element {
   const classes = useStyles()
@@ -66,22 +55,12 @@ function App (): JSX.Element {
   }
 
   if (!globals.user.hasCanvasToken) {
-    // Initiate OAuth flow
-    redirect('/canvas/redirectOAuth')
-    return loading
-  }
-
-  interface BreadcrumbProps {
-    isLink: boolean
-  }
-
-  const HomeBreadcrumb = (props: BreadcrumbProps): JSX.Element => {
-    const typography = (<Typography className={classes.breadcrumbs} color='textPrimary'>
-                          Canvas Course Manager
-                        </Typography>)
-    return props.isLink
-      ? (<Link component={RouterLink} to='/'>{typography}</Link>)
-      : (typography)
+    return (
+      <div className='App'>
+        <Breadcrumbs />
+        <AuthorizePrompt />
+      </div>
+    )
   }
 
   return (
@@ -92,21 +71,7 @@ function App (): JSX.Element {
             <Route>
               {({ location }) => {
                 const pathnames = location.pathname.split('/').filter(x => x)
-                return (
-                  <Breadcrumbs className={classes.breadcrumbContainer} aria-label="breadcrumb" separator={<NavigateNextIcon fontSize="small" />}>
-                    <HomeBreadcrumb isLink={(pathnames.length > 0)} />
-                    {pathnames.map((value, index) => {
-                      const last = index === pathnames.length - 1
-                      const to = `/${pathnames.slice(0, index + 1).join('/')}`
-                      const feature = features.filter(f => { return f.route.substring(1) === value })[0]
-                      const titleTypographyProps: TitleTypographyProps = last ? { to: to } : {}
-
-                      return (<Typography className={classes.breadcrumbs} color='textPrimary' key={to} {...titleTypographyProps}>
-                        {feature.data.title}
-                      </Typography>)
-                    })}
-                  </Breadcrumbs>
-                )
+                return <Breadcrumbs {...{ features, pathnames }} />
               }}
             </Route>
           </div>

--- a/ccm_web/client/src/components/AuthorizePrompt.tsx
+++ b/ccm_web/client/src/components/AuthorizePrompt.tsx
@@ -15,7 +15,9 @@ export default function AuthorizePrompt (): JSX.Element {
   const classes = useStyles()
   return (
     <div className={classes.root}>
-      <Typography variant='h5' component='h1' gutterBottom>Need to Authorize Canvas Integration</Typography>
+      <Typography variant='h5' component='h1' gutterBottom>
+        Authorize Course Manager to Access Your Canvas Account
+      </Typography>
       <Typography gutterBottom>
         This tool is not integrated with Canvas.
       </Typography>

--- a/ccm_web/client/src/components/AuthorizePrompt.tsx
+++ b/ccm_web/client/src/components/AuthorizePrompt.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Button, makeStyles, Typography } from '@material-ui/core'
+
+const useStyles = makeStyles(() => ({
+  root: {
+    padding: 25,
+    textAlign: 'left'
+  },
+  button: {
+    marginTop: 15
+  }
+}))
+
+export default function AuthorizePrompt (): JSX.Element {
+  const classes = useStyles()
+  return (
+    <div className={classes.root}>
+      <Typography variant='h5' component='h1' gutterBottom>Canvas Integration</Typography>
+      <Typography gutterBottom>
+        To use Canvas Course Manager, you must first authorize the tool to make requests to Canvas on your behalf.
+        To do so, click the &quot;Go to Canvas&quot; button below, which will redirect you to a Canvas prompt.
+      </Typography>
+      <Typography gutterBottom>
+        <b>Note:</b> If you have done this before, it is likely that your integration was removed in Canvas.
+      </Typography>
+      <Button
+        className={classes.button}
+        color='primary'
+        variant='contained'
+        href='/canvas/redirectOAuth'
+        aria-label='Authorize Canvas integration'
+      >
+        Go to Canvas
+      </Button>
+    </div>
+  )
+}

--- a/ccm_web/client/src/components/AuthorizePrompt.tsx
+++ b/ccm_web/client/src/components/AuthorizePrompt.tsx
@@ -15,10 +15,12 @@ export default function AuthorizePrompt (): JSX.Element {
   const classes = useStyles()
   return (
     <div className={classes.root}>
-      <Typography variant='h5' component='h1' gutterBottom>Canvas Integration</Typography>
+      <Typography variant='h5' component='h1' gutterBottom>Need to Authorize Canvas Integration</Typography>
       <Typography gutterBottom>
-        To use Canvas Course Manager, you must first authorize the tool to make requests to Canvas on your behalf.
-        To do so, click the &quot;Go to Canvas&quot; button below, which will redirect you to a Canvas prompt.
+        This tool is not integrated with Canvas.
+      </Typography>
+      <Typography gutterBottom>
+        Use the <b>GO TO AUTHORIZE PAGE button</b> to start the authorization process.
       </Typography>
       <Typography gutterBottom>
         <b>Note:</b> If you have done this before, it is likely that your integration was removed in Canvas.
@@ -28,9 +30,9 @@ export default function AuthorizePrompt (): JSX.Element {
         color='primary'
         variant='contained'
         href='/canvas/redirectOAuth'
-        aria-label='Authorize Canvas integration'
+        aria-label='Go to authorize page'
       >
-        Go to Canvas
+        GO TO AUTHORIZE PAGE
       </Button>
     </div>
   )

--- a/ccm_web/client/src/components/Breadcrumbs.tsx
+++ b/ccm_web/client/src/components/Breadcrumbs.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { Link as RouterLink } from 'react-router-dom'
+import { Breadcrumbs as MuiBreadcrumbs, Link, makeStyles, Typography } from '@material-ui/core'
+import NavigateNextIcon from '@material-ui/icons/NavigateNext'
+
+import { FeatureUIProps } from '../models/FeatureUIData'
+
+const useStyles = makeStyles(() => ({
+  breadcrumbs: {
+    fontSize: '1.125rem'
+  },
+  breadcrumbContainer: {
+    paddingLeft: 25,
+    paddingTop: 25
+  }
+}))
+
+interface HomeBreadcrumbProps {
+  isLink: boolean
+  className: string
+}
+
+interface TitleTypographyProps {
+  to?: string
+}
+
+const HomeBreadcrumb = (props: HomeBreadcrumbProps): JSX.Element => {
+  const typography = (
+    <Typography className={props.className} color='textPrimary'>
+      Canvas Course Manager
+    </Typography>
+  )
+  return props.isLink
+    ? (<Link component={RouterLink} to='/'>{typography}</Link>)
+    : (typography)
+}
+
+interface BreadcrumbsProps {
+  pathnames?: string[]
+  features?: FeatureUIProps[]
+}
+
+function Breadcrumbs (props: BreadcrumbsProps): JSX.Element {
+  const classes = useStyles()
+  const { features, pathnames } = props
+  return (
+    <MuiBreadcrumbs
+      className={classes.breadcrumbContainer}
+      aria-label='breadcrumb'
+      separator={<NavigateNextIcon fontSize='small' />}
+    >
+      <HomeBreadcrumb isLink={pathnames !== undefined && pathnames.length > 0} className={classes.breadcrumbs} />
+        {
+          (pathnames !== undefined && features !== undefined) && (
+            pathnames.map((value, index) => {
+              const last = index === pathnames.length - 1
+              const to = `/${pathnames.slice(0, index + 1).join('/')}`
+              const feature = features.filter(f => { return f.route.substring(1) === value })[0]
+              const titleTypographyProps: TitleTypographyProps = last ? { to: to } : {}
+              return (
+                <Typography className={classes.breadcrumbs} color='textPrimary' key={to} {...titleTypographyProps}>
+                  {feature.data.title}
+                </Typography>
+              )
+            })
+          )
+        }
+    </MuiBreadcrumbs>
+  )
+}
+
+export default Breadcrumbs

--- a/ccm_web/client/src/utils/redirect.ts
+++ b/ccm_web/client/src/utils/redirect.ts
@@ -1,4 +1,4 @@
-type RedirectRoute = '/' | '/canvas/redirectOAuth'
+type RedirectRoute = '/'
 
 export default function redirect (route: RedirectRoute): void {
   location.href = route


### PR DESCRIPTION
This PR changes the OAuth redirect logic so that it shows the user an intermediary prompt with information about the missing integration and a button that when clicked takes them to the Canvas authorize page. The changes include an extraction of the `Breadcrumbs` implementation so that it could be more easily reused (as in the `AuthorizePrompt` block), styling specific to that component would be isolated, and the `App.tsx` component would be streamlined. Language used has been requested and cleared by Janel, but may be adjusted at a later date. The PR aims to resolve #189.