### PR TITLE
Merge sections

### DIFF
--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -117,7 +117,7 @@ function App (): JSX.Element {
               <div className={classes.swaggerLink}>
                 <Link href={`/swagger?csrfToken=${String(getCSRFToken())}`}>Swagger UI</Link>
               </div>
-              <div style={{ position: 'fixed', right: '25px', top: '25px' }}>
+              <div style={{ position: 'fixed', right: '25px', top: '25px', zIndex: 999 }}>
                 <ResponsiveHelper/>
               </div>
             </div>

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -11,6 +11,7 @@ import { CanvasCourseBase } from './models/canvas'
 import allFeatures from './models/FeatureUIData'
 import Home from './pages/Home'
 import './App.css'
+import ResponsiveHelper from './components/ResponsiveHelper'
 
 const useStyles = makeStyles((theme) => ({
   breadcrumbs: {
@@ -112,8 +113,13 @@ function App (): JSX.Element {
         {
           globals?.environment === 'development' &&
           (
-            <div className={classes.swaggerLink}>
-              <Link href={`/swagger?csrfToken=${String(getCSRFToken())}`}>Swagger UI</Link>
+            <div>
+              <div className={classes.swaggerLink}>
+                <Link href={`/swagger?csrfToken=${String(getCSRFToken())}`}>Swagger UI</Link>
+              </div>
+              <div style={{ position: 'fixed', right: '25px', top: '25px' }}>
+                <ResponsiveHelper/>
+              </div>
             </div>
           )
         }

--- a/ccm_web/client/src/api.ts
+++ b/ccm_web/client/src/api.ts
@@ -83,6 +83,13 @@ export const getMergedSections = async (courseId: number): Promise<CanvasCourseS
   return await resp.json()
 }
 
+export const getTeacherSections = async (courseId: number): Promise<CanvasCourseSection[]> => {
+  const request = getGet()
+  const resp = await fetch(`/api/course/${courseId.toString()}/sections/instructed`, request)
+  await handleErrors(resp)
+  return await resp.json()
+}
+
 export const searchSections = async (courseId: number, searchType: 'uniqname' | 'coursename', searchText: string): Promise<CanvasCourseSection[]> => {
   const request = getGet()
   const resp = await fetch(`/api/course/${courseId.toString()}/sections/search?${searchType}=${searchText}`, request)

--- a/ccm_web/client/src/api.ts
+++ b/ccm_web/client/src/api.ts
@@ -75,3 +75,17 @@ export const setCSRFTokenCookie = async (): Promise<void> => {
   const resp = await fetch('/auth/csrfToken', request)
   await handleErrors(resp)
 }
+
+export const getMergedSections = async (courseId: number): Promise<CanvasCourseSection[]> => {
+  const request = getGet()
+  const resp = await fetch('/api/course/' + courseId.toString() + '/sections/merged', request)
+  await handleErrors(resp)
+  return await resp.json()
+}
+
+export const searchSections = async (courseId: number, searchType: 'uniqname' | 'coursename', searchText: string): Promise<CanvasCourseSection[]> => {
+  const request = getGet()
+  const resp = await fetch(`/api/course/${courseId.toString()}/sections/search?${searchType}=${searchText}`, request)
+  await handleErrors(resp)
+  return await resp.json()
+}

--- a/ccm_web/client/src/components/BulkSectionCreateValidators.ts
+++ b/ccm_web/client/src/components/BulkSectionCreateValidators.ts
@@ -81,7 +81,6 @@ class SectionNameTooLongValidator implements SectionRowsValidator {
   validate = (sectionNames: string[]): SectionsRowInvalidation[] => {
     const invalidations: SectionsRowInvalidation[] = []
     sectionNames.forEach((sectionName, row) => {
-      console.log('Line length: ' + sectionName.trim().length.toString())
       if (sectionName.trim().length > 255) {
         invalidations.push({ message: 'Section name must be 255 characters or less', rowNumber: row + 2, type: InvalidationType.Error })
       }

--- a/ccm_web/client/src/components/ResponsiveHelper.tsx
+++ b/ccm_web/client/src/components/ResponsiveHelper.tsx
@@ -1,0 +1,17 @@
+import { useMediaQuery, useTheme } from '@material-ui/core'
+import React from 'react'
+
+function ResponsiveHelper (): JSX.Element {
+  const theme = useTheme()
+  const sm = useMediaQuery(theme.breakpoints.up('sm'))
+  const md = useMediaQuery(theme.breakpoints.up('md'))
+  const lg = useMediaQuery(theme.breakpoints.up('lg'))
+
+  return (
+    <div>
+      <p>Size {lg ? 'lg' : md ? 'md' : sm ? 'sm' : 'xs'}</p>
+    </div>
+  )
+}
+
+export default ResponsiveHelper

--- a/ccm_web/client/src/components/ResponsiveHelper.tsx
+++ b/ccm_web/client/src/components/ResponsiveHelper.tsx
@@ -8,8 +8,8 @@ function ResponsiveHelper (): JSX.Element {
   const lg = useMediaQuery(theme.breakpoints.up('lg'))
 
   return (
-    <div>
-      <p>Size {lg ? 'lg' : md ? 'md' : sm ? 'sm' : 'xs'}</p>
+    <div style={{ backgroundColor: 'rgba(255, 203, 5, 0.2)' }}>
+      <p>{lg ? 'lg' : md ? 'md' : sm ? 'sm' : 'xs'}</p>
     </div>
   )
 }

--- a/ccm_web/client/src/components/SectionSearchBar.tsx
+++ b/ccm_web/client/src/components/SectionSearchBar.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+function SectionSearchBar (): JSX.Element {
+  return (
+    <div>Search</div>
+  )
+}
+
+export default SectionSearchBar

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -151,7 +151,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   // Passing in the height in the props seems like the wrong solution, but wanted to move on from solving that for now
   return (
     <>
-      <span aria-live='polite' className={classes.srOnly}>{props.selectedSections.length} selected</span>
+      <span aria-live='polite' aria-atomic='true' className={classes.srOnly}>{props.selectedSections.length} section{props.selectedSections.length === 1 ? '' : 's' } selected</span>
       <Grid container>
         <Grid item container className={classes.searchContainer} style={props.search === 'None' ? { display: 'none' } : props.search === 'Hidden' ? { visibility: 'hidden' } : {}} xs={12}>
           <TextField className={classes.searchTextField} onChange={searchChange} value={sectionFilterText} id='textField_Search' size='small' label='Search Sections' variant='outlined' InputProps={{ endAdornment: getSearchTextFieldEndAdornment(sectionFilterText.length > 0) }}/>

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControlLabel, FormGroup, Grid, List, ListItem, ListItemText, makeStyles, TextField, Typography } from '@material-ui/core'
+import { Button, Checkbox, FormControlLabel, FormGroup, Grid, List, ListItem, ListItemText, makeStyles, TextField, Typography } from '@material-ui/core'
 import ClearIcon from '@material-ui/icons/Clear'
 import React, { useEffect, useState } from 'react'
 import { CanvasCourseSection } from '../models/canvas'
@@ -33,6 +33,10 @@ const useStyles = makeStyles((theme) => ({
   },
   inline: {
     display: 'inline'
+  },
+  checkBoxContainer: {
+    float: 'right',
+    textAlign: 'center'
   }
 }))
 
@@ -49,6 +53,7 @@ interface ISectionSelectorWidgetProps {
   search: 'None' | 'Hidden' | true
   title?: string
   showCourseName?: boolean
+  action?: {text: string, cb: () => void, disabled: boolean}
 }
 
 function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element {
@@ -73,7 +78,6 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   }
 
   useEffect(() => {
-    console.debug(`SectionSelectorWidget ${props.title ?? ''} selectedSections changed`)
     setIsSelectAllChecked(selectableSections().length > 0 && props.selectedSections.length === selectableSections().length)
   }, [props.selectedSections])
 
@@ -148,6 +152,20 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     }
   }
 
+  const actionButton = (): JSX.Element => {
+    if (props.action === undefined) {
+      return (<></>)
+    } else {
+      return (
+      <Grid item xs={12} sm={3}>
+        <Button style={{ float: 'right' }} variant="contained" color="primary" onClick={props.action.cb} disabled={props.action.disabled}>
+          {props.action?.text}
+        </Button>
+      </Grid>
+      )
+    }
+  }
+
   // Passing in the height in the props seems like the wrong solution, but wanted to move on from solving that for now
   return (
     <>
@@ -157,15 +175,15 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
           <TextField className={classes.searchTextField} onChange={searchChange} value={sectionFilterText} id='textField_Search' size='small' label='Search Sections' variant='outlined' InputProps={{ endAdornment: getSearchTextFieldEndAdornment(sectionFilterText.length > 0) }}/>
         </Grid>
         <Grid item container>
-          <Grid item xs={12} sm={8} className={classes.title}>
+          <Grid item xs={8} sm={6} className={classes.title}>
             <Typography style={{ visibility: props.title !== undefined ? 'visible' : 'hidden' }}>{props.title}
               <span hidden={props.selectedSections.length === 0}>
                 ({props.selectedSections.length})
               </span>
             </Typography>
           </Grid>
-          <Grid item xs={12} sm={4}>
-            <FormGroup row style={{ visibility: props.multiSelect ? 'visible' : 'hidden' }}>
+          <Grid item xs={4} sm={3}>
+            <FormGroup row style={{ visibility: props.multiSelect ? 'visible' : 'hidden' }} className={classes.checkBoxContainer}>
               <FormControlLabel
               control={
                   <Checkbox
@@ -180,6 +198,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
               />
             </FormGroup>
           </Grid>
+          {actionButton()}
         </Grid>
         <Grid item xs={12}>
           <List className={classes.listContainer} style={{ maxHeight: props.height }}>

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -1,4 +1,4 @@
-import { Grid, List, ListItem, ListItemText, makeStyles, TextField } from '@material-ui/core'
+import { Checkbox, FormControlLabel, FormGroup, Grid, List, ListItem, ListItemText, makeStyles, TextField, Typography } from '@material-ui/core'
 import ClearIcon from '@material-ui/icons/Clear'
 import React, { useEffect, useState } from 'react'
 import { CanvasCourseSection } from '../models/canvas'
@@ -13,6 +13,13 @@ const useStyles = makeStyles((theme) => ({
   },
   searchTextField: {
     width: '100%'
+  },
+  title: {
+    textAlign: 'left',
+    display: 'flex',
+    justifyContent: 'center',
+    alignContent: 'center',
+    flexDirection: 'column'
   }
 }))
 
@@ -23,6 +30,7 @@ interface ISectionSelectorWidgetProps {
   multiSelect: boolean
   selectionUpdated: (section: CanvasCourseSection[]) => void
   search: 'None' | 'Hidden' | true
+  title?: string
 }
 
 function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element {
@@ -31,6 +39,8 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   const [sectionFilterText, setSectionFilterText] = useState<string>('')
   const [filteredSections, setFilteredSections] = useState<CanvasCourseSection[]>(props.sections)
 
+  const [isSelectAllChecked, setIsSelectAllChecked] = useState<boolean>(false)
+
   useEffect(() => {
     if (sectionFilterText.length === 0) {
       setFilteredSections(props.sections)
@@ -38,6 +48,10 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
       setFilteredSections(props.sections.filter(p => { return p.name.toUpperCase().includes(sectionFilterText.toUpperCase()) }))
     }
   }, [sectionFilterText, props.sections])
+
+  useEffect(() => {
+    setIsSelectAllChecked(props.sections.length > 0 && props.selectedSections.length === props.sections.length)
+  }, [props.selectedSections])
 
   const handleListItemClick = (
     sectionId: number
@@ -53,6 +67,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
         newSelections = [filteredSections.filter(s => { return s.id === sectionId })[0]]
       }
     }
+
     props.selectionUpdated(newSelections)
   }
 
@@ -75,12 +90,36 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
       return (<ClearIcon onClick={clearSearch}/>)
     }
   }
+
+  const handleSelectAllClicked = (): void => {
+    setIsSelectAllChecked(!isSelectAllChecked)
+    props.selectionUpdated(!isSelectAllChecked ? props.sections : [])
+  }
+
   // Passing in the height in the props seems like the wrong solution, but wanted to move on from solving that for now
   return (
     <>
       <Grid container>
         <Grid item container className={classes.searchContainer} style={props.search === 'None' ? { display: 'none' } : props.search === 'Hidden' ? { visibility: 'hidden' } : {}} xs={12}>
           <TextField className={classes.searchTextField} onChange={searchChange} value={sectionFilterText} id='textField_Search' size='small' label='Search Sections' variant='outlined' InputProps={{ endAdornment: getSearchTextFieldEndAdornment(sectionFilterText.length > 0) }}/>
+        </Grid>
+        <Grid item container>
+          <Grid item xs={12} sm={8} className={classes.title}><Typography style={{ visibility: props.title !== undefined ? 'visible' : 'hidden' }}>{props.title}</Typography></Grid>
+          <Grid item xs={12} sm={4}>
+            <FormGroup row style={{ visibility: props.multiSelect ? 'visible' : 'hidden' }}>
+              <FormControlLabel
+              control={
+                  <Checkbox
+                    checked={isSelectAllChecked}
+                    onChange={handleSelectAllClicked}
+                    name="selectAllUnstagedCB"
+                    color="primary"
+                  />
+                }
+                label="Select All"
+              />
+            </FormGroup>
+          </Grid>
         </Grid>
         <Grid item xs={12}>
           <List className={classes.listContainer} style={{ maxHeight: props.height }}>

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -175,11 +175,11 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   }, [searchFieldTextDebounced])
 
   const clearSearch = (): void => {
+    props.selectionUpdated([])
     setSearchFieldText('')
     setSectionSearcherText(undefined)
   }
 
-  // TODO Debounce
   const handleChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
     const sort = event.target.value as string
     setSearcher((props.search).filter(searcher => { return searcher.name === sort })[0])
@@ -188,6 +188,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
 
   const [search, isSearching, searchError] = usePromise(async () => {
     if (searcher !== undefined) {
+      props.selectionUpdated([])
       if (sectionSearcherText !== undefined) {
         console.log('search hook search')
         void searcher.search(sectionSearcherText)

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -1,24 +1,9 @@
-import { Button, Checkbox, FormControlLabel, FormGroup, Grid, List, ListItem, ListItemText, makeStyles, Menu, MenuItem, TextField, Typography } from '@material-ui/core'
+import { Button, Checkbox, FormControlLabel, FormGroup, Grid, GridSize, List, ListItem, ListItemText, makeStyles, Menu, MenuItem, TextField, Typography, useMediaQuery, useTheme } from '@material-ui/core'
 // import { ClearIcon, SortIcon } from '@material-ui/icons'
 import ClearIcon from '@material-ui/icons/Clear'
 import SortIcon from '@material-ui/icons/Sort'
 import React, { useEffect, useState } from 'react'
 import { CanvasCourseSection, ICanvasCourseSectionSort } from '../models/canvas'
-
-/*
- Use Cases
-  Add UM Users
-    No header items
-  Merge
-    Instructor View
-      Title, Select All, Sort
-    Sub Account Admin
-      Search ( Course Name, Uniqname )
-      Title, Select All, Sort
-    Service Center
-      Search ( Course Name )
-      Title, Select All, Sort
-*/
 
 const useStyles = makeStyles((theme) => ({
   listContainer: {
@@ -55,11 +40,11 @@ const useStyles = makeStyles((theme) => ({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis'
-  },
-  checkBoxContainer: {
-    float: 'right',
-    textAlign: 'center'
-  }
+  }//,
+  // checkBoxContainer: {
+  //   float: 'right'
+  //   // textAlign: 'center'
+  // }
 }))
 
 export interface SelectableCanvasCourseSection extends CanvasCourseSection {
@@ -73,7 +58,6 @@ interface ISectionSelectorWidgetProps {
   multiSelect: boolean
   selectionUpdated: (section: SelectableCanvasCourseSection[]) => void
   search: 'None' | 'Hidden' | true
-  // title?: string
   showCourseName?: boolean
   action?: {text: string, cb: () => void, disabled: boolean}
   header?: {
@@ -185,7 +169,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
       return (<></>)
     } else {
       return (
-      <Grid item xs={12} sm={3}>
+      <Grid item xs={getColumns('action', 'xs')} sm={getColumns('action', 'sm')} md={getColumns('action', 'md')}>
         <Button style={{ float: 'right' }} variant="contained" color="primary" onClick={props.action.cb} disabled={props.action.disabled}>
           {props.action?.text}
         </Button>
@@ -209,11 +193,66 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     setAnchorSortEl(null)
   }
 
+  /*
+ Use Cases
+  Add UM Users
+    No header items
+  Merge
+    Instructor View
+      Title, Select All, Sort
+    Sub Account Admin
+      Search ( Course Name, Uniqname )
+      Title, Select All, Sort
+    Service Center
+      Search ( Course Name )
+      Title, Select All, Sort
+*/
+
+  const getColumns = (item: 'title'|'select all'|'sort'|'action', size: 'xs'|'sm'|'md'): GridSize => {
+    const hasSort = props.header?.sort !== undefined
+    switch (item) {
+      case 'title':
+        if (size === 'xs') {
+          return 12
+        } else if (size === 'sm') {
+          return 8
+        } else {
+          return hasSort ? 4 : 6
+        }
+      case 'select all':
+        if (size === 'xs') {
+          return 4
+        } else if (size === 'sm') {
+          return 4
+        } else {
+          return 3
+        }
+      case 'sort':
+        if (size === 'xs') {
+          return 4
+        } else if (size === 'sm') {
+          return 6
+        } else {
+          return 2
+        }
+      case 'action':
+        if (size === 'xs') {
+          return 4
+        } else if (size === 'sm') {
+          return hasSort ? 6 : 12
+        } else {
+          return 3
+        }
+      default:
+        return 12
+    }
+  }
+
   const sortButton = (): JSX.Element => {
-    if ((props.header != null) && props.header.sort?.sorters.length > 0) {
+    if (props.header?.sort !== undefined && props.header.sort?.sorters.length > 0) {
       return (
-        <Grid item xs={12} sm={3}>
-        <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleSortMenuClick} disabled={filteredSections.length < 2}>
+        <Grid item xs={getColumns('sort', 'xs')} sm={getColumns('sort', 'sm')} md={getColumns('sort', 'md')}>
+        <Button style={{ float: 'left' }} aria-controls="simple-menu" aria-haspopup="true" onClick={handleSortMenuClick} disabled={filteredSections.length < 2}>
           <SortIcon/>Sort
         </Button>
         <Menu
@@ -233,6 +272,15 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
       return (<></>)
     }
   }
+
+  const checkboxStyle = (): Record<string, unknown> => {
+    const theme = useTheme()
+    const xs = useMediaQuery(theme.breakpoints.up('xs'))
+    return {
+      visibility: props.multiSelect ? 'visible' : 'hidden',
+      float: xs ? 'left' : 'right'
+    }
+  }
   // Passing in the height in the props seems like the wrong solution, but wanted to move on from solving that for now
   return (
     <>
@@ -241,16 +289,16 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
         <Grid item container className={classes.searchContainer} style={props.search === 'None' ? { display: 'none' } : props.search === 'Hidden' ? { visibility: 'hidden' } : {}} xs={12}>
           <TextField className={classes.searchTextField} onChange={searchChange} value={sectionFilterText} id='textField_Search' size='small' label='Search Sections' variant='outlined' InputProps={{ endAdornment: getSearchTextFieldEndAdornment(sectionFilterText.length > 0) }}/>
         </Grid>
-        <Grid item container>
-          <Grid item xs={8} sm={6} className={classes.title}>
+        <Grid item container style={{ paddingLeft: '16px' }}>
+          <Grid item xs={getColumns('title', 'xs')} sm={getColumns('title', 'sm')} md={getColumns('title', 'md')} className={classes.title}>
             <Typography style={{ visibility: props.header?.title !== undefined ? 'visible' : 'hidden' }}>{props.header?.title}
               <span hidden={props.selectedSections.length === 0}>
                 ({props.selectedSections.length})
               </span>
             </Typography>
           </Grid>
-          <Grid item xs={4} sm={3}>
-            <FormGroup row style={{ visibility: props.multiSelect ? 'visible' : 'hidden' }} className={classes.checkBoxContainer}>
+          <Grid item xs={getColumns('select all', 'xs')} sm={getColumns('select all', 'sm')} md={getColumns('select all', 'md')}>
+            <FormGroup row style={checkboxStyle()}>
               <FormControlLabel
               control={
                   <Checkbox

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -20,11 +20,21 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'center',
     alignContent: 'center',
     flexDirection: 'column'
+  },
+  srOnly: {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: '0',
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0,0,0,0)',
+    border: '0'
   }
 }))
 
 export interface SelectableCanvasCourseSection extends CanvasCourseSection {
-  locked: boolean
+  locked?: boolean
 }
 
 interface ISectionSelectorWidgetProps {
@@ -54,7 +64,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   }, [sectionFilterText, props.sections])
 
   const selectableSections = (): SelectableCanvasCourseSection[] => {
-    const s = props.sections.filter(s => { return !s.locked })
+    const s = props.sections.filter(s => { return !(s.locked ?? false) })
     return s
   }
 
@@ -103,18 +113,25 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
 
   const handleSelectAllClicked = (): void => {
     setIsSelectAllChecked(!isSelectAllChecked)
-    props.selectionUpdated(!isSelectAllChecked ? props.sections.filter(s => { return !s.locked }) : [])
+    props.selectionUpdated(!isSelectAllChecked ? props.sections.filter(s => { return !(s.locked ?? false) }) : [])
   }
 
   // Passing in the height in the props seems like the wrong solution, but wanted to move on from solving that for now
   return (
     <>
+      <span aria-live='polite' className={classes.srOnly}>{props.selectedSections.length} selected</span>
       <Grid container>
         <Grid item container className={classes.searchContainer} style={props.search === 'None' ? { display: 'none' } : props.search === 'Hidden' ? { visibility: 'hidden' } : {}} xs={12}>
           <TextField className={classes.searchTextField} onChange={searchChange} value={sectionFilterText} id='textField_Search' size='small' label='Search Sections' variant='outlined' InputProps={{ endAdornment: getSearchTextFieldEndAdornment(sectionFilterText.length > 0) }}/>
         </Grid>
         <Grid item container>
-          <Grid item xs={12} sm={8} className={classes.title}><Typography style={{ visibility: props.title !== undefined ? 'visible' : 'hidden' }}>{props.title}</Typography></Grid>
+          <Grid item xs={12} sm={8} className={classes.title}>
+            <Typography style={{ visibility: props.title !== undefined ? 'visible' : 'hidden' }}>{props.title}
+              <span hidden={props.selectedSections.length === 0}>
+                ({props.selectedSections.length})
+              </span>
+            </Typography>
+          </Grid>
           <Grid item xs={12} sm={4}>
             <FormGroup row style={{ visibility: props.multiSelect ? 'visible' : 'hidden' }}>
               <FormControlLabel

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -105,6 +105,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
 
   useEffect(() => {
     setInternalSections(props.sections)
+    setIsSelectAllChecked(selectableSections().length > 0 && props.selectedSections.length === selectableSections().length)
   }, [props.sections])
 
   useEffect(() => {

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -23,9 +23,13 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
+export interface SelectableCanvasCourseSection extends CanvasCourseSection {
+  locked: boolean
+}
+
 interface ISectionSelectorWidgetProps {
-  sections: CanvasCourseSection[]
-  selectedSections: CanvasCourseSection[]
+  sections: SelectableCanvasCourseSection[]
+  selectedSections: SelectableCanvasCourseSection[]
   height: number
   multiSelect: boolean
   selectionUpdated: (section: CanvasCourseSection[]) => void
@@ -37,7 +41,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   const classes = useStyles()
 
   const [sectionFilterText, setSectionFilterText] = useState<string>('')
-  const [filteredSections, setFilteredSections] = useState<CanvasCourseSection[]>(props.sections)
+  const [filteredSections, setFilteredSections] = useState<SelectableCanvasCourseSection[]>(props.sections)
 
   const [isSelectAllChecked, setIsSelectAllChecked] = useState<boolean>(false)
 
@@ -50,7 +54,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   }, [sectionFilterText, props.sections])
 
   useEffect(() => {
-    setIsSelectAllChecked(props.sections.length > 0 && props.selectedSections.length === props.sections.length)
+    setIsSelectAllChecked(props.sections.length > 0 && props.selectedSections.length === props.sections.filter(s => { return !s.locked }).length)
   }, [props.selectedSections])
 
   const handleListItemClick = (
@@ -93,7 +97,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
 
   const handleSelectAllClicked = (): void => {
     setIsSelectAllChecked(!isSelectAllChecked)
-    props.selectionUpdated(!isSelectAllChecked ? props.sections : [])
+    props.selectionUpdated(!isSelectAllChecked ? props.sections.filter(s => { return !s.locked }) : [])
   }
 
   // Passing in the height in the props seems like the wrong solution, but wanted to move on from solving that for now
@@ -124,7 +128,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
         <Grid item xs={12}>
           <List className={classes.listContainer} style={{ maxHeight: props.height }}>
             {filteredSections.map((section, index) => {
-              return (<ListItem divider key={section.id} button selected={isSectionSelected(section.id)} onClick={(event) => handleListItemClick(section.id)}>
+              return (<ListItem divider key={section.id} button disabled={section.locked} selected={isSectionSelected(section.id)} onClick={(event) => handleListItemClick(section.id)}>
                 <ListItemText primary={section.name} secondary={`${section.total_students ?? '?'} students`}></ListItemText>
               </ListItem>)
             })}

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -75,7 +75,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   const classes = useStyles()
 
   const [sectionSearchText, setSectionSearchText] = useState<string>('')
-  const [sectionSearchTextDebounced, setSetctionSearchTextDebounced] = useDebounce<string>(sectionSearchText, 500)
+  const [sectionSearchTextDebounced, setSetctionSearchTextDebounced] = useDebounce<string | undefined>(undefined, 500)
   const [filteredSections, setFilteredSections] = useState<SelectableCanvasCourseSection[]>(props.sections)
 
   const [isSelectAllChecked, setIsSelectAllChecked] = useState<boolean>(false)
@@ -133,9 +133,23 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     setSetctionSearchTextDebounced(event.target.value)
   }
 
+  const useFirstRender = (): boolean => {
+    const firstRender = React.useRef(true)
+    useEffect(() => {
+      firstRender.current = false
+    }, [])
+    return firstRender.current
+  }
+
+  const firstRender = useFirstRender()
+
   useEffect(() => {
-    console.log(`Search time ${sectionSearchTextDebounced}`)
-    void search()
+    if (!firstRender) {
+      console.log(`Search because search text ${String(props.header?.title)} '${String(sectionSearchTextDebounced)}'`)
+      void search()
+    } else {
+      console.log('Search skipped on first render')
+    }
   }, [sectionSearchTextDebounced])
 
   const clearSearch = (): void => {
@@ -179,8 +193,10 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   const getSearchTextFieldEndAdornment = (hasText: boolean): JSX.Element => {
     if (!hasText && props.search.length > 1) {
       return (getSearchTypeAdornment())
-    } else {
+    } else if (sectionSearchText.length > 0) {
       return (<ClearIcon onClick={clearSearch}/>)
+    } else {
+      return (<></>)
     }
   }
 
@@ -342,7 +358,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
       <Grid container>
         <Grid className={classes.header} container item xs={12}>
           <Grid item container className={classes.searchContainer} style={props.search.length === 0 ? { display: 'none' } : {}} xs={12}>
-            <TextField className={classes.searchTextField} onChange={searchChange} value={sectionSearchText} id='textField_Search' size='small' label={searchTextFieldLabel} variant='outlined' InputProps={{ endAdornment: getSearchTextFieldEndAdornment(sectionSearchText.length > 0) }}/>
+            <TextField className={classes.searchTextField} disabled={isSearching} onChange={searchChange} value={sectionSearchText} id='textField_Search' size='small' label={searchTextFieldLabel} variant='outlined' InputProps={{ endAdornment: getSearchTextFieldEndAdornment(sectionSearchText.length > 0) }}/>
           </Grid>
           <Grid item container style={{ paddingLeft: '16px' }}>
             <Grid item xs={getColumns('title', 'xs')} sm={getColumns('title', 'sm')} md={getColumns('title', 'md')} className={classes.title}>

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -40,11 +40,10 @@ const useStyles = makeStyles((theme) => ({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis'
-  }//,
-  // checkBoxContainer: {
-  //   float: 'right'
-  //   // textAlign: 'center'
-  // }
+  },
+  header: {
+    backgroundColor: '#F8F8F8'
+  }
 }))
 
 export interface SelectableCanvasCourseSection extends CanvasCourseSection {
@@ -286,46 +285,48 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     <>
       <span aria-live='polite' aria-atomic='true' className={classes.srOnly}>{props.selectedSections.length} section{props.selectedSections.length === 1 ? '' : 's' } selected</span>
       <Grid container>
-        <Grid item container className={classes.searchContainer} style={props.search === 'None' ? { display: 'none' } : props.search === 'Hidden' ? { visibility: 'hidden' } : {}} xs={12}>
-          <TextField className={classes.searchTextField} onChange={searchChange} value={sectionFilterText} id='textField_Search' size='small' label='Search Sections' variant='outlined' InputProps={{ endAdornment: getSearchTextFieldEndAdornment(sectionFilterText.length > 0) }}/>
-        </Grid>
-        <Grid item container style={{ paddingLeft: '16px' }}>
-          <Grid item xs={getColumns('title', 'xs')} sm={getColumns('title', 'sm')} md={getColumns('title', 'md')} className={classes.title}>
-            <Typography style={{ visibility: props.header?.title !== undefined ? 'visible' : 'hidden' }}>{props.header?.title}
-              <span hidden={props.selectedSections.length === 0}>
-                ({props.selectedSections.length})
-              </span>
-            </Typography>
+        <Grid className={classes.header} container item xs={12}>
+          <Grid item container className={classes.searchContainer} style={props.search === 'None' ? { display: 'none' } : props.search === 'Hidden' ? { visibility: 'hidden' } : {}} xs={12}>
+            <TextField className={classes.searchTextField} onChange={searchChange} value={sectionFilterText} id='textField_Search' size='small' label='Search Sections' variant='outlined' InputProps={{ endAdornment: getSearchTextFieldEndAdornment(sectionFilterText.length > 0) }}/>
           </Grid>
-          <Grid item xs={getColumns('select all', 'xs')} sm={getColumns('select all', 'sm')} md={getColumns('select all', 'md')}>
-            <FormGroup row style={checkboxStyle()}>
-              <FormControlLabel
-              control={
-                  <Checkbox
-                    checked={isSelectAllChecked}
-                    onChange={handleSelectAllClicked}
-                    name="selectAllUnstagedCB"
-                    color="primary"
-                  />
-                }
-                disabled={selectableSections().length === 0}
-                label="Select All"
-              />
-            </FormGroup>
+          <Grid item container style={{ paddingLeft: '16px' }}>
+            <Grid item xs={getColumns('title', 'xs')} sm={getColumns('title', 'sm')} md={getColumns('title', 'md')} className={classes.title}>
+              <Typography variant='h6' style={{ visibility: props.header?.title !== undefined ? 'visible' : 'hidden' }}>{props.header?.title}
+                <span hidden={props.selectedSections.length === 0}>
+                  ({props.selectedSections.length})
+                </span>
+              </Typography>
+            </Grid>
+            <Grid item xs={getColumns('select all', 'xs')} sm={getColumns('select all', 'sm')} md={getColumns('select all', 'md')}>
+              <FormGroup row style={checkboxStyle()}>
+                <FormControlLabel
+                control={
+                    <Checkbox
+                      checked={isSelectAllChecked}
+                      onChange={handleSelectAllClicked}
+                      name="selectAllUnstagedCB"
+                      color="primary"
+                    />
+                  }
+                  disabled={selectableSections().length === 0}
+                  label="Select All"
+                />
+              </FormGroup>
+            </Grid>
+            {sortButton()}
+            {actionButton()}
           </Grid>
-          {sortButton()}
-          {actionButton()}
         </Grid>
-        <Grid item xs={12}>
-          <List className={classes.listContainer} style={{ maxHeight: props.height }}>
-            {filteredSections.map((section, index) => {
-              return (<ListItem divider key={section.id} button disabled={section.locked} selected={isSectionSelected(section.id)} onClick={(event) => handleListItemClick(section.id)}>
-                {listItemText(section)}
-              </ListItem>)
-            })}
-          </List>
-        </Grid>
+      <Grid item xs={12}>
+        <List className={classes.listContainer} style={{ maxHeight: props.height }}>
+          {filteredSections.map((section, index) => {
+            return (<ListItem divider key={section.id} button disabled={section.locked} selected={isSectionSelected(section.id)} onClick={(event) => handleListItemClick(section.id)}>
+              {listItemText(section)}
+            </ListItem>)
+          })}
+        </List>
       </Grid>
+    </Grid>
     </>
   )
 }

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -31,8 +31,13 @@ const useStyles = makeStyles((theme) => ({
     clip: 'rect(0,0,0,0)',
     border: '0'
   },
-  inline: {
+  secondaryTypography: {
     display: 'inline'
+  },
+  overflowEllipsis: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis'
   },
   checkBoxContainer: {
     float: 'right',
@@ -133,10 +138,10 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
               <Typography
                 component="span"
                 variant="body2"
-                className={classes.inline}
+                className={classes.secondaryTypography}
                 color="textPrimary"
               >
-                {section.course_name}
+                <p className={classes.overflowEllipsis}>{section.course_name}</p>
               </Typography>
               <span style={{ float: 'right' }}>
                 {`${section.total_students ?? '?'} students`}

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -3,6 +3,8 @@ import { useDebounce } from '@react-hook/debounce'
 import ClearIcon from '@material-ui/icons/Clear'
 import SortIcon from '@material-ui/icons/Sort'
 import React, { useEffect, useState } from 'react'
+import { useSnackbar } from 'notistack'
+
 import { CanvasCourseSection, ICanvasCourseSectionSort } from '../models/canvas'
 import { ISectionSearcher } from '../pages/MergeSections'
 import usePromise from '../hooks/usePromise'
@@ -86,6 +88,7 @@ interface ISectionSelectorWidgetProps {
 
 function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element {
   const classes = useStyles()
+  const { enqueueSnackbar } = useSnackbar()
 
   // The the search text ultimately used when searching
   const [sectionSearcherText, setSectionSearcherText] = useState<string | undefined>(undefined)
@@ -186,14 +189,22 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     if (searcher !== undefined) {
       props.selectionUpdated([])
       if (sectionSearcherText !== undefined) {
-        void searcher.search(sectionSearcherText)
+        await searcher.search(sectionSearcherText)
       } else {
-        void searcher.init()
+        await searcher.init()
       }
     }
     return null
   }
   )
+
+  useEffect(() => {
+    if (searchError !== undefined) {
+      enqueueSnackbar('Error searching sections', {
+        variant: 'error'
+      })
+    }
+  }, [searchError])
 
   const getSearchTypeAdornment = (): JSX.Element => {
     return (

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -32,7 +32,7 @@ interface ISectionSelectorWidgetProps {
   selectedSections: SelectableCanvasCourseSection[]
   height: number
   multiSelect: boolean
-  selectionUpdated: (section: CanvasCourseSection[]) => void
+  selectionUpdated: (section: SelectableCanvasCourseSection[]) => void
   search: 'None' | 'Hidden' | true
   title?: string
 }
@@ -53,8 +53,14 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     }
   }, [sectionFilterText, props.sections])
 
+  const selectableSections = (): SelectableCanvasCourseSection[] => {
+    const s = props.sections.filter(s => { return !s.locked })
+    return s
+  }
+
   useEffect(() => {
-    setIsSelectAllChecked(props.sections.length > 0 && props.selectedSections.length === props.sections.filter(s => { return !s.locked }).length)
+    console.debug(`SectionSelectorWidget ${props.title ?? ''} selectedSections changed`)
+    setIsSelectAllChecked(selectableSections().length > 0 && props.selectedSections.length === selectableSections().length)
   }, [props.selectedSections])
 
   const handleListItemClick = (

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -30,6 +30,9 @@ const useStyles = makeStyles((theme) => ({
     overflow: 'hidden',
     clip: 'rect(0,0,0,0)',
     border: '0'
+  },
+  inline: {
+    display: 'inline'
   }
 }))
 
@@ -45,6 +48,7 @@ interface ISectionSelectorWidgetProps {
   selectionUpdated: (section: SelectableCanvasCourseSection[]) => void
   search: 'None' | 'Hidden' | true
   title?: string
+  showCourseName?: boolean
 }
 
 function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element {
@@ -116,6 +120,34 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     props.selectionUpdated(!isSelectAllChecked ? props.sections.filter(s => { return !(s.locked ?? false) }) : [])
   }
 
+  const listItemText = (section: SelectableCanvasCourseSection): JSX.Element => {
+    if (props.showCourseName ?? false) {
+      return (
+        <ListItemText primary={section.name}
+          secondary={
+            <React.Fragment>
+              <Typography
+                component="span"
+                variant="body2"
+                className={classes.inline}
+                color="textPrimary"
+              >
+                {section.course_name}
+              </Typography>
+              <span style={{ float: 'right' }}>
+                {`${section.total_students ?? '?'} students`}
+              </span>
+            </React.Fragment>
+        }>
+        </ListItemText>
+      )
+    } else {
+      return (
+        <ListItemText primary={section.name} secondary={`${section.total_students ?? '?'} students`}></ListItemText>
+      )
+    }
+  }
+
   // Passing in the height in the props seems like the wrong solution, but wanted to move on from solving that for now
   return (
     <>
@@ -153,7 +185,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
           <List className={classes.listContainer} style={{ maxHeight: props.height }}>
             {filteredSections.map((section, index) => {
               return (<ListItem divider key={section.id} button disabled={section.locked} selected={isSectionSelected(section.id)} onClick={(event) => handleListItemClick(section.id)}>
-                <ListItemText primary={section.name} secondary={`${section.total_students ?? '?'} students`}></ListItemText>
+                {listItemText(section)}
               </ListItem>)
             })}
           </List>

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, FormControlLabel, FormGroup, Grid, GridSize, List, ListItem, ListItemText, makeStyles, Menu, MenuItem, TextField, Typography, useMediaQuery, useTheme } from '@material-ui/core'
+import { Button, Checkbox, FormControl, FormControlLabel, FormGroup, Grid, GridSize, InputLabel, List, ListItem, ListItemText, makeStyles, Menu, MenuItem, Select, TextField, Typography, useMediaQuery, useTheme } from '@material-ui/core'
 // import { ClearIcon, SortIcon } from '@material-ui/icons'
 import ClearIcon from '@material-ui/icons/Clear'
 import SortIcon from '@material-ui/icons/Sort'
@@ -39,7 +39,8 @@ const useStyles = makeStyles((theme) => ({
   overflowEllipsis: {
     whiteSpace: 'nowrap',
     overflow: 'hidden',
-    textOverflow: 'ellipsis'
+    textOverflow: 'ellipsis',
+    display: 'block'
   },
   header: {
     backgroundColor: '#F8F8F8'
@@ -122,9 +123,31 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     setSectionFilterText('')
   }
 
+  const [age, setAge] = React.useState('')
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>): void => {
+    setAge(event.target.value as string)
+  }
+
+  const getSearchTypeAdornment = (): JSX.Element => {
+    return (
+    <FormControl>
+        <InputLabel id="demo-simple-select-label">Sort By</InputLabel>
+        <Select
+          labelId="demo-simple-select-label"
+          id="demo-simple-select"
+          value={age}
+          onChange={handleChange}
+        >
+          <MenuItem value={10}>Uniqname</MenuItem>
+          <MenuItem value={20}>Course Name</MenuItem>
+        </Select>
+      </FormControl>
+    )
+  }
+
   const getSearchTextFieldEndAdornment = (hasText: boolean): JSX.Element => {
     if (!hasText) {
-      return (<></>)
+      return (getSearchTypeAdornment())
     } else {
       return (<ClearIcon onClick={clearSearch}/>)
     }
@@ -147,7 +170,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
                 className={classes.secondaryTypography}
                 color="textPrimary"
               >
-                <p className={classes.overflowEllipsis}>{section.course_name}</p>
+                <span className={classes.overflowEllipsis}>{section.course_name}</span>
               </Typography>
               <span style={{ float: 'right' }}>
                 {`${section.total_students ?? '?'} students`}
@@ -200,10 +223,10 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     Instructor View
       Title, Select All, Sort
     Sub Account Admin
-      Search ( Course Name, Uniqname )
+      Search ( Course Name )
       Title, Select All, Sort
     Service Center
-      Search ( Course Name )
+      Search ( Course Name, Uniqname )
       Title, Select All, Sort
 */
 

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -74,6 +74,7 @@ interface ISectionSelectorWidgetProps {
 function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element {
   const classes = useStyles()
 
+  const [sectionSearcherText, setSectionSearcherText] = useState<string | undefined>(undefined)
   const [sectionSearchText, setSectionSearchText] = useState<string>('')
   const [sectionSearchTextDebounced, setSetctionSearchTextDebounced] = useDebounce<string | undefined>(undefined, 500)
   const [filteredSections, setFilteredSections] = useState<SelectableCanvasCourseSection[]>(props.sections)
@@ -86,7 +87,6 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   const [searchTextFieldLabel, setSearchTextFieldLabel] = React.useState<string | undefined>(props.search.length > 0 ? `Search By ${(props.search)[0].name}` : undefined)
 
   useEffect(() => {
-    console.log('props.sections updated')
     setFilteredSections(props.sections)
   }, [props.sections])
 
@@ -145,16 +145,24 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
 
   useEffect(() => {
     if (!firstRender) {
-      console.log(`Search because search text ${String(props.header?.title)} '${String(sectionSearchTextDebounced)}'`)
+      console.log(`Search because sectionSearcherText ${String(props.header?.title)} '${String(sectionSearcherText)}'`)
       void search()
     } else {
       console.log('Search skipped on first render')
+    }
+  }, [sectionSearcherText])
+
+  useEffect(() => {
+    if (!firstRender) {
+      setSectionSearcherText(sectionSearchTextDebounced)
+    } else {
+      console.log('sectionSearchTextDebounced update skipped on first render')
     }
   }, [sectionSearchTextDebounced])
 
   const clearSearch = (): void => {
     setSectionSearchText('')
-    void search()
+    setSectionSearcherText(undefined)
   }
 
   // TODO Debounce

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -126,6 +126,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
                     color="primary"
                   />
                 }
+                disabled={selectableSections().length === 0}
                 label="Select All"
               />
             </FormGroup>

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -58,7 +58,8 @@ const useStyles = makeStyles((theme) => ({
     textAlign: 'center',
     borderStyle: 'solid',
     borderWidth: '1px',
-    borderColor: '#EEEEEE'
+    borderColor: '#EEEEEE',
+    minHeight: '100px'
   },
   backdrop: {
     zIndex: theme.zIndex.drawer + 1,

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -22,6 +22,7 @@ interface ISectionSelectorWidgetProps {
   height: number
   multiSelect: boolean
   selectionUpdated: (section: CanvasCourseSection[]) => void
+  search: 'None' | 'Hidden' | true
 }
 
 function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element {
@@ -78,7 +79,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   return (
     <>
       <Grid container>
-        <Grid item container className={classes.searchContainer} xs={12}>
+        <Grid item container className={classes.searchContainer} style={props.search === 'None' ? { display: 'none' } : props.search === 'Hidden' ? { visibility: 'hidden' } : {}} xs={12}>
           <TextField className={classes.searchTextField} onChange={searchChange} value={sectionFilterText} id='textField_Search' size='small' label='Search Sections' variant='outlined' InputProps={{ endAdornment: getSearchTextFieldEndAdornment(sectionFilterText.length > 0) }}/>
         </Grid>
         <Grid item xs={12}>

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -160,18 +160,13 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
 
   useEffect(() => {
     if (!firstRender) {
-      console.log(`Search because sectionSearcherText ${String(props.header?.title)} '${String(sectionSearcherText)}'`)
       void search()
-    } else {
-      console.log('Search skipped on first render')
     }
   }, [sectionSearcherText])
 
   useEffect(() => {
     if (!firstRender) {
       setSectionSearcherText(searchFieldTextDebounced)
-    } else {
-      console.log('sectionSearchTextDebounced update skipped on first render')
     }
   }, [searchFieldTextDebounced])
 
@@ -191,10 +186,8 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     if (searcher !== undefined) {
       props.selectionUpdated([])
       if (sectionSearcherText !== undefined) {
-        console.log('search hook search')
         void searcher.search(sectionSearcherText)
       } else {
-        console.log('search hook init')
         void searcher.init()
       }
     }

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -1,7 +1,26 @@
-import { Button, Checkbox, FormControlLabel, FormGroup, Grid, List, ListItem, ListItemText, makeStyles, TextField, Typography } from '@material-ui/core'
+import { Button, Checkbox, FormControlLabel, FormGroup, Grid, List, ListItem, ListItemText, makeStyles, Menu, MenuItem, TextField, Typography } from '@material-ui/core'
+// import { ClearIcon, SortIcon } from '@material-ui/icons'
 import ClearIcon from '@material-ui/icons/Clear'
+import SortIcon from '@material-ui/icons/Sort'
 import React, { useEffect, useState } from 'react'
-import { CanvasCourseSection } from '../models/canvas'
+import { CanvasCourseSection, CanvasCourseSectionSort_AZ, CanvasCourseSectionSort_UserCount, CanvasCourseSectionSort_ZA, ICanvasCourseSectionSort } from '../models/canvas'
+
+/*
+ Use Cases
+  Add UM Users
+    No header items
+  Merge
+    Instructor View
+      Title, Select All, Sort
+    Sub Account Admin
+      Search ( Course Name, Uniqname )
+      Title, Select All, Sort
+    Service Center
+      Search ( Course Name )
+      Title, Select All, Sort
+
+
+*/
 
 const useStyles = makeStyles((theme) => ({
   listContainer: {
@@ -68,6 +87,8 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   const [filteredSections, setFilteredSections] = useState<SelectableCanvasCourseSection[]>(props.sections)
 
   const [isSelectAllChecked, setIsSelectAllChecked] = useState<boolean>(false)
+
+  const [anchorSortEl, setAnchorSortEl] = React.useState<null | HTMLElement>(null)
 
   useEffect(() => {
     if (sectionFilterText.length === 0) {
@@ -171,6 +192,39 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     }
   }
 
+  const handleSortMenuClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
+    setAnchorSortEl(event.currentTarget)
+  }
+
+  const handleSort = (event: React.MouseEvent<HTMLElement>, sorter: ICanvasCourseSectionSort): void => {
+    setAnchorSortEl(null)
+    setFilteredSections(sorter.sort(filteredSections))
+  }
+
+  const handleSortMenuClose = (): void => {
+    setAnchorSortEl(null)
+  }
+
+  const sortButton = (): JSX.Element => {
+    return (
+      <Grid item xs={12} sm={3}>
+      <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleSortMenuClick} disabled={filteredSections.}>
+        <SortIcon/>Sort
+      </Button>
+      <Menu
+        id="simple-menu"
+        anchorEl={anchorSortEl}
+        keepMounted
+        open={Boolean(anchorSortEl)}
+        onClose={handleSortMenuClose}
+      >
+        <MenuItem onClick={(e) => { handleSort(e, new CanvasCourseSectionSort_UserCount()) }}># of students</MenuItem>
+        <MenuItem onClick={(e) => { handleSort(e, new CanvasCourseSectionSort_AZ()) }}>A-Z</MenuItem>
+        <MenuItem onClick={(e) => { handleSort(e, new CanvasCourseSectionSort_ZA()) }}>Z-A</MenuItem>
+      </Menu>
+    </Grid>
+    )
+  }
   // Passing in the height in the props seems like the wrong solution, but wanted to move on from solving that for now
   return (
     <>
@@ -203,6 +257,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
               />
             </FormGroup>
           </Grid>
+          {sortButton()}
           {actionButton()}
         </Grid>
         <Grid item xs={12}>

--- a/ccm_web/client/src/models/canvas.ts
+++ b/ccm_web/client/src/models/canvas.ts
@@ -7,6 +7,7 @@ export interface CanvasCourseSection {
   id: number
   name: string
   total_students: number
+  course_name?: string
 }
 
 export interface CanvasRole {

--- a/ccm_web/client/src/models/canvas.ts
+++ b/ccm_web/client/src/models/canvas.ts
@@ -7,7 +7,7 @@ export interface CanvasCourseSection {
   id: number
   name: string
   total_students: number
-  course_name?: string
+  course_name: string
 }
 
 export interface CanvasRole {
@@ -22,3 +22,30 @@ export const canvasRoles: CanvasRole[] = [
   { clientName: 'observer', canvasName: 'ObserverEnrollment' },
   { clientName: 'designer', canvasName: 'DesignerEnrollment' }
 ]
+
+export interface ICanvasCourseSectionSort {
+  sort: (sections: CanvasCourseSection[]) => CanvasCourseSection[]
+}
+
+export class CanvasCourseSectionSort_AZ implements ICanvasCourseSectionSort {
+  sort = (sections: CanvasCourseSection[]): CanvasCourseSection[] => {
+    return sections.sort((a, b) => {
+      return (a.name.localeCompare(b.name, 'en', { sensitivity: 'base' }))
+    })
+  }
+}
+
+export class CanvasCourseSectionSort_ZA implements ICanvasCourseSectionSort {
+  sort = (sections: CanvasCourseSection[]): CanvasCourseSection[] => {
+    const sorter = new CanvasCourseSectionSort_AZ()
+    return sorter.sort(sections).reverse()
+  }
+}
+
+export class CanvasCourseSectionSort_UserCount implements ICanvasCourseSectionSort {
+  sort = (sections: CanvasCourseSection[]): CanvasCourseSection[] => {
+    return sections.sort((a, b) => {
+      return (b.total_students - a.total_students)
+    })
+  }
+}

--- a/ccm_web/client/src/models/canvas.ts
+++ b/ccm_web/client/src/models/canvas.ts
@@ -24,10 +24,12 @@ export const canvasRoles: CanvasRole[] = [
 ]
 
 export interface ICanvasCourseSectionSort {
+  description: string
   sort: (sections: CanvasCourseSection[]) => CanvasCourseSection[]
 }
 
 export class CanvasCourseSectionSort_AZ implements ICanvasCourseSectionSort {
+  description = 'Sort alphabetically A to Z'
   sort = (sections: CanvasCourseSection[]): CanvasCourseSection[] => {
     return sections.sort((a, b) => {
       return (a.name.localeCompare(b.name, 'en', { sensitivity: 'base' }))
@@ -36,6 +38,7 @@ export class CanvasCourseSectionSort_AZ implements ICanvasCourseSectionSort {
 }
 
 export class CanvasCourseSectionSort_ZA implements ICanvasCourseSectionSort {
+  description = 'Sort alphabetically Z to A'
   sort = (sections: CanvasCourseSection[]): CanvasCourseSection[] => {
     const sorter = new CanvasCourseSectionSort_AZ()
     return sorter.sort(sections).reverse()
@@ -43,6 +46,7 @@ export class CanvasCourseSectionSort_ZA implements ICanvasCourseSectionSort {
 }
 
 export class CanvasCourseSectionSort_UserCount implements ICanvasCourseSectionSort {
+  description = 'Sort by number of users, descending'
   sort = (sections: CanvasCourseSection[]): CanvasCourseSection[] => {
     return sections.sort((a, b) => {
       return (b.total_students - a.total_students)

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -247,7 +247,7 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
           </div>
           <Typography variant='subtitle1'>Or select one available section to add users</Typography>
           <div className={classes.sectionSelectionContainer}>
-            <SectionSelectorWidget height={400} search='None' multiSelect={false} sections={sections !== undefined ? sections : []} selectedSections={selectedSections} selectionUpdated={setSelectedSections}></SectionSelectorWidget>
+            <SectionSelectorWidget height={400} search={[]} multiSelect={false} sections={sections !== undefined ? sections : []} selectedSections={selectedSections} selectionUpdated={setSelectedSections}></SectionSelectorWidget>
             <div>
               <Button className={classes.sectionSelectButton} variant='contained' color='primary' disabled={selectedSections.length === 0} onClick={() => { setActiveStep(activeStep + 1) }}>Select</Button>
             </div>

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -247,7 +247,7 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
           </div>
           <Typography variant='subtitle1'>Or select one available section to add users</Typography>
           <div className={classes.sectionSelectionContainer}>
-            <SectionSelectorWidget height={400} multiSelect={false} sections={sections !== undefined ? sections : []} selectedSections={selectedSections} selectionUpdated={setSelectedSections}></SectionSelectorWidget>
+            <SectionSelectorWidget height={400} search='None' multiSelect={false} sections={sections !== undefined ? sections : []} selectedSections={selectedSections} selectionUpdated={setSelectedSections}></SectionSelectorWidget>
             <div>
               <Button className={classes.sectionSelectButton} variant='contained' color='primary' disabled={selectedSections.length === 0} onClick={() => { setActiveStep(activeStep + 1) }}>Select</Button>
             </div>

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -61,7 +61,8 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   const [doLoadUnstagedSectionData, isUnstagedSectionsLoading, loadUnstagedSectionsError] = usePromise(
     async () => await getCourseSections(props.globals.course.id),
     (sections: CanvasCourseSection[]) => {
-      updateUnstagedSections(sections)
+      // TODO Some temp stuff in here to populate course names -- get rid of the map
+      updateUnstagedSections(sections.map(s => { return { ...s, course_name: 'Course ' + Array(Math.floor(Math.random() * (128 - 8 + 1) + 8)).fill('x').join('') } }))
     }
   )
 
@@ -151,6 +152,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
               title={'Prepared to merge'}
               search={'None'}
               multiSelect={true}
+              showCourseName={true}
               sections={stagedSections !== undefined ? stagedSections : []}
               selectedSections={selectedStagedSections}
               selectionUpdated={setSelectedStagedSections}></SectionSelectorWidget>

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -95,7 +95,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
       return (
         <>
           <div>
-            <SectionSelectorWidget height={400} search={'None'} multiSelect={true} sections={unstagedSections !== undefined ? unstagedSections : []} selectedSections={selectedUnstagedSections} selectionUpdated={setSelectedUnstagedSections}></SectionSelectorWidget>
+            <SectionSelectorWidget height={400} title={'Sections I teach'} search={'None'} multiSelect={true} sections={unstagedSections !== undefined ? unstagedSections : []} selectedSections={selectedUnstagedSections} selectionUpdated={setSelectedUnstagedSections}></SectionSelectorWidget>
             <Backdrop className={classes.backdrop} open={isUnstagedSectionsLoading}>
               <Grid container>
                 <Grid item xs={12}>

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -107,10 +107,16 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
       return (
         <>
           <div>
-            <Button variant="contained" color="primary" onClick={stageSections} disabled={selectedUnstagedSections.length === 0}>
-              Add
-            </Button>
-            <SectionSelectorWidget height={400} title={'Sections I teach'} search={'None'} multiSelect={true} showCourseName={true} sections={unstagedSections !== undefined ? unstagedSections : []} selectedSections={selectedUnstagedSections} selectionUpdated={setSelectedUnstagedSections}></SectionSelectorWidget>
+            <SectionSelectorWidget
+              action={{ text: 'Merge', cb: stageSections, disabled: selectedUnstagedSections.length === 0 }}
+              height={400}
+              title={'Sections I teach'}
+              search={'None'}
+              multiSelect={true}
+              showCourseName={true}
+              sections={unstagedSections !== undefined ? unstagedSections : []}
+              selectedSections={selectedUnstagedSections}
+              selectionUpdated={setSelectedUnstagedSections}></SectionSelectorWidget>
             <Backdrop className={classes.backdrop} open={isUnstagedSectionsLoading}>
               <Grid container>
                 <Grid item xs={12}>
@@ -139,10 +145,15 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
       return (
         <>
           <div>
-            <Button variant="contained" color="primary" onClick={unStageSections} disabled={selectedStagedSections.length === 0}>
-              Undo
-            </Button>
-            <SectionSelectorWidget height={400} title={'Prepared to merge'} search={'None'} multiSelect={true} sections={stagedSections !== undefined ? stagedSections : []} selectedSections={selectedStagedSections} selectionUpdated={setSelectedStagedSections}></SectionSelectorWidget>
+            <SectionSelectorWidget
+              action={{ text: 'Undo', cb: unStageSections, disabled: selectedStagedSections.length === 0 }}
+              height={400}
+              title={'Prepared to merge'}
+              search={'None'}
+              multiSelect={true}
+              sections={stagedSections !== undefined ? stagedSections : []}
+              selectedSections={selectedStagedSections}
+              selectionUpdated={setSelectedStagedSections}></SectionSelectorWidget>
             <Backdrop className={classes.backdrop} open={isStagedSectionsLoading}>
               <Grid container>
                 <Grid item xs={12}>

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -110,7 +110,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
             <Button variant="contained" color="primary" onClick={stageSections} disabled={selectedUnstagedSections.length === 0}>
               Add
             </Button>
-            <SectionSelectorWidget height={400} title={'Sections I teach'} search={'None'} multiSelect={true} sections={unstagedSections !== undefined ? unstagedSections : []} selectedSections={selectedUnstagedSections} selectionUpdated={setSelectedUnstagedSections}></SectionSelectorWidget>
+            <SectionSelectorWidget height={400} title={'Sections I teach'} search={'None'} multiSelect={true} showCourseName={true} sections={unstagedSections !== undefined ? unstagedSections : []} selectedSections={selectedUnstagedSections} selectionUpdated={setSelectedUnstagedSections}></SectionSelectorWidget>
             <Backdrop className={classes.backdrop} open={isUnstagedSectionsLoading}>
               <Grid container>
                 <Grid item xs={12}>

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -159,7 +159,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
     } else {
       return (
         <Paper className={classes.sectionLoadError} role='alert'>
-          <Typography>Error loading sections</Typography>
+          <Typography>Error loading merged sections</Typography>
           <ErrorIcon className={classes.sectionLoadErrorIcon} fontSize='large'/>
         </Paper>
       )
@@ -169,11 +169,11 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   const getSelectSections = (): JSX.Element => {
     return (
       <>
-        <Grid className={classes.sectionSelectionContainer} container spacing={5}>
-          <Grid item xs={12} sm={6}>
+        <Grid container spacing={5}>
+          <Grid className={classes.sectionSelectionContainer} item xs={12} sm={6}>
             {getSelectSectionsUnstaged()}
           </Grid>
-          <Grid item xs={12} sm={6}>
+          <Grid className={classes.sectionSelectionContainer} item xs={12} sm={6}>
             {getSelectSectionsStaged()}
           </Grid>
         </Grid>

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -78,7 +78,6 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   const [unstagedSectionsSort, setUnstagedSectionsSort] = useState<ICanvasCourseSectionSort>(new CanvasCourseSectionSort_AZ())
 
   useEffect(() => {
-    console.log('unsyncedUnstagedSections changed')
     setUnstagedSections(
       unsyncedUnstagedSections
         .map(s => { return { ...s, locked: stagedSections.filter(staged => { return staged.id === s.id }).length > 0 } })
@@ -111,7 +110,6 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
 
   useEffect(() => {
     void doLoadStagedSectionData()
-    console.log(JSON.stringify(props.globals))
   }, [])
 
   const renderComponent = (): JSX.Element => {

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-import { Backdrop, Button, CircularProgress, Grid, makeStyles, Paper, Typography } from '@material-ui/core'
+import { Backdrop, CircularProgress, Grid, makeStyles, Paper, Typography } from '@material-ui/core'
 import { Error as ErrorIcon } from '@material-ui/icons'
 
 import { CCMComponentProps } from '../models/FeatureUIData'
@@ -71,7 +71,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   }
 
   const [doLoadStagedSectionData, isStagedSectionsLoading, loadStagedSectionsError] = usePromise(
-    async () => await Promise.resolve([{ id: 0, name: 'Already Merged Section', total_students: 123 }]),
+    async () => await Promise.resolve([{ id: 0, course_name: 'Spelunking 101', name: 'Already Merged Section', total_students: 123 }]),
     (sections: CanvasCourseSection[]) => {
       updateStagedSections(sections)
     }

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -9,6 +9,7 @@ import SectionSelectorWidget, { SelectableCanvasCourseSection } from '../compone
 import { CanvasCourseSection, CanvasCourseSectionSort_AZ, CanvasCourseSectionSort_UserCount, CanvasCourseSectionSort_ZA, ICanvasCourseSectionSort } from '../models/canvas'
 import { getCourseSections } from '../api'
 import usePromise from '../hooks/usePromise'
+import { RoleEnum } from '../models/models'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -88,6 +89,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   useEffect(() => {
     void doLoadUnstagedSectionData()
     void doLoadStagedSectionData()
+    console.log(JSON.stringify(props.globals))
   }, [])
 
   const renderComponent = (): JSX.Element => {
@@ -97,6 +99,18 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
       default:
         return <div>?</div>
     }
+  }
+
+  const isTeacher = (): boolean => {
+    return props.globals.course.roles.includes(RoleEnum.Teacher)
+  }
+
+  const isSubAccountAdmin = (): boolean => {
+    return props.globals.course.roles.includes(RoleEnum['Subaccount admin'])
+  }
+
+  const isAccountAdmin = (): boolean => {
+    return props.globals.course.roles.includes(RoleEnum['Account Admin'])
   }
 
   const stageSections = (): void => {
@@ -131,7 +145,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
                   ]
                 }
               }}
-              search={'None'}
+              search={ isSubAccountAdmin() || isAccountAdmin() ? true : 'None'}
               multiSelect={true}
               showCourseName={true}
               sections={unstagedSections !== undefined ? unstagedSections : []}
@@ -169,7 +183,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
               action={{ text: 'Undo', cb: unStageSections, disabled: selectedStagedSections.length === 0 }}
               height={400}
               header={{ title: 'Prepared to merge' }}
-              search={'None'}
+              search={ isSubAccountAdmin() || isAccountAdmin() ? 'Hidden' : 'None'}
               multiSelect={true}
               showCourseName={true}
               sections={stagedSections !== undefined ? stagedSections : []}

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -59,8 +59,9 @@ export interface ISectionSearcher {
   init: () => Promise<void>
 }
 
-// TODO for dev testing remove
-const OVERRIDE_ROLE: RoleEnum | undefined = RoleEnum.Teacher
+// TODO for dev testing remove all this before merging
+// Can set to a specific role for testing purposes
+const OVERRIDE_ROLE: RoleEnum | undefined = undefined // RoleEnum.Teacher
 
 function MergeSections (props: CCMComponentProps): JSX.Element {
   const classes = useStyles()

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -1,10 +1,58 @@
-import React from 'react'
+import React, { useState } from 'react'
 
-import { Typography } from '@material-ui/core'
+import { Grid, makeStyles, Paper, Typography } from '@material-ui/core'
+import { CCMComponentProps } from '../models/FeatureUIData'
+import { mergeSectionProps } from '../models/feature'
 
-function MergeSections (): JSX.Element {
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: 25,
+    textAlign: 'left',
+    '& button': {
+      margin: 5
+    }
+  },
+  selectSections: {
+    // flexGrow: 1
+    // width: '100%'
+  }
+}))
+
+enum PageState {
+  SelectSections = 0
+}
+
+function MergeSections (props: CCMComponentProps): JSX.Element {
+  const classes = useStyles()
+  const [pageState, setPageState] = useState<PageState>(PageState.SelectSections)
+
+  const renderComponent = (): JSX.Element => {
+    switch (pageState) {
+      case PageState.SelectSections:
+        return getSelectSections()
+      default:
+        return <div>?</div>
+    }
+  }
+
+  const getSelectSections = (): JSX.Element => {
+    return (
+      <Grid className={classes.selectSections} container spacing={2}>
+        <Grid container item sm={12} md>
+          <Paper>Sections</Paper>
+        </Grid>
+        <Grid container item sm={12} md>
+          <Paper>Prepared to merge</Paper>
+        </Grid>
+      </Grid>
+    )
+  }
+
   return (
-    <div><Typography variant='h2'>Merge</Typography></div>
+    <div className={classes.root}>
+      <Typography variant='h5'>{mergeSectionProps.title}</Typography>
+      {renderComponent()}
+    </div>
   )
 }
 

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -56,16 +56,19 @@ export interface ISectionSearcher {
   name: string
   preload: string | undefined
   search: (searchString: string) => Promise<void>
+  init: () => Promise<void>
 }
 
 // TODO for dev testing remove
-const OVERRIDE_ROLE: RoleEnum | undefined = undefined // RoleEnum.Teacher
+const OVERRIDE_ROLE: RoleEnum | undefined = RoleEnum.Teacher
 
 function MergeSections (props: CCMComponentProps): JSX.Element {
   const classes = useStyles()
   const [pageState, setPageState] = useState<PageState>(PageState.SelectSections)
 
+  // Updating untagedSections is done via setUnsyncedUnstagedSections so that the synchornizing of unstaged/staged sections can be done in useEffect
   const [unsyncedUnstagedSections, setUnsyncedUnstagedSections] = useState<SelectableCanvasCourseSection[]>([])
+  // setUnstagedSections should only be called from the effect on unsyncedUnstagedSections. Maybe this is a way to hide this
   const [unstagedSections, setUnstagedSections] = useState<SelectableCanvasCourseSection[]>([])
   const [stagedSections, setStagedSections] = useState<SelectableCanvasCourseSection[]>([])
 

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -91,8 +91,15 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   }
 
   const stageSections = (): void => {
-    setStagedSections(stagedSections.concat(selectedUnstagedSections.map(s => { return { ...s, locked: false } })))
-    setUnstagedSections(unstagedSections.filter(s => { return !selectedUnstagedSections.includes(s) }))
+    setStagedSections(stagedSections.concat(selectedUnstagedSections).sort((a, b) => { return a.name.localeCompare(b.name) }))
+    setUnstagedSections(unstagedSections.filter(s => { return !selectedUnstagedSections.includes(s) }).sort((a, b) => { return a.name.localeCompare(b.name) }))
+    setSelectedUnstagedSections([])
+  }
+
+  const unStageSections = (): void => {
+    setUnstagedSections(unstagedSections.concat(selectedStagedSections).sort((a, b) => { return a.name.localeCompare(b.name) }))
+    setStagedSections(stagedSections.filter(s => { return !selectedStagedSections.includes(s) }).sort((a, b) => { return a.name.localeCompare(b.name) }))
+    setSelectedStagedSections([])
   }
 
   const getSelectSectionsUnstaged = (): JSX.Element => {
@@ -132,7 +139,10 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
       return (
         <>
           <div>
-            <SectionSelectorWidget height={400} search={'None'} multiSelect={true} sections={stagedSections !== undefined ? stagedSections : []} selectedSections={selectedStagedSections} selectionUpdated={setSelectedStagedSections}></SectionSelectorWidget>
+            <Button variant="contained" color="primary" onClick={unStageSections} disabled={selectedStagedSections.length === 0}>
+              Undo
+            </Button>
+            <SectionSelectorWidget height={400} title={'Prepared to merge'} search={'None'} multiSelect={true} sections={stagedSections !== undefined ? stagedSections : []} selectedSections={selectedStagedSections} selectionUpdated={setSelectedStagedSections}></SectionSelectorWidget>
             <Backdrop className={classes.backdrop} open={isStagedSectionsLoading}>
               <Grid container>
                 <Grid item xs={12}>

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-import { Backdrop, CircularProgress, Grid, makeStyles, Paper, Typography } from '@material-ui/core'
+import { Backdrop, Button, CircularProgress, Grid, makeStyles, Paper, Typography } from '@material-ui/core'
 import { Error as ErrorIcon } from '@material-ui/icons'
 
 import { CCMComponentProps } from '../models/FeatureUIData'
@@ -25,7 +25,10 @@ const useStyles = makeStyles((theme) => ({
   sectionSelectionContainer: {
     position: 'relative',
     zIndex: 0,
-    textAlign: 'center'
+    textAlign: 'center',
+    borderStyle: 'solid',
+    borderWidth: '1px',
+    borderColor: '#EEEEEE'
   },
   backdrop: {
     zIndex: theme.zIndex.drawer + 1,
@@ -37,6 +40,9 @@ const useStyles = makeStyles((theme) => ({
   },
   sectionLoadError: {
     textAlign: 'center'
+  },
+  submitButton: {
+    float: 'right'
   }
 }))
 
@@ -112,7 +118,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
         <>
           <div>
             <SectionSelectorWidget
-              action={{ text: 'Merge', cb: stageSections, disabled: selectedUnstagedSections.length === 0 }}
+              action={{ text: 'Add', cb: stageSections, disabled: selectedUnstagedSections.length === 0 }}
               height={400}
               header={{
                 title: 'Sections I teach',
@@ -192,10 +198,18 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
     }
   }
 
+  const submit = (): void => {
+    console.log('Submit')
+  }
+
+  const canMerge = (): boolean => {
+    return stagedSections.filter(s => { return !(s.locked ?? false) }).length > 0
+  }
+
   const getSelectSections = (): JSX.Element => {
     return (
       <>
-        <Grid container spacing={5}>
+        <Grid container spacing={5} style={{ marginBottom: '0px', marginTop: '0px' }}>
           <Grid className={classes.sectionSelectionContainer} item xs={12} sm={6}>
             {getSelectSectionsUnstaged()}
           </Grid>
@@ -203,7 +217,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
             {getSelectSectionsStaged()}
           </Grid>
         </Grid>
-
+        <Button className={classes.submitButton} onClick={submit} variant='contained' color='primary' disabled={!canMerge()}>Go Merge</Button>
       </>
     )
   }

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -70,7 +70,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   }
 
   const [doLoadStagedSectionData, isStagedSectionsLoading, loadStagedSectionsError] = usePromise(
-    async () => await Promise.resolve([{ id: 0, name: 'Fake Section', total_students: 123 }]),
+    async () => await Promise.resolve([{ id: 0, name: 'Already Merged Section', total_students: 123 }]),
     (sections: CanvasCourseSection[]) => {
       updateStagedSections(sections)
     }

--- a/ccm_web/client/src/utils/SectionSearcher.ts
+++ b/ccm_web/client/src/utils/SectionSearcher.ts
@@ -18,7 +18,6 @@ export abstract class SectionSearcher implements ISectionSearcher {
   abstract searchImpl: (searchText: string) => Promise<void>
 
   init = async (): Promise<void> => {
-    console.log(`SectionSearcher init [preload: '${String(this.preload)}']`)
     if (this.preload !== undefined) {
       return await this.searchImpl(this.preload)
     } else {
@@ -27,7 +26,6 @@ export abstract class SectionSearcher implements ISectionSearcher {
   }
 
   search = async (searchString: string): Promise<void> => {
-    console.log(`${this.name} search '${searchString}'`)
     return await this.searchImpl(searchString)
   }
 }
@@ -75,7 +73,7 @@ export class SectionNameSearcher extends SectionSearcher {
     getTeacherSections(this.courseId).then(sections => {
       this.setSections(sections.filter(s => { return localeIncludes(s.name, searchText) }))
     }).catch(error => {
-      console.log(error)
+      throw error
     })
   }
 }

--- a/ccm_web/client/src/utils/SectionSearcher.ts
+++ b/ccm_web/client/src/utils/SectionSearcher.ts
@@ -39,11 +39,8 @@ export class UniqnameSearcher extends SectionSearcher {
     if (searchText === undefined) {
       return
     }
-    searchSections(this.courseId, 'uniqname', searchText).then(sections => {
-      this.setSections(sections)
-    }).catch(error => {
-      throw error
-    })
+
+    this.setSections(await searchSections(this.courseId, 'uniqname', searchText))
   }
 }
 
@@ -56,11 +53,8 @@ export class CourseNameSearcher extends SectionSearcher {
     if (searchText === undefined) {
       return
     }
-    searchSections(this.courseId, 'coursename', searchText).then(sections => {
-      this.setSections(sections)
-    }).catch(error => {
-      throw error
-    })
+
+    this.setSections(await searchSections(this.courseId, 'coursename', searchText))
   }
 }
 
@@ -70,10 +64,7 @@ export class SectionNameSearcher extends SectionSearcher {
   }
 
   searchImpl = async (searchText: string): Promise<void> => {
-    getTeacherSections(this.courseId).then(sections => {
-      this.setSections(sections.filter(s => { return localeIncludes(s.name, searchText) }))
-    }).catch(error => {
-      throw error
-    })
+    const sections = await (await getTeacherSections(this.courseId)).filter(s => { return localeIncludes(s.name, searchText) })
+    this.setSections(sections)
   }
 }

--- a/ccm_web/client/src/utils/SectionSearcher.ts
+++ b/ccm_web/client/src/utils/SectionSearcher.ts
@@ -1,0 +1,75 @@
+import { getTeacherSections, searchSections } from '../api'
+import { CanvasCourseSection } from '../models/canvas'
+import { ISectionSearcher } from '../pages/MergeSections'
+import { localeIncludes } from './localeIncludes'
+
+export abstract class SectionSearcher implements ISectionSearcher {
+  name: string
+  preload: string | undefined
+  courseId: number
+  setSections: (sections: CanvasCourseSection[]) => void
+  constructor (courseId: number, name: string, preload: string | undefined, setSectionsCallabck: (sections: CanvasCourseSection[]) => void) {
+    this.courseId = courseId
+    this.name = name
+    this.preload = preload
+    this.setSections = setSectionsCallabck
+  }
+
+  abstract searchImpl: (searchText: string) => Promise<void>
+
+  search = async (searchString: string): Promise<void> => {
+    console.log(`${this.name} search ${searchString}`)
+    return await this.searchImpl(searchString)
+  }
+}
+
+export class UniqnameSearcher extends SectionSearcher {
+  constructor (courseId: number, setSectionsCallabck: (sections: CanvasCourseSection[]) => void) {
+    super(courseId, 'Uniqname', undefined, setSectionsCallabck)
+  }
+
+  searchImpl = async (searchText: string): Promise<void> => {
+    console.log(`${this.name} searchImpl ${String(searchText)}`)
+    if (searchText === undefined) {
+      return
+    }
+    searchSections(this.courseId, 'uniqname', searchText).then(sections => {
+      this.setSections(sections)
+    }).catch(error => {
+      throw error
+    })
+  }
+}
+
+export class CourseNameSearcher extends SectionSearcher {
+  constructor (courseId: number, setSectionsCallabck: (sections: CanvasCourseSection[]) => void) {
+    super(courseId, 'Course Name', undefined, setSectionsCallabck)
+  }
+
+  searchImpl = async (searchText: string): Promise<void> => {
+    console.log(`${this.name} searchImpl ${String(searchText)}`)
+    if (searchText === undefined) {
+      return
+    }
+    searchSections(this.courseId, 'coursename', searchText).then(sections => {
+      this.setSections(sections)
+    }).catch(error => {
+      throw error
+    })
+  }
+}
+
+export class SectionNameSearcher extends SectionSearcher {
+  constructor (courseId: number, setSectionsCallabck: (sections: CanvasCourseSection[]) => void) {
+    super(courseId, 'Section Name', '', setSectionsCallabck)
+  }
+
+  searchImpl = async (searchText: string): Promise<void> => {
+    console.log(`${this.name} searchImpl ${String(searchText)}`)
+    getTeacherSections(this.courseId).then(sections => {
+      this.setSections(sections.filter(s => { return localeIncludes(s.name, searchText) }))
+    }).catch(error => {
+      console.log(error)
+    })
+  }
+}

--- a/ccm_web/client/src/utils/SectionSearcher.ts
+++ b/ccm_web/client/src/utils/SectionSearcher.ts
@@ -18,7 +18,7 @@ export abstract class SectionSearcher implements ISectionSearcher {
   abstract searchImpl: (searchText: string) => Promise<void>
 
   search = async (searchString: string): Promise<void> => {
-    console.log(`${this.name} search ${searchString}`)
+    console.log(`${this.name} search '${searchString}'`)
     return await this.searchImpl(searchString)
   }
 }
@@ -29,7 +29,6 @@ export class UniqnameSearcher extends SectionSearcher {
   }
 
   searchImpl = async (searchText: string): Promise<void> => {
-    console.log(`${this.name} searchImpl ${String(searchText)}`)
     if (searchText === undefined) {
       return
     }
@@ -47,7 +46,6 @@ export class CourseNameSearcher extends SectionSearcher {
   }
 
   searchImpl = async (searchText: string): Promise<void> => {
-    console.log(`${this.name} searchImpl ${String(searchText)}`)
     if (searchText === undefined) {
       return
     }
@@ -65,7 +63,6 @@ export class SectionNameSearcher extends SectionSearcher {
   }
 
   searchImpl = async (searchText: string): Promise<void> => {
-    console.log(`${this.name} searchImpl ${String(searchText)}`)
     getTeacherSections(this.courseId).then(sections => {
       this.setSections(sections.filter(s => { return localeIncludes(s.name, searchText) }))
     }).catch(error => {

--- a/ccm_web/client/src/utils/SectionSearcher.ts
+++ b/ccm_web/client/src/utils/SectionSearcher.ts
@@ -17,6 +17,15 @@ export abstract class SectionSearcher implements ISectionSearcher {
 
   abstract searchImpl: (searchText: string) => Promise<void>
 
+  init = async (): Promise<void> => {
+    console.log(`SectionSearcher init [preload: '${String(this.preload)}']`)
+    if (this.preload !== undefined) {
+      return await this.searchImpl(this.preload)
+    } else {
+      this.setSections([])
+    }
+  }
+
   search = async (searchString: string): Promise<void> => {
     console.log(`${this.name} search '${searchString}'`)
     return await this.searchImpl(searchString)

--- a/ccm_web/client/src/utils/localeIncludes.ts
+++ b/ccm_web/client/src/utils/localeIncludes.ts
@@ -1,0 +1,22 @@
+// Tweaked from https://www.npmjs.com/package/locale-includes
+export const localeIncludes = (string: string, searchString: string): boolean => {
+  if (string === undefined ||
+      string === null ||
+      searchString === undefined ||
+      searchString === null
+  ) {
+    throw new Error('localeIncludes requires at least 2 parameters')
+  }
+
+  const stringLength = string.length
+  const searchStringLength = searchString.length
+  const lengthDiff = stringLength - searchStringLength
+
+  for (let i = 0; i <= lengthDiff; i++) {
+    if (string.substring(i, i + searchStringLength).localeCompare(searchString, 'en', { sensitivity: 'base' }) === 0) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/ccm_web/package-lock.json
+++ b/ccm_web/package-lock.json
@@ -1143,6 +1143,19 @@
         "node-fetch": "^2.6.1"
       }
     },
+    "@react-hook/debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@react-hook/debounce/-/debounce-4.0.0.tgz",
+      "integrity": "sha512-706Xcg+KKWHk9BuZQUQ0ZQKp9zhv3/MbqFenWVfHcynYpSGRVwQTzJRGvPxvsdtXxJv+HfgKTY/O/hEejakwmA==",
+      "requires": {
+        "@react-hook/latest": "^1.0.2"
+      }
+    },
+    "@react-hook/latest": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
+      "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg=="
+    },
     "@rushstack/ts-command-line": {
       "version": "4.7.10",
       "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.10.tgz",
@@ -1434,7 +1447,7 @@
     "@types/express-serve-static-core": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
-      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
+      "integrity": "sha1-AKz8FjLnKaysTxUw6eFvbdFQih0=",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1701,7 +1714,7 @@
     "@types/qs": {
       "version": "6.9.6",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==",
+      "integrity": "sha1-35w8izGiR+wxXmmWVmvjFx30s7E=",
       "dev": true
     },
     "@types/range-parser": {

--- a/ccm_web/package.json
+++ b/ccm_web/package.json
@@ -30,6 +30,7 @@
     "@nestjs/platform-express": "^7.6.15",
     "@nestjs/sequelize": "^0.2.0",
     "@nestjs/swagger": "^4.8.0",
+    "@react-hook/debounce": "^4.0.0",
     "axios": "^0.21.1",
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",

--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -1,6 +1,6 @@
 import { SessionData } from 'express-session'
 import {
-  Body, Controller, Get, HttpException, Param, ParseIntPipe, Post, Put, Session, UseGuards
+  Body, Controller, Get, HttpException, Param, ParseIntPipe, Post, Put, Query, Session, UseGuards
 } from '@nestjs/common'
 import { ApiSecurity } from '@nestjs/swagger'
 
@@ -58,5 +58,32 @@ export class APIController {
     const result = await this.apiService.createSections(user, courseId, sections)
     if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
     return result
+  }
+
+  @ApiSecurity('CSRF-Token')
+  @Get('course/:id/sections/merged')
+  async mergedSections (@Param('id', ParseIntPipe) courseId: number, @UserDec() user: User): Promise<CanvasCourseSection[]> {
+    const result = await this.apiService.getMergedSections(user, courseId)
+    if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
+    return result
+  }
+
+  @ApiSecurity('CSRF-Token')
+  @Get('course/:id/sections/search')
+  async searchSections (@Param('id', ParseIntPipe) courseId: number,
+    @Query('uniqname') uniqname: string,
+    @Query('coursename') courseName: string,
+    @UserDec() user: User): Promise<CanvasCourseSection[]> {
+    if (courseName !== undefined) {
+      const result = await this.apiService.getCourseSectionsByCourseName(user, courseId, courseName)
+      if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
+      return result
+    } else if (uniqname !== undefined) {
+      const result = await this.apiService.getCourseSectionsByUniqname(user, courseId, uniqname)
+      if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
+      return result
+    } else {
+      throw new HttpException('Invalid section search parameter', 400)
+    }
   }
 }

--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -68,6 +68,15 @@ export class APIController {
     return result
   }
 
+  // TODO placeholder implementation just using getCourseSections. I think this needs a new query
+  @ApiSecurity('CSRF-Token')
+  @Get('course/:id/sections/instructed')
+  async instructedSections (@Param('id', ParseIntPipe) courseId: number, @UserDec() user: User): Promise<CanvasCourseSection[]> {
+    const result = await this.apiService.getCourseSections(user, courseId)
+    if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
+    return result
+  }
+
   @ApiSecurity('CSRF-Token')
   @Get('course/:id/sections/search')
   async searchSections (@Param('id', ParseIntPipe) courseId: number,

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -4,7 +4,7 @@ import { ConfigService } from '@nestjs/config'
 
 import { handleAPIError } from './api.utils'
 import { CanvasCourse, CanvasCourseBase, CanvasCourseSection } from '../canvas/canvas.interfaces'
-import { APIErrorData, Globals } from './api.interfaces'
+import { APIErrorData, Globals, isAPIErrorData } from './api.interfaces'
 import { CreateSectionApiHandler } from './api.create.section.handler'
 import { CanvasService } from '../canvas/canvas.service'
 import { User } from '../user/user.model'
@@ -90,5 +90,29 @@ export class APIService {
     const requestor = await this.canvasService.createRequestorForUser(user, '/api/v1/')
     const createSectionsApiHandler = new CreateSectionApiHandler(requestor, sections, course)
     return await createSectionsApiHandler.createSections()
+  }
+
+  // TODO hack just return all course sections
+  async getTeacherSections (user: User, course: number): Promise<CanvasCourseSection[] | APIErrorData> {
+    return await this.getCourseSections(user, course)
+  }
+
+  // TODO hack
+  async getMergedSections (user: User, course: number): Promise<CanvasCourseSection[] | APIErrorData> {
+    return await Promise.resolve([{ id: 0, course_name: 'Spelunking 101', name: 'Already Merged Section', total_students: 123 }])
+  }
+
+  // TODO hack just search by section name
+  async getCourseSectionsByCourseName (user: User, course: number, searchText: string): Promise<CanvasCourseSection[] | APIErrorData> {
+    const result = await this.getTeacherSections(user, course)
+    if (isAPIErrorData(result)) return result
+    return result.filter(c => { return c.name.split('').some(s => s.localeCompare(searchText, 'en', { sensitivity: 'base' }) === 0) })
+  }
+
+  // TODO hack just search by section name
+  async getCourseSectionsByUniqname (user: User, course: number, searchText: string): Promise<CanvasCourseSection[] | APIErrorData> {
+    const result = await this.getTeacherSections(user, course)
+    if (isAPIErrorData(result)) return result
+    return result.filter(c => { return c.name.split('').some(s => s.localeCompare(searchText, 'en', { sensitivity: 'base' }) === 0) })
   }
 }

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -8,8 +8,8 @@ import { APIErrorData, Globals, isAPIErrorData } from './api.interfaces'
 import { CreateSectionApiHandler } from './api.create.section.handler'
 import { CanvasService } from '../canvas/canvas.service'
 import { User } from '../user/user.model'
-
 import baseLogger from '../logger'
+import { localeIncludes } from '../localeIncludes'
 
 const logger = baseLogger.child({ filePath: __filename })
 
@@ -106,13 +106,13 @@ export class APIService {
   async getCourseSectionsByCourseName (user: User, course: number, searchText: string): Promise<CanvasCourseSection[] | APIErrorData> {
     const result = await this.getTeacherSections(user, course)
     if (isAPIErrorData(result)) return result
-    return result.filter(c => { return c.name.split('').some(s => s.localeCompare(searchText, 'en', { sensitivity: 'base' }) === 0) })
+    return result.filter(c => { return localeIncludes(c.name, searchText) })
   }
 
   // TODO hack just search by section name
   async getCourseSectionsByUniqname (user: User, course: number, searchText: string): Promise<CanvasCourseSection[] | APIErrorData> {
     const result = await this.getTeacherSections(user, course)
     if (isAPIErrorData(result)) return result
-    return result.filter(c => { return c.name.split('').some(s => s.localeCompare(searchText, 'en', { sensitivity: 'base' }) === 0) })
+    return result.filter(c => { return localeIncludes(c.name, searchText) })
   }
 }

--- a/ccm_web/server/src/localeIncludes.ts
+++ b/ccm_web/server/src/localeIncludes.ts
@@ -1,0 +1,22 @@
+// Tweaked from https://www.npmjs.com/package/locale-includes
+export const localeIncludes = (string: string, searchString: string): boolean => {
+  if (string === undefined ||
+      string === null ||
+      searchString === undefined ||
+      searchString === null
+  ) {
+    throw new Error('localeIncludes requires at least 2 parameters')
+  }
+
+  const stringLength = string.length
+  const searchStringLength = searchString.length
+  const lengthDiff = stringLength - searchStringLength
+
+  for (let i = 0; i <= lengthDiff; i++) {
+    if (string.substring(i, i + searchStringLength).localeCompare(searchString, 'en', { sensitivity: 'base' }) === 0) {
+      return true
+    }
+  }
+
+  return false
+}


### PR DESCRIPTION
Draft of Merge Sections UI #182 

I expect there to be some issues, this turned out more complicated than I thought.

Actual section lookup is mocked up as the backend was not available while I was working on this.

Instructor view  should initialize with a view of sections (all sections the  user has a teacher role)

If they are a sub account admin or an account admin, they will be able to search by uniqname and course name, and the list will not preload anything.  (Both of these are currently just searching against the section name itself for re: BE)

Searches are auto initiated after a .5 second delay.

Clearing the search reverts to the original state.

MergeSections.tsx has some temporary code to allow you to simulate different user roles.  I actually attempted to make a utility for this but it required readable properties in globals so I went for this hack instead.

```
// TODO for dev testing remove all this before merging
// Can set to a specific role for testing purposes
const OVERRIDE_ROLE: RoleEnum | undefined = undefined // RoleEnum.Teacher
```

Course name should show in the list along with section  name and student count, but it is currently not returned by the backend.