### PR TITLE
Add `nonxlist_course_id` to `CanvasCourseSectionBase`

### DIFF
--- a/ccm_web/server/src/api/api.course.handler.ts
+++ b/ccm_web/server/src/api/api.course.handler.ts
@@ -74,6 +74,7 @@ export class CourseApiHandler {
         id: s.id,
         name: s.name,
         course_id: s.course_id,
+        nonxlist_course_id: s.nonxlist_course_id,
         total_students: s.total_students
       }))
     } catch (error) {

--- a/ccm_web/server/src/api/api.section.handler.ts
+++ b/ccm_web/server/src/api/api.section.handler.ts
@@ -25,7 +25,8 @@ export class SectionApiHandler {
     return {
       id: section.id,
       name: section.name,
-      course_id: section.course_id
+      course_id: section.course_id,
+      nonxlist_course_id: section.nonxlist_course_id
     }
   }
 

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -59,6 +59,7 @@ export interface CanvasCourseSectionBase {
   id: number
   name: string
   course_id: number
+  nonxlist_course_id: number | null
 }
 
 export interface CanvasCourseSection extends CanvasCourseSectionBase {


### PR DESCRIPTION
This PR follows up on the work of #199, adding the `nonxlist_course_id` field to `CanvasCourseSectionBase` so that the FE can determine whether a course can be unmerged (de-crosslisted) or not (if it's `null`, it's currently part of its original course and can't be unmerged).