### PR TITLE
Redo "use got default retry statusCodes (iss. #194)"

### DIFF
--- a/ccm_web/server/src/canvas/canvas.service.ts
+++ b/ccm_web/server/src/canvas/canvas.service.ts
@@ -3,7 +3,7 @@ import CanvasRequestor from '@kth/canvas-api'
 import { HttpService, HttpStatus, Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { InjectModel } from '@nestjs/sequelize'
-import { Options as GotOptions } from 'got'
+import got, { Options as GotOptions } from 'got'
 
 import { CanvasOAuthAPIError, CanvasTokenNotFoundError, InvalidTokenRefreshError } from './canvas.errors'
 import { TokenCodeResponseBody, TokenRefreshResponseBody } from './canvas.interfaces'
@@ -29,9 +29,7 @@ const requestorOptions: GotOptions = {
   retry: {
     limit: 2,
     methods: ['POST', 'GET', 'PUT', 'DELETE'],
-    // TODO: After got@12 upgrade, replace following list with something like…
-    // got.defaultInternals.retry.statusCodes.concat(403)
-    statusCodes: [403, 408, 413, 429, 500, 502, 503, 504, 521, 522, 524]
+    statusCodes: got.defaults.options.retry.statusCodes.concat([403])
   },
   hooks: {
     beforeRequest: [


### PR DESCRIPTION
Reverts tl-its-umich-edu/canvas-course-manager-next#211

That is, it reverts the revert, redoing the original PR.  What I thought was broken actually works.  I wasn't getting the results I expected because of other factors.

**_Now_** I feel silly for having a knee-jerk reaction and reverting my PR, then having to redo it again later. 😨 