### PR TITLE
handle various umich.edu email domains (iss. #192)

### DIFF
--- a/ccm_web/server/src/api/api.section.handler.ts
+++ b/ccm_web/server/src/api/api.section.handler.ts
@@ -32,7 +32,7 @@ export class SectionApiHandler {
 
   async enrollUser (user: SectionUserDto): Promise<CanvasEnrollment | APIErrorData> {
     const enrollLoginId = user.loginId
-      .replace(/@.*umich\.edu$/i, '')
+      .replace(/@([^@.]+\.)*umich\.edu$/gi, '')
       .replace('@', '+')
 
     try {


### PR DESCRIPTION
Resolves #192.

Use a slightly more complex regular expression to match U-M email addresses, `@.*umich\.edu$`.  This will catch all the "@med.umich.edu", "@engin.umich.edu", etc. addresses, but it will also match "@fubarumich.edu".  (Note the lack of "." before "umich".)  Is this a concern?  I don't think so.  I could update the regular expression if others think it is necessary.