### PR TITLE
Revert "use got default retry statusCodes (iss. #194)"

### DIFF
--- a/ccm_web/server/src/canvas/canvas.service.ts
+++ b/ccm_web/server/src/canvas/canvas.service.ts
@@ -3,7 +3,7 @@ import CanvasRequestor from '@kth/canvas-api'
 import { HttpService, HttpStatus, Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { InjectModel } from '@nestjs/sequelize'
-import got, { Options as GotOptions } from 'got'
+import { Options as GotOptions } from 'got'
 
 import { CanvasOAuthAPIError, CanvasTokenNotFoundError, InvalidTokenRefreshError } from './canvas.errors'
 import { TokenCodeResponseBody, TokenRefreshResponseBody } from './canvas.interfaces'
@@ -29,7 +29,9 @@ const requestorOptions: GotOptions = {
   retry: {
     limit: 2,
     methods: ['POST', 'GET', 'PUT', 'DELETE'],
-    statusCodes: got.defaults.options.retry.statusCodes.concat([403])
+    // TODO: After got@12 upgrade, replace following list with something like…
+    // got.defaultInternals.retry.statusCodes.concat(403)
+    statusCodes: [403, 408, 413, 429, 500, 502, 503, 504, 521, 522, 524]
   },
   hooks: {
     beforeRequest: [


### PR DESCRIPTION
Reverts tl-its-umich-edu/canvas-course-manager-next#202

While working on #190 with this change in place, I'm starting to doubt this actually works.  It seemed like it had been working, which is why I thought I'd open it as a standalone PR so others could benefit from it.  However, it seems to not be correct.

I am reverting this change so it doesn't impact anyone else's work.  I'll work on this in the PR for #190 instead.