### PR TITLE
Implement Format Third-Party Gradebook feature (#21, #229)

### DIFF
--- a/ccm_web/client/src/api.ts
+++ b/ccm_web/client/src/api.ts
@@ -86,6 +86,13 @@ export interface AddSectionEnrollment {
   type: string
 }
 
+export const getStudentsEnrolledInSection = async (sectionId: number): Promise<string[]> => {
+  const request = getGet()
+  const resp = await fetch(`/api/sections/${sectionId}/students`, request)
+  await handleErrors(resp)
+  return await resp.json()
+}
+
 export const addSectionEnrollments = async (
   sectionId: number, enrollments: AddSectionEnrollment[]
 ): Promise<CanvasEnrollment> => {

--- a/ccm_web/client/src/components/Alert.tsx
+++ b/ccm_web/client/src/components/Alert.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { Grid, makeStyles, Paper } from '@material-ui/core'
+
+const useStyles = makeStyles((theme) => ({
+  padding: {
+    padding: theme.spacing(1)
+  },
+  dialog: {
+    textAlign: 'center',
+    margin: 'auto',
+    marginTop: 30,
+    marginBottom: 15,
+    '& ol': {
+      margin: 'auto'
+    },
+    '& li': {
+      textAlign: 'left',
+      marginBottom: 10
+    }
+  }
+}))
+
+interface AlertProps {
+  children: React.ReactNode
+  icon: JSX.Element
+}
+
+export default function Alert (props: AlertProps): JSX.Element {
+  const classes = useStyles()
+  const { icon, children } = props
+  return (
+    <Grid item xs={12} sm={9} md={6} className={`${classes.dialog} ${classes.padding}`}>
+      <Paper className={classes.padding} role='alert'>
+        {icon}
+        {children}
+      </Paper>
+    </Grid>
+  )
+}

--- a/ccm_web/client/src/components/Alert.tsx
+++ b/ccm_web/client/src/components/Alert.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
-import { Grid, makeStyles, Paper } from '@material-ui/core'
+import { Grid, makeStyles, Paper, Typography } from '@material-ui/core'
 
 const useStyles = makeStyles((theme) => ({
   padding: {
     padding: theme.spacing(1)
+  },
+  standalone: {
+    margin: 'auto'
   },
   dialog: {
     textAlign: 'center',
@@ -22,18 +25,27 @@ const useStyles = makeStyles((theme) => ({
 
 interface AlertProps {
   children: React.ReactNode
+  title: string
   icon: JSX.Element
+  embedded?: boolean
 }
 
 export default function Alert (props: AlertProps): JSX.Element {
   const classes = useStyles()
-  const { icon, children } = props
+  const { title, icon, embedded, children } = props
+
+  const core = (
+    <Paper className={`${classes.dialog} ${classes.padding}`} role='alert'>
+      <Typography gutterBottom>{title}</Typography>
+      {icon}
+      {children}
+    </Paper>
+  )
+
+  if (embedded === true) return core
   return (
-    <Grid item xs={12} sm={9} md={6} className={`${classes.dialog} ${classes.padding}`}>
-      <Paper className={classes.padding} role='alert'>
-        {icon}
-        {children}
-      </Paper>
+    <Grid item xs={12} sm={9} md={6} className={classes.standalone}>
+      {core}
     </Grid>
   )
 }

--- a/ccm_web/client/src/components/ConfirmDialog.tsx
+++ b/ccm_web/client/src/components/ConfirmDialog.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { Button, Link, makeStyles, Paper, Typography } from '@material-ui/core'
+import CloudDoneIcon from '@material-ui/icons/CloudDone'
+
+import { DownloadData } from '../models/models'
+
+const useStyles = makeStyles((theme) => ({
+  padding: {
+    padding: theme.spacing(1)
+  },
+  dialog: {
+    textAlign: 'center',
+    marginBottom: 15
+  },
+  dialogIcon: {
+    color: '#3F648E'
+  },
+  dialogButton: {
+    margin: 5
+  }
+}))
+
+interface ConfirmDialogProps {
+  title?: string
+  message?: string
+  cancel: () => void
+  submit: (() => void) | (() => Promise<void>)
+  download?: DownloadData
+}
+
+export default function ConfirmDialog (props: ConfirmDialogProps): JSX.Element {
+  const classes = useStyles()
+  const defaultTitle = 'Review Your CSV File'
+  const defaultMessage = 'Your file is valid! If this looks correct, click "Submit" to proceed.'
+
+  const submitButton = (
+    <Button className={classes.dialogButton} variant='contained' color='primary' onClick={props.submit}>Submit</Button>
+  )
+
+  return (
+    <div className={classes.dialog}>
+      <Paper className={classes.padding} role='status'>
+        <Typography>{props.title ?? defaultTitle}</Typography>
+        <CloudDoneIcon className={classes.dialogIcon} fontSize='large' />
+        <Typography>{props.message ?? defaultMessage}</Typography>
+        <Button className={classes.dialogButton} variant='outlined' onClick={props.cancel}>Cancel</Button>
+        {
+          props.download !== undefined
+            ? <Link href={props.download.data} download={props.download.fileName}>{submitButton}</Link>
+            : submitButton
+        }
+      </Paper>
+    </div>
+  )
+}

--- a/ccm_web/client/src/components/ConfirmDialog.tsx
+++ b/ccm_web/client/src/components/ConfirmDialog.tsx
@@ -10,6 +10,8 @@ const useStyles = makeStyles((theme) => ({
   },
   dialog: {
     textAlign: 'center',
+    margin: 'auto',
+    marginTop: 30,
     marginBottom: 15
   },
   dialogIcon: {
@@ -32,7 +34,7 @@ interface ConfirmDialogProps {
 
 export default function ConfirmDialog (props: ConfirmDialogProps): JSX.Element {
   const classes = useStyles()
-  const defaultTitle = 'Review Your CSV File'
+  const defaultTitle = 'Review your CSV file'
   const defaultMessage = 'Your file is valid! If this looks correct, click "Submit" to proceed.'
 
   const submitButton = (

--- a/ccm_web/client/src/components/ConfirmDialog.tsx
+++ b/ccm_web/client/src/components/ConfirmDialog.tsx
@@ -42,7 +42,7 @@ export default function ConfirmDialog (props: ConfirmDialogProps): JSX.Element {
       <Paper className={classes.padding} role='status'>
         <Typography>{props.title ?? defaultTitle}</Typography>
         <CloudDoneIcon className={classes.dialogIcon} fontSize='large' />
-        <Typography>{props.message ?? defaultMessage}</Typography>
+        <Typography gutterBottom>{props.message ?? defaultMessage}</Typography>
         <Button className={classes.dialogButton} variant='outlined' onClick={props.cancel}>Cancel</Button>
         {
           props.download !== undefined

--- a/ccm_web/client/src/components/ConfirmDialog.tsx
+++ b/ccm_web/client/src/components/ConfirmDialog.tsx
@@ -23,9 +23,11 @@ const useStyles = makeStyles((theme) => ({
 interface ConfirmDialogProps {
   title?: string
   message?: string
+  icon?: JSX.Element
   cancel: () => void
   submit: (() => void) | (() => Promise<void>)
   download?: DownloadData
+  disabled?: boolean
 }
 
 export default function ConfirmDialog (props: ConfirmDialogProps): JSX.Element {
@@ -34,16 +36,26 @@ export default function ConfirmDialog (props: ConfirmDialogProps): JSX.Element {
   const defaultMessage = 'Your file is valid! If this looks correct, click "Submit" to proceed.'
 
   const submitButton = (
-    <Button className={classes.dialogButton} variant='contained' color='primary' onClick={props.submit}>Submit</Button>
+    <Button
+      className={classes.dialogButton}
+      variant='contained'
+      color='primary'
+      onClick={props.submit}
+      disabled={props.disabled}
+    >
+      Submit
+    </Button>
   )
 
   return (
     <div className={classes.dialog}>
       <Paper className={classes.padding} role='status'>
         <Typography>{props.title ?? defaultTitle}</Typography>
-        <CloudDoneIcon className={classes.dialogIcon} fontSize='large' />
+        {props.icon !== undefined ? props.icon : <CloudDoneIcon className={classes.dialogIcon} fontSize='large' />}
         <Typography gutterBottom>{props.message ?? defaultMessage}</Typography>
-        <Button className={classes.dialogButton} variant='outlined' onClick={props.cancel}>Cancel</Button>
+        <Button className={classes.dialogButton} variant='outlined' onClick={props.cancel} disabled={props.disabled}>
+          Cancel
+        </Button>
         {
           props.download !== undefined
             ? <Link href={props.download.data} download={props.download.fileName}>{submitButton}</Link>

--- a/ccm_web/client/src/components/ErrorAlert.tsx
+++ b/ccm_web/client/src/components/ErrorAlert.tsx
@@ -1,24 +1,10 @@
 import React from 'react'
-import { Button, Grid, makeStyles, Paper, Typography } from '@material-ui/core'
+import { Button, makeStyles, Typography } from '@material-ui/core'
 import ErrorIcon from '@material-ui/icons/Error'
 
-const useStyles = makeStyles((theme) => ({
-  padding: {
-    padding: theme.spacing(1)
-  },
-  dialog: {
-    textAlign: 'center',
-    margin: 'auto',
-    marginTop: 30,
-    marginBottom: 15,
-    '& ol': {
-      margin: 'auto'
-    },
-    '& li': {
-      textAlign: 'left',
-      marginBottom: 10
-    }
-  },
+import Alert from './Alert'
+
+const useStyles = makeStyles(() => ({
   dialogIcon: {
     color: '#3F648E'
   }
@@ -50,13 +36,10 @@ export default function ErrorAlert (props: ErrorAlertProps): JSX.Element {
       : <ol>{messages.map((m, i) => <li key={i}>{m}</li>)}</ol>
 
   return (
-    <Grid item xs={12} sm={9} md={6} className={`${classes.dialog} ${classes.padding}`}>
-      <Paper className={classes.padding} role='alert'>
-        {icon !== undefined ? icon : <ErrorIcon className={classes.dialogIcon} fontSize='large' />}
-        {Boolean(messages?.length) && preface}
-        {messageBlock}
-        {tryAgain !== undefined && <Button color='primary' onClick={props.tryAgain}>Try Again</Button>}
-      </Paper>
-    </Grid>
+    <Alert icon={icon !== undefined ? icon : <ErrorIcon className={classes.dialogIcon} fontSize='large' />}>
+      {Boolean(messages?.length) && preface}
+      {messageBlock}
+      {tryAgain !== undefined && <Button color='primary' onClick={props.tryAgain}>Try Again</Button>}
+    </Alert>
   )
 }

--- a/ccm_web/client/src/components/ErrorAlert.tsx
+++ b/ccm_web/client/src/components/ErrorAlert.tsx
@@ -14,21 +14,18 @@ interface ErrorAlertProps {
   // Spacing works out best when you use Material UI Typography components or p tags.
   messages?: JSX.Element[]
   tryAgain?: () => void
+  title?: string
   icon?: JSX.Element
+  embedded?: boolean
 }
 
 export default function ErrorAlert (props: ErrorAlertProps): JSX.Element {
   const classes = useStyles()
+
+  const { messages, tryAgain, title, icon, embedded } = props
+
   const defaultMessage = <Typography>Something went wrong. Please try again later.</Typography>
-  const preface = (
-    <>
-    <Typography gutterBottom>One or more errors occurred.</Typography>
-    <Typography gutterBottom>If possible, fix the issue(s), and/or try again.</Typography>
-    </>
-  )
-
-  const { messages, tryAgain, icon } = props
-
+  const preface = <Typography gutterBottom>If possible, fix the issue(s), and/or try again.</Typography>
   const messageBlock = (messages === undefined || messages.length === 0)
     ? defaultMessage
     : messages.length === 1
@@ -36,7 +33,11 @@ export default function ErrorAlert (props: ErrorAlertProps): JSX.Element {
       : <ol>{messages.map((m, i) => <li key={i}>{m}</li>)}</ol>
 
   return (
-    <Alert icon={icon !== undefined ? icon : <ErrorIcon className={classes.dialogIcon} fontSize='large' />}>
+    <Alert
+      title={title !== undefined ? title : 'Some errors occurred'}
+      icon={icon !== undefined ? icon : <ErrorIcon className={classes.dialogIcon} fontSize='large' />}
+      embedded={embedded}
+    >
       {Boolean(messages?.length) && preface}
       {messageBlock}
       {tryAgain !== undefined && <Button color='primary' onClick={props.tryAgain}>Try Again</Button>}

--- a/ccm_web/client/src/components/ExampleFileDownloadHeader.tsx
+++ b/ccm_web/client/src/components/ExampleFileDownloadHeader.tsx
@@ -1,35 +1,36 @@
 import React from 'react'
 import { makeStyles, Typography } from '@material-ui/core'
+
 import StaticContentDownloadLink from './StaticContentDownloadLink'
 
-interface ExampleFileDownloadHeaderProps {
-  bodyText: string
-  fileData: string
-  fileName: string
-  linkText: string
-  titleText: string
-}
-
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   uploadHeader: {
-    paddingTop: 15
+    marginTop: 15,
+    marginBottom: 15
   }
 }))
 
+interface ExampleFileDownloadHeaderProps {
+  body: JSX.Element
+  description?: string
+  fileData: string
+  fileName: string
+}
+
 function ExampleFileDownloadHeader (props: ExampleFileDownloadHeaderProps): JSX.Element {
   const classes = useStyles()
+  const { body, description, fileData, fileName } = props
 
-  const renderUploadHeader = (): JSX.Element => {
-    const fileData = props.fileData
-    return <div className={classes.uploadHeader}>
-      <Typography variant='h6'>{props.titleText}</Typography>
+  return (
+    <div className={classes.uploadHeader}>
+      <Typography variant='h6'component='h2'>Upload your CSV file</Typography>
+      {description !== undefined && <Typography>{props.description}</Typography>}
       <br/>
-      <Typography><strong>Requirement(s):</strong> {props.bodyText}</Typography>
-      <StaticContentDownloadLink data={fileData} fileName={props.fileName} linkText={props.linkText}/>
+      <Typography><strong>Requirement(s):</strong></Typography>
+      {body}
+      <StaticContentDownloadLink data={fileData} fileName={fileName} linkText='Download an example' />
     </div>
-  }
-
-  return (renderUploadHeader())
+  )
 }
 
 export type { ExampleFileDownloadHeaderProps }

--- a/ccm_web/client/src/components/ExampleFileDownloadHeader.tsx
+++ b/ccm_web/client/src/components/ExampleFileDownloadHeader.tsx
@@ -23,7 +23,7 @@ function ExampleFileDownloadHeader (props: ExampleFileDownloadHeaderProps): JSX.
 
   return (
     <div className={classes.uploadHeader}>
-      <Typography variant='h6'component='h2'>Upload your CSV file</Typography>
+      <Typography variant='h6' component='h2'>Upload your CSV file</Typography>
       {description !== undefined && <Typography>{props.description}</Typography>}
       <br/>
       <Typography><strong>Requirement(s):</strong></Typography>

--- a/ccm_web/client/src/components/RowLevelErrorsContent.tsx
+++ b/ccm_web/client/src/components/RowLevelErrorsContent.tsx
@@ -1,26 +1,17 @@
 import React from 'react'
-import { Button, Box, Grid, makeStyles, Paper, Typography } from '@material-ui/core'
-import { Error as ErrorIcon, Warning } from '@material-ui/icons'
+import { Box, Grid, makeStyles, Typography } from '@material-ui/core'
+
+import ErrorAlert from './ErrorAlert'
 
 const useStyles = makeStyles((theme) => ({
   padding: {
     padding: theme.spacing(1)
-  },
-  dialog: {
-    textAlign: 'center'
-  },
-  errorIcon: {
-    color: '#3F648E'
-  },
-  warningIcon: {
-    color: '#E2CF2A'
   }
 }))
 
 interface RowLevelErrorsContentProps {
   table: JSX.Element
   title: string
-  errorType: 'error' | 'warning'
   resetUpload: () => void
   message?: JSX.Element
 }
@@ -29,7 +20,7 @@ function RowLevelErrorsContent (props: RowLevelErrorsContentProps): JSX.Element 
   const classes = useStyles()
   const defaultMessage = (
     <Typography>
-      Create a new file with corrected versions of these lines and try again.
+      Create a new file with corrected versions of these lines, and try again.
     </Typography>
   )
 
@@ -39,17 +30,13 @@ function RowLevelErrorsContent (props: RowLevelErrorsContentProps): JSX.Element 
         <Grid item xs={12} sm={8} className={classes.padding}>{props.table}</Grid>
       </Box>
       <Box clone order={{ xs: 1, sm: 2 }}>
-        <Grid item xs={12} sm={4} className={`${classes.dialog} ${classes.padding}`}>
-          <Paper className={classes.padding} role='alert'>
-            <Typography>{props.title}</Typography>
-            {
-              props.errorType === 'error'
-                ? <ErrorIcon className={classes.errorIcon} fontSize='large'/>
-                : <Warning className={classes.warningIcon} fontSize='large'/>
-            }
-            {props.message !== undefined ? props.message : defaultMessage}
-            <Button color='primary' component='span' onClick={props.resetUpload}>Upload again</Button>
-          </Paper>
+        <Grid item xs={12} sm={4}>
+          <ErrorAlert
+            title={props.title}
+            messages={[props.message !== undefined ? props.message : defaultMessage]}
+            tryAgain={props.resetUpload}
+            embedded={true}
+          />
         </Grid>
       </Box>
     </Grid>

--- a/ccm_web/client/src/components/RowLevelErrorsContent.tsx
+++ b/ccm_web/client/src/components/RowLevelErrorsContent.tsx
@@ -18,11 +18,7 @@ interface RowLevelErrorsContentProps {
 
 function RowLevelErrorsContent (props: RowLevelErrorsContentProps): JSX.Element {
   const classes = useStyles()
-  const defaultMessage = (
-    <Typography>
-      Create a new file with corrected versions of these lines, and try again.
-    </Typography>
-  )
+  const defaultMessage = <Typography>Create a new file with corrected versions of these rows.</Typography>
 
   return (
     <Grid container justify='flex-start'>

--- a/ccm_web/client/src/components/SuccessCard.tsx
+++ b/ccm_web/client/src/components/SuccessCard.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles(() => ({
 
 interface SuccessCardProps {
   message: JSX.Element
-  nextAction: JSX.Element
+  nextAction?: JSX.Element
 }
 
 export default function SuccessCard (props: SuccessCardProps): JSX.Element {
@@ -34,7 +34,10 @@ export default function SuccessCard (props: SuccessCardProps): JSX.Element {
         <CheckCircle className={classes.icon} fontSize='large'/>
         {props.message}
       </CardContent>
-      <CardActions className={classes.cardFooter}>{props.nextAction}</CardActions>
+      {
+        props.nextAction !== undefined &&
+          <CardActions className={classes.cardFooter}>{props.nextAction}</CardActions>
+      }
     </Card>
   )
 }

--- a/ccm_web/client/src/components/ThirdPartyGradebookConfirmationTable.tsx
+++ b/ccm_web/client/src/components/ThirdPartyGradebookConfirmationTable.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react'
+import CustomTable from './CustomTable'
+
+interface NumberedSlimGradebookRecord {
+  rowNumber: number
+  'Student Name': string
+  'SIS Login ID': string
+}
+
+interface ThirdPartyGradebookConfirmationTableProps {
+  records: NumberedSlimGradebookRecord[]
+}
+
+interface TableHeaderColumnInfoShouldUseMatUIType {
+  id: keyof NumberedSlimGradebookRecord
+  label: string
+  minWidth: number
+  align?: 'left' | 'right' | undefined
+}
+
+const columns: TableHeaderColumnInfoShouldUseMatUIType[] = [
+  { id: 'rowNumber', label: 'New Row Number', minWidth: 25 },
+  { id: 'Student Name', label: 'Student Name', minWidth: 50 },
+  { id: 'SIS Login ID', label: 'SIS Login ID', minWidth: 100 }
+]
+
+function ThirdPartyGradebookConfirmationTable (props: ThirdPartyGradebookConfirmationTableProps): JSX.Element {
+  const [page, setPage] = useState<number>(0)
+
+  const tableRows = props.records.sort((a, b) => (a.rowNumber < b.rowNumber ? -1 : 1))
+  return <CustomTable<NumberedSlimGradebookRecord> {...{ tableRows, columns, page, setPage }} />
+}
+
+export default ThirdPartyGradebookConfirmationTable

--- a/ccm_web/client/src/components/ThirdPartyGradebookConfirmationTable.tsx
+++ b/ccm_web/client/src/components/ThirdPartyGradebookConfirmationTable.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
+
 import CustomTable from './CustomTable'
+import { REQUIRED_LOGIN_ID_HEADER } from '../utils/ThirdPartyGradebookProcessor'
 
 interface NumberedSlimGradebookRecord extends Record<string, string | number | undefined> {
   rowNumber: number
@@ -21,7 +23,7 @@ interface TableHeaderColumnInfoShouldUseMatUIType {
 function ThirdPartyGradebookConfirmationTable (props: ThirdPartyGradebookConfirmationTableProps): JSX.Element {
   const columns: TableHeaderColumnInfoShouldUseMatUIType[] = [
     { id: 'rowNumber', label: 'New Row Number', minWidth: 25 },
-    { id: 'SIS Login ID', label: 'SIS Login ID', minWidth: 100 },
+    { id: REQUIRED_LOGIN_ID_HEADER, label: REQUIRED_LOGIN_ID_HEADER, minWidth: 100 },
     { id: props.assignmentHeader, label: props.assignmentHeader, minWidth: 100 }
   ]
 

--- a/ccm_web/client/src/components/ThirdPartyGradebookConfirmationTable.tsx
+++ b/ccm_web/client/src/components/ThirdPartyGradebookConfirmationTable.tsx
@@ -22,7 +22,7 @@ interface TableHeaderColumnInfoShouldUseMatUIType {
 
 function ThirdPartyGradebookConfirmationTable (props: ThirdPartyGradebookConfirmationTableProps): JSX.Element {
   const columns: TableHeaderColumnInfoShouldUseMatUIType[] = [
-    { id: 'rowNumber', label: 'New Row Number', minWidth: 25 },
+    { id: 'rowNumber', label: 'Row Number', minWidth: 25 },
     { id: REQUIRED_LOGIN_ID_HEADER, label: REQUIRED_LOGIN_ID_HEADER, minWidth: 100 },
     { id: props.assignmentHeader, label: props.assignmentHeader, minWidth: 100 }
   ]

--- a/ccm_web/client/src/components/ThirdPartyGradebookConfirmationTable.tsx
+++ b/ccm_web/client/src/components/ThirdPartyGradebookConfirmationTable.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react'
 import CustomTable from './CustomTable'
 
-interface NumberedSlimGradebookRecord {
+interface NumberedSlimGradebookRecord extends Record<string, string | number | undefined> {
   rowNumber: number
-  'Student Name': string
   'SIS Login ID': string
 }
 
 interface ThirdPartyGradebookConfirmationTableProps {
   records: NumberedSlimGradebookRecord[]
+  assignmentHeader: string
 }
 
 interface TableHeaderColumnInfoShouldUseMatUIType {
@@ -18,13 +18,13 @@ interface TableHeaderColumnInfoShouldUseMatUIType {
   align?: 'left' | 'right' | undefined
 }
 
-const columns: TableHeaderColumnInfoShouldUseMatUIType[] = [
-  { id: 'rowNumber', label: 'New Row Number', minWidth: 25 },
-  { id: 'Student Name', label: 'Student Name', minWidth: 50 },
-  { id: 'SIS Login ID', label: 'SIS Login ID', minWidth: 100 }
-]
-
 function ThirdPartyGradebookConfirmationTable (props: ThirdPartyGradebookConfirmationTableProps): JSX.Element {
+  const columns: TableHeaderColumnInfoShouldUseMatUIType[] = [
+    { id: 'rowNumber', label: 'New Row Number', minWidth: 25 },
+    { id: 'SIS Login ID', label: 'SIS Login ID', minWidth: 100 },
+    { id: props.assignmentHeader, label: props.assignmentHeader, minWidth: 100 }
+  ]
+
   const [page, setPage] = useState<number>(0)
 
   const tableRows = props.records.sort((a, b) => (a.rowNumber < b.rowNumber ? -1 : 1))

--- a/ccm_web/client/src/components/WarningAlert.tsx
+++ b/ccm_web/client/src/components/WarningAlert.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Button, makeStyles, Typography } from '@material-ui/core'
+import ErrorIcon from '@material-ui/icons/Error'
+
+import Alert from './Alert'
+
+const useStyles = makeStyles(() => ({
+  dialogIcon: {
+    color: '#E2CF2A'
+  },
+  dialogButton: {
+    margin: 5
+  }
+}))
+
+interface WarningAlertProps {
+  // Spacing works out best when you use Material UI Typography components or p tags.
+  messages: JSX.Element[]
+  cancel: () => void
+  cont: () => void
+  icon?: JSX.Element
+}
+
+export default function ErrorAlert (props: WarningAlertProps): JSX.Element {
+  const classes = useStyles()
+  const preface = (
+    <Typography gutterBottom>One or more warnings occurred.</Typography>
+  )
+
+  const { messages, cancel, cont, icon } = props
+
+  const messageBlock = messages.length === 1
+    ? messages[0]
+    : <ol>{messages.map((m, i) => <li key={i}>{m}</li>)}</ol>
+
+  return (
+    <Alert icon={icon !== undefined ? icon : <ErrorIcon className={classes.dialogIcon} fontSize='large' />}>
+      {Boolean(messages?.length) && preface}
+      {messageBlock}
+      <Button className={classes.dialogButton} color='primary' variant='outlined' onClick={cancel}>Cancel</Button>
+      <Button className={classes.dialogButton} color='primary' variant='contained' onClick={cont}>Continue</Button>
+    </Alert>
+  )
+}

--- a/ccm_web/client/src/components/WarningAlert.tsx
+++ b/ccm_web/client/src/components/WarningAlert.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, makeStyles, Typography } from '@material-ui/core'
+import { Button, makeStyles } from '@material-ui/core'
 import ErrorIcon from '@material-ui/icons/Error'
 
 import Alert from './Alert'
@@ -18,24 +18,25 @@ interface WarningAlertProps {
   messages: JSX.Element[]
   cancel: () => void
   cont: () => void
+  title?: string
   icon?: JSX.Element
+  embedded?: boolean
 }
 
 export default function ErrorAlert (props: WarningAlertProps): JSX.Element {
   const classes = useStyles()
-  const preface = (
-    <Typography gutterBottom>One or more warnings occurred.</Typography>
-  )
-
-  const { messages, cancel, cont, icon } = props
+  const { messages, cancel, cont, title, icon, embedded } = props
 
   const messageBlock = messages.length === 1
     ? messages[0]
     : <ol>{messages.map((m, i) => <li key={i}>{m}</li>)}</ol>
 
   return (
-    <Alert icon={icon !== undefined ? icon : <ErrorIcon className={classes.dialogIcon} fontSize='large' />}>
-      {Boolean(messages?.length) && preface}
+    <Alert
+      title={title !== undefined ? title : 'Some warnings occurred'}
+      icon={icon !== undefined ? icon : <ErrorIcon className={classes.dialogIcon} fontSize='large' />}
+      embedded={embedded}
+    >
       {messageBlock}
       <Button className={classes.dialogButton} color='primary' variant='outlined' onClick={cancel}>Cancel</Button>
       <Button className={classes.dialogButton} color='primary' variant='contained' onClick={cont}>Continue</Button>

--- a/ccm_web/client/src/models/FeatureUIData.tsx
+++ b/ccm_web/client/src/models/FeatureUIData.tsx
@@ -6,11 +6,15 @@ import PersonAddIcon from '@material-ui/icons/PersonAdd'
 import PersonAddOutlinedIcon from '@material-ui/icons/PersonAddOutlined'
 import PostAddOutlinedIcon from '@material-ui/icons/PostAddOutlined'
 
-import { FeatureDataProps, mergeSectionProps, canvasGradebookFormatterProps, ExternalToolsGradebookFormatterProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps } from './feature'
+import {
+  FeatureDataProps, mergeSectionProps, canvasGradebookFormatterProps, externalToolsGradebookFormatterProps,
+  createSectionsProps, addUMUsersProps, addNonUMUsersProps
+} from './feature'
+import AddUMUsers from '../pages/AddUMUsers'
+import BulkSectionCreate from '../pages/BulkSectionCreate'
+import FormatThirdPartyGradebook from '../pages/FormatThirdPartyGradebook'
 import ConvertCanvasGradebook from '../pages/GradebookCanvas'
 import MergeSections from '../pages/MergeSections'
-import BulkSectionCreate from '../pages/BulkSectionCreate'
-import AddUMUsers from '../pages/AddUMUsers'
 import { Globals, RoleEnum } from './models'
 import { CanvasCourseBase } from './canvas'
 
@@ -34,6 +38,8 @@ interface FeatureUIProps {
   route: string
 }
 
+const NotYetImplementedComponent = (): JSX.Element => <p>This feature has not been implemented yet.</p>
+
 const mergeSectionCardProps: FeatureUIProps = {
   data: mergeSectionProps,
   icon: <MergeTypeIcon fontSize='large' />,
@@ -48,10 +54,10 @@ const canvasGradebookFormatterCardProps: FeatureUIProps = {
   route: '/gradebook-canvas'
 }
 
-const ExternalToolsGradebookFormatterCardProps: FeatureUIProps = {
-  data: ExternalToolsGradebookFormatterProps,
+const externalToolsGradebookFormatterCardProps: FeatureUIProps = {
+  data: externalToolsGradebookFormatterProps,
   icon: <PostAddOutlinedIcon fontSize='large' />,
-  component: MergeSections,
+  component: FormatThirdPartyGradebook,
   route: '/gradebook-thirdparty'
 }
 
@@ -72,12 +78,12 @@ const addUMUsersCardProps: FeatureUIProps = {
 const addNonUMUsersCardProps: FeatureUIProps = {
   data: addNonUMUsersProps,
   icon: <PersonAddOutlinedIcon fontSize='large' />,
-  component: MergeSections,
+  component: NotYetImplementedComponent,
   route: '/add-non-um-users'
 }
 
 const allFeatures: FeatureUIGroup[] = [
-  { id: 'GradebookTools', title: 'Gradebook Tools', ordinality: 1, features: [canvasGradebookFormatterCardProps, ExternalToolsGradebookFormatterCardProps] },
+  { id: 'GradebookTools', title: 'Gradebook Tools', ordinality: 1, features: [canvasGradebookFormatterCardProps, externalToolsGradebookFormatterCardProps] },
   { id: 'Users', title: 'Users', ordinality: 2, features: [addUMUsersCardProps, addNonUMUsersCardProps] },
   { id: 'Sections', title: 'Sections', ordinality: 3, features: [mergeSectionCardProps, createSectionsCardProps] }
 ]

--- a/ccm_web/client/src/models/canvas.ts
+++ b/ccm_web/client/src/models/canvas.ts
@@ -77,7 +77,6 @@ export interface CanvasEnrollment {
   course_section_id: number
   user_id: number
   type: CanvasRoleType
-  user: { login_id: string }
 }
 
 const clientToCanvasRoleMap: Record<ClientRoleType, CanvasRoleType> = {

--- a/ccm_web/client/src/models/canvas.ts
+++ b/ccm_web/client/src/models/canvas.ts
@@ -77,6 +77,7 @@ export interface CanvasEnrollment {
   course_section_id: number
   user_id: number
   type: CanvasRoleType
+  user: { login_id: string }
 }
 
 const clientToCanvasRoleMap: Record<ClientRoleType, CanvasRoleType> = {

--- a/ccm_web/client/src/models/feature.ts
+++ b/ccm_web/client/src/models/feature.ts
@@ -27,7 +27,7 @@ const canvasGradebookFormatterProps: FeatureDataProps = {
   helpURLEnding: '/gradebook-canvas.html'
 }
 
-const ExternalToolsGradebookFormatterProps: FeatureDataProps = {
+const externalToolsGradebookFormatterProps: FeatureDataProps = {
   id: 'ExternalToolsGradebookFormatter',
   title: 'External Tools Gradebook Formatter',
   description: 'Formats a CSV file exported from an external tool for importing grades into the Canvas Gradebook.',
@@ -66,4 +66,7 @@ const addNonUMUsersProps: FeatureDataProps = {
 const courseRenameRoles: RoleEnum[] = [RoleEnum['Account Admin'], RoleEnum['Subaccount admin'], RoleEnum['Support Consultant']]
 
 export type { FeatureDataProps }
-export { mergeSectionProps, canvasGradebookFormatterProps, ExternalToolsGradebookFormatterProps, createSectionsProps, addUMUsersProps, addNonUMUsersProps, courseRenameRoles }
+export {
+  mergeSectionProps, canvasGradebookFormatterProps, externalToolsGradebookFormatterProps,
+  createSectionsProps, addUMUsersProps, addNonUMUsersProps, courseRenameRoles
+}

--- a/ccm_web/client/src/models/feature.ts
+++ b/ccm_web/client/src/models/feature.ts
@@ -23,7 +23,7 @@ const canvasGradebookFormatterProps: FeatureDataProps = {
   title: 'Canvas Gradebook Formatter',
   description: 'Formats the exported Canvas Gradebook CSV file for uploading into Faculty Center\'s Grade Roster.',
   ordinality: 2,
-  roles: [RoleEnum.Teacher, RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant']],
+  roles: [RoleEnum.Teacher, RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant'], RoleEnum.TA],
   helpURLEnding: '/gradebook-canvas.html'
 }
 
@@ -32,7 +32,7 @@ const externalToolsGradebookFormatterProps: FeatureDataProps = {
   title: 'External Tools Gradebook Formatter',
   description: 'Formats a CSV file exported from an external tool for importing grades into the Canvas Gradebook.',
   ordinality: 3,
-  roles: [RoleEnum.Teacher, RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant']],
+  roles: [RoleEnum.Teacher, RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant'], RoleEnum.TA],
   helpURLEnding: '/gradebook-thirdparty.html'
 }
 

--- a/ccm_web/client/src/models/models.ts
+++ b/ccm_web/client/src/models/models.ts
@@ -82,3 +82,10 @@ export enum InvalidationType {
   Error,
   Warning
 }
+
+// Files
+
+export interface DownloadData {
+  data: string
+  fileName: string
+}

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -386,7 +386,6 @@ designer,userd`
       <RowLevelErrorsContent
         table={<ValidationErrorTable invalidations={errors} />}
         title='Review your CSV file'
-        errorType='error'
         resetUpload={handleUploadReset}
       />
       </>
@@ -417,7 +416,6 @@ designer,userd`
             <RowLevelErrorsContent
               table={<CanvasAPIErrorsTable errors={error.errors} />}
               title='Some errors occurred'
-              errorType='error'
               resetUpload={handleUploadReset}
             />
             </>

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -1,14 +1,15 @@
 import {
-  Backdrop, Box, Button, CircularProgress, createStyles, Grid, Link, makeStyles, Paper, Step, StepLabel,
+  Backdrop, Box, Button, CircularProgress, createStyles, Grid, Link, makeStyles, Step, StepLabel,
   Stepper, Theme, Tooltip, Typography
 } from '@material-ui/core'
 import React, { useEffect, useState } from 'react'
-import { CloudDone as CloudDoneIcon, HelpOutline as HelpIcon } from '@material-ui/icons'
+import { HelpOutline as HelpIcon } from '@material-ui/icons'
 
 import { addSectionEnrollments, getCourseSections } from '../api'
 import ErrorAlert from '../components/ErrorAlert'
 import BulkEnrollUMUserConfirmationTable, { IAddUMUserEnrollment } from '../components/BulkEnrollUMUserConfirmationTable'
 import CanvasAPIErrorsTable from '../components/CanvasAPIErrorsTable'
+import ConfirmDialog from '../components/ConfirmDialog'
 import CreateSectionWidget from '../components/CreateSectionWidget'
 import CSVFileName from '../components/CSVFileName'
 import ExampleFileDownloadHeader, { ExampleFileDownloadHeaderProps } from '../components/ExampleFileDownloadHeader'
@@ -76,21 +77,9 @@ const useStyles = makeStyles((theme: Theme) =>
       zIndex: 0,
       textAlign: 'center'
     },
-    dialog: {
-      textAlign: 'center',
-      marginBottom: 15,
-      paddingLeft: 10,
-      paddingRight: 10
-    },
-    dialogButton: {
-      margin: 5
-    },
     table: {
       paddingLeft: 10,
       paddingRight: 10
-    },
-    dialogIcon: {
-      color: '#3F648E'
     },
     newSectionHint: {
       display: 'flex'
@@ -364,20 +353,12 @@ designer,userd`
             </Grid>
           </Box>
           <Box clone order={{ xs: 1, sm: 2 }}>
-            <Grid item xs={12} sm={3} className={classes.dialog}>
-              <Paper role='status'>
-                <Typography>Review your CSV file</Typography>
-                <CloudDoneIcon className={classes.dialogIcon} fontSize='large'/>
-                <Typography>Your file is valid!  If this looks correct, click &quot;Submit&quot; to proceed.</Typography>
-                <Button className={classes.dialogButton} variant='outlined' onClick={handleUploadReset}>Cancel</Button>
-                <Button
-                  className={classes.dialogButton}
-                  variant='outlined'
-                  onClick={async () => await doAddEnrollments(section, enrollments)}
-                >
-                  Submit
-                </Button>
-              </Paper>
+            <Grid item xs={12} sm={3}>
+              <ConfirmDialog
+                submit={async () => await doAddEnrollments(section, enrollments)}
+                cancel={handleUploadReset}
+                disabled={isAddEnrollmentsLoading}
+              />
             </Grid>
           </Box>
         </Grid>

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -414,6 +414,7 @@ designer,userd`
             <RowLevelErrorsContent
               table={<CanvasAPIErrorsTable errors={error.errors} />}
               title='Some errors occurred'
+              message={<Typography>Some of your entries received errors when being added to Canvas.</Typography>}
               resetUpload={handleUploadReset}
             />
             </>

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -305,17 +305,16 @@ ta,userb
 observer,userc
 designer,userd`
     const fileDownloadHeaderProps: ExampleFileDownloadHeaderProps = {
-      bodyText: (
-        `Your file should include a ${USER_ID_TEXT.toLocaleLowerCase()} ` +
-        `and a ${USER_ROLE_TEXT.toLocaleLowerCase()} for each user. ` +
-        MAX_ENROLLMENT_MESSAGE
+      body: (
+        <Typography>
+          Your file should include a {USER_ID_TEXT.toLocaleLowerCase()} and
+          a {USER_ROLE_TEXT.toLocaleLowerCase()} for each user. {MAX_ENROLLMENT_MESSAGE}
+        </Typography>
       ),
-      fileData: fileData,
-      fileName: 'bulk_um_enroll.csv',
-      linkText: 'Download an example',
-      titleText: 'Upload your CSV File'
+      fileData,
+      fileName: 'bulk_um_enroll.csv'
     }
-    return (<ExampleFileDownloadHeader {...fileDownloadHeaderProps} />)
+    return <ExampleFileDownloadHeader {...fileDownloadHeaderProps} />
   }
 
   const uploadComplete = (file: File): void => {
@@ -334,11 +333,10 @@ designer,userd`
 
   const getUploadContent = (): JSX.Element => {
     return (
-    <div>
-      {renderUploadHeader()}
-      <br/>
-      {renderFileUpload()}
-    </div>
+      <div>
+        {renderUploadHeader()}
+        {renderFileUpload()}
+      </div>
     )
   }
 

--- a/ccm_web/client/src/pages/BulkSectionCreate.tsx
+++ b/ccm_web/client/src/pages/BulkSectionCreate.tsx
@@ -339,6 +339,7 @@ Section 001`
             <RowLevelErrorsContent
               table={<CanvasAPIErrorsTable errors={error.errors} />}
               title='Some errors occurred'
+              message={<Typography>Some of your entries received errors when being added to Canvas.</Typography>}
               resetUpload={resetPageState}
             />
             </>

--- a/ccm_web/client/src/pages/BulkSectionCreate.tsx
+++ b/ccm_web/client/src/pages/BulkSectionCreate.tsx
@@ -245,13 +245,11 @@ function BulkSectionCreate (props: CCMComponentProps): JSX.Element {
 `SECTION_NAME
 Section 001`
     const fileDownloadHeaderProps: ExampleFileDownloadHeaderProps = {
-      bodyText: 'Your file should include one section name per line',
+      body: <Typography>Your file should include one section name per line.</Typography>,
       fileData: fileData,
-      fileName: 'sections.csv',
-      linkText: 'Download an example',
-      titleText: 'Upload your CSV File'
+      fileName: 'sections.csv'
     }
-    return (<ExampleFileDownloadHeader {...fileDownloadHeaderProps} />)
+    return <ExampleFileDownloadHeader {...fileDownloadHeaderProps} />
   }
 
   const renderLoadingText = (): JSX.Element | undefined => {
@@ -283,11 +281,12 @@ Section 001`
   }
 
   const renderUpload = (): JSX.Element => {
-    return <div>
-      {renderUploadHeader()}
-      <br/>
-      {renderFileUpload()}
-    </div>
+    return (
+      <div>
+        {renderUploadHeader()}
+        {renderFileUpload()}
+      </div>
+    )
   }
 
   const renderTopLevelErrors = (errors: JSX.Element[]): JSX.Element => {

--- a/ccm_web/client/src/pages/BulkSectionCreate.tsx
+++ b/ccm_web/client/src/pages/BulkSectionCreate.tsx
@@ -310,7 +310,6 @@ Section 001`
           table={<ValidationErrorTable invalidations={pageState.rowInvalidations} />}
           resetUpload={resetPageState}
           title='Review your CSV file'
-          errorType='error'
         />
         </>
       )
@@ -341,7 +340,6 @@ Section 001`
             <RowLevelErrorsContent
               table={<CanvasAPIErrorsTable errors={error.errors} />}
               title='Some errors occurred'
-              errorType='error'
               resetUpload={resetPageState}
             />
             </>

--- a/ccm_web/client/src/pages/BulkSectionCreate.tsx
+++ b/ccm_web/client/src/pages/BulkSectionCreate.tsx
@@ -1,8 +1,5 @@
-import {
-  Backdrop, Box, Button, CircularProgress, Grid, Link, makeStyles, Paper, Typography
-} from '@material-ui/core'
-import { CloudDone as CloudDoneIcon } from '@material-ui/icons'
 import React, { useEffect, useState } from 'react'
+import { Backdrop, Box, CircularProgress, Grid, Link, makeStyles, Typography } from '@material-ui/core'
 
 import { addCourseSections, getCourseSections } from '../api'
 import ErrorAlert from '../components/ErrorAlert'
@@ -12,6 +9,7 @@ import {
   SectionRowsValidator, SectionsRowInvalidation
 } from '../components/BulkSectionCreateValidators'
 import CanvasAPIErrorsTable from '../components/CanvasAPIErrorsTable'
+import ConfirmDialog from '../components/ConfirmDialog'
 import CSVFileName from '../components/CSVFileName'
 import ExampleFileDownloadHeader, { ExampleFileDownloadHeaderProps } from '../components/ExampleFileDownloadHeader'
 import FileUpload from '../components/FileUpload'
@@ -56,22 +54,10 @@ const useStyles = makeStyles((theme) => ({
   },
   paper: {
     padding: theme.spacing(1)
-  }
-}))
-
-const useConfirmationStyles = makeStyles((theme) => ({
-  dialog: {
-    textAlign: 'center',
-    marginBottom: 15,
-    paddingLeft: 10,
-    paddingRight: 10
   },
   table: {
     paddingLeft: 10,
     paddingRight: 10
-  },
-  dialogIcon: {
-    color: '#3F648E'
   }
 }))
 
@@ -101,7 +87,6 @@ interface BulkSectionCreatePageStateData {
 
 function BulkSectionCreate (props: CCMComponentProps): JSX.Element {
   const classes = useStyles()
-  const confirmationClasses = useConfirmationStyles()
 
   const [pageState, setPageState] = useState<BulkSectionCreatePageStateData>(
     { state: BulkSectionCreatePageState.UploadPending, schemaInvalidations: [], rowInvalidations: [] }
@@ -371,19 +356,13 @@ Section 001`
         {file !== undefined && <CSVFileName file={file} />}
         <Grid container>
           <Box clone order={{ xs: 2, sm: 1 }}>
-            <Grid item xs={12} sm={9} className={confirmationClasses.table}>
+            <Grid item xs={12} sm={9} className={classes.table}>
               <BulkSectionCreateUploadConfirmationTable sectionNames={sectionNames} />
             </Grid>
           </Box>
           <Box clone order={{ xs: 1, sm: 2 }}>
-            <Grid item xs={12} sm={3} className={confirmationClasses.dialog}>
-              <Paper role='status'>
-                <Typography>Review your CSV file</Typography>
-                <CloudDoneIcon className={confirmationClasses.dialogIcon} fontSize='large'/>
-                <Typography>Your file is valid!  If this looks correct, click &quot;Submit&quot; to proceed.</Typography>
-                <Button variant="outlined" onClick={(e) => resetPageState()}>Cancel</Button>
-                <Button variant="outlined" disabled={isSubmitting()} onClick={submit}>Submit</Button>
-              </Paper>
+            <Grid item xs={12} sm={3}>
+              <ConfirmDialog submit={submit} cancel={resetPageState} disabled={isSubmitting()} />
             </Grid>
           </Box>
         </Grid>

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -55,6 +55,9 @@ const useStyles = makeStyles((theme) => ({
   reviewContainer: {
     textAlign: 'center'
   },
+  reviewNotes: {
+    textAlign: 'left'
+  },
   backdrop: {
     zIndex: theme.zIndex.drawer + 1,
     color: '#FFF',
@@ -371,17 +374,19 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
         <Grid container>
           <Box clone order={{ xs: 2, sm: 2, md: 1, lg: 1 }}>
             <Grid item xs={12} sm={12} md={9} className={classes.table}>
+              <Typography gutterBottom className={classes.reviewNotes}>
+                Notes: The first row shown below is the &quot;{POINTS_POS_TEXT}&quot; row.
+                In addition to the &quot;{REQUIRED_LOGIN_ID_HEADER}&quot; and assignment columns,
+                the downloaded file will include other columns in a specific order
+                to make it compatible with the Canvas upload process.
+              </Typography>
               <ThirdPartyGradebookConfirmationTable records={recordsToReview} assignmentHeader={assignmentHeader} />
             </Grid>
           </Box>
           <Box clone order={{ xs: 1, sm: 1, md: 2, lg: 2 }}>
             <Grid item xs={12} sm={12} md={3}>
               <ConfirmDialog
-                message={(
-                  'Your file is valid! If this looks correct, click "Submit" to proceed with downloading. ' +
-                  'Note that the downloaded file will order the columns ' +
-                  'and add empty ones to satisfy Canvas requirements.'
-                )}
+                message='Your file is valid! If this looks correct, click "Submit" to proceed with downloading.'
                 submit={() => setActiveStep(FormatGradebookStep.Confirmation)}
                 cancel={() => {
                   handleResetUpload()

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -15,8 +15,8 @@ import ThirdPartyGradebookConfirmationTable from '../components/ThirdPartyGradeb
 import WarningAlert from '../components/WarningAlert'
 import usePromise from '../hooks/usePromise'
 import { CanvasCourseSection, injectCourseName } from '../models/canvas'
-import { InvalidationType } from '../models/models'
 import { CCMComponentProps } from '../models/FeatureUIData'
+import { InvalidationType } from '../models/models'
 import CSVSchemaValidator, { SchemaInvalidation } from '../utils/CSVSchemaValidator'
 import FileParserWrapper, { CSVRecord } from '../utils/FileParserWrapper'
 import ThirdPartyGradebookProcessor, {
@@ -324,7 +324,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
         </li>
         <li>
           <Typography>
-            Your file must include records for at least one student in the selected section
+            Your file must include records for at least one student in the selected sections
             (students are identified using the &quot;{REQUIRED_LOGIN_ID_HEADER}&quot; value).
           </Typography>
         </li>
@@ -362,7 +362,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
   const renderReview = (
     processedRecords: GradebookUploadRecord[], assignmentHeader: string, file: File
   ): JSX.Element => {
-    const recordsToReview = (processedRecords).map((r, i) => ({ rowNumber: i + 2, ...r }))
+    const recordsToReview = processedRecords.map((r, i) => ({ rowNumber: i + 2, ...r }))
     const dataToDownload = 'data:text/csv;charset=utf-8,' + csvParser.createCSV({
       fields: [...REQUIRED_ORDERED_HEADERS, assignmentHeader],
       data: processedRecords

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles((theme) => ({
   uploadContainer: {
     textAlign: 'center'
   },
-  confirmContainer: {
+  reviewContainer: {
     textAlign: 'center'
   },
   backdrop: {
@@ -339,7 +339,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
     })
 
     return (
-      <div className={classes.confirmContainer}>
+      <div className={classes.reviewContainer}>
         {file !== undefined && <CSVFileName file={file} />}
         <Grid container>
           <Box clone order={{ xs: 2, sm: 2, md: 1, lg: 1 }}>

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -7,6 +7,7 @@ import * as api from '../api'
 import ConfirmDialog from '../components/ConfirmDialog'
 import CSVFileName from '../components/CSVFileName'
 import ErrorAlert from '../components/ErrorAlert'
+import ExampleFileDownloadHeader from '../components/ExampleFileDownloadHeader'
 import FileUpload from '../components/FileUpload'
 import SectionSelectorWidget, { SelectableCanvasCourseSection } from '../components/SectionSelectorWidget'
 import SuccessCard from '../components/SuccessCard'
@@ -282,41 +283,53 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
       return renderGradebookInvalidations(gradebookInvalidations)
     }
 
+    const description = (
+      'This tool creates a new version of the uploaded file so it only includes students in the selected sections' +
+      'and is formatted appropriately for uploading to Canvas.'
+    )
     const gradeUploadDocsLink = 'https://community.canvaslms.com/t5/Instructor-Guide/tkb-p/Instructor#Grades'
+    const requirements = (
+      <ol>
+        <li>
+          <Typography>
+            The file includes a &quot;{REQUIRED_LOGIN_ID_HEADER}&quot; column (the Canvas equivalent of Uniqname)
+            and one other column of scores, with the column&apos;s header being the name of a new assignment.
+            Other columns required by Canvas
+            (see the <Link href={gradeUploadDocsLink} target='_blank' rel='noopener'>help docs</Link>)
+            are allowed but not required.
+          </Typography>
+        </li>
+        <li>
+          <Typography>
+            The first non-header row is a &quot;Points Possible&quot; row, meaning that the value in the new
+            assignment column will be the maximum points possible for that assignment
+            and that &quot;Points Possible&quot; is present in another cell in the row
+            (such as the row&apos;s cell for &quot;{REQUIRED_LOGIN_ID_HEADER}&quot;).
+          </Typography>
+        </li>
+        <li>
+          <Typography>
+            Your file must include records for at least one student in the selected section
+            (students are identified using the &quot;{REQUIRED_LOGIN_ID_HEADER}&quot; value).
+          </Typography>
+        </li>
+      </ol>
+    )
+    const fileData = (
+      'SIS Login ID,Example Assignment\n' +
+      'Points Possible,100\n' +
+      'studentone,80\n' +
+      'studenttwo,90\n'
+    )
+
     return (
       <div>
-        <Typography variant='h6' component='h2'>Upload your CSV File</Typography>
-        <Typography>
-          This tool creates a new version of the uploaded file so it only includes students in the selected section
-          and is formatted appropriately for uploading to Canvas.
-        </Typography>
-        <br/>
-        <Typography><strong>Requirements</strong></Typography>
-        <ol>
-          <li>
-            <Typography>
-              The file includes a &quot;{REQUIRED_LOGIN_ID_HEADER}&quot; column (the Canvas equivalent of Uniqname)
-              and one other column of scores, with the column&apos;s header being the name of a new assignment.
-              Other columns required by Canvas
-              (see the <Link href={gradeUploadDocsLink} target='_blank' rel='noopener'>help docs</Link>)
-              are allowed but not required.
-            </Typography>
-          </li>
-          <li>
-            <Typography>
-              The first non-header row is a &quot;Points Possible&quot; row, meaning that the value in the new
-              assignment column will be the maximum points possible for that assignment
-              and that &quot;Points Possible&quot; is present in another cell in the row
-              (such as the row&apos;s cell for &quot;{REQUIRED_LOGIN_ID_HEADER}&quot;).
-            </Typography>
-          </li>
-          <li>
-            <Typography>
-              Your file must include records for at least one student in the selected section
-              (students are identified using the &quot;{REQUIRED_LOGIN_ID_HEADER}&quot; value).
-            </Typography>
-          </li>
-        </ol>
+        <ExampleFileDownloadHeader
+          description={description}
+          body={requirements}
+          fileName='third_party_gradebook.csv'
+          fileData={fileData}
+        />
         <div className={classes.uploadContainer}>
           <Grid container>
             <Grid item xs={12}>

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -294,7 +294,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
     }
 
     const description = (
-      'This tool creates a new version of the uploaded file so it only includes students in the selected sections' +
+      'This tool creates a new version of the uploaded file so it only includes students in the selected sections ' +
       'and is formatted appropriately for uploading to Canvas.'
     )
     const gradeUploadDocsLink = 'https://community.canvaslms.com/t5/Instructor-Guide/tkb-p/Instructor#Grades'

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -388,7 +388,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
                   setActiveStep(FormatGradebookStep.Upload)
                 }}
                 download={{
-                  fileName: createOutputFileName(file, '-puff'),
+                  fileName: createOutputFileName(file.name, '-puff'),
                   data: dataToDownload
                 }}
               />

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -19,10 +19,10 @@ import { InvalidationType } from '../models/models'
 import { CCMComponentProps } from '../models/FeatureUIData'
 import CSVSchemaValidator, { SchemaInvalidation } from '../utils/CSVSchemaValidator'
 import FileParserWrapper, { CSVRecord } from '../utils/FileParserWrapper'
-import GradebookProcessor, {
-  GradebookInvalidation, GradebookUploadRecord, isGradebookUploadRecord, REQUIRED_LOGIN_ID_HEADER,
-  REQUIRED_ORDERED_HEADERS
-} from '../utils/GradebookProcessor'
+import ThirdPartyGradebookProcessor, {
+  GradebookInvalidation, GradebookUploadRecord, isGradebookUploadRecord, POINTS_POS_TEXT,
+  REQUIRED_LOGIN_ID_HEADER, REQUIRED_ORDERED_HEADERS
+} from '../utils/ThirdPartyGradebookProcessor'
 import { createOutputFileName } from '../utils/fileUtils'
 
 const useStyles = makeStyles((theme) => ({
@@ -147,7 +147,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
 
   useEffect(() => {
     if (studentLoginIds !== undefined && records !== undefined) {
-      const processor = new GradebookProcessor(studentLoginIds)
+      const processor = new ThirdPartyGradebookProcessor(studentLoginIds)
       const result = processor.process(records)
       if (result.valid) {
         setProcessedRecords(result.processedRecords)
@@ -313,9 +313,9 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
         </li>
         <li>
           <Typography>
-            The first non-header row is a &quot;Points Possible&quot; row, meaning that the value in the new
+            The first non-header row is a &quot;{POINTS_POS_TEXT}&quot; row, meaning that the value in the new
             assignment column will be the maximum points possible for that assignment
-            and that &quot;Points Possible&quot; is present in another cell in the row
+            and that &quot;{POINTS_POS_TEXT}&quot; is present in another cell in the row
             (such as the row&apos;s cell for &quot;{REQUIRED_LOGIN_ID_HEADER}&quot;).
           </Typography>
         </li>
@@ -328,8 +328,8 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
       </ol>
     )
     const fileData = (
-      'SIS Login ID,Example Assignment\n' +
-      'Points Possible,100\n' +
+      `${REQUIRED_LOGIN_ID_HEADER},Example Assignment\n` +
+      `${POINTS_POS_TEXT},100\n` +
       'studentone,80\n' +
       'studenttwo,90\n'
     )

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -1,0 +1,298 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Button, Backdrop, CircularProgress, Grid, Link, makeStyles, Step, StepLabel, Stepper, Typography
+} from '@material-ui/core'
+
+import * as api from '../api'
+import ErrorAlert from '../components/ErrorAlert'
+import FileUpload from '../components/FileUpload'
+import SectionSelectorWidget, { SelectableCanvasCourseSection } from '../components/SectionSelectorWidget'
+import usePromise from '../hooks/usePromise'
+import { CanvasCourseSection, injectCourseName } from '../models/canvas'
+import { InvalidationType } from '../models/models'
+import { CCMComponentProps } from '../models/FeatureUIData'
+import CSVSchemaValidator, { SchemaInvalidation } from '../utils/CSVSchemaValidator'
+import FileParserWrapper, { CSVRecord } from '../utils/FileParserWrapper'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: 25,
+    textAlign: 'left'
+  },
+  buttonGroup: {
+    marginTop: theme.spacing(1)
+  },
+  backButton: {
+    marginRight: theme.spacing(1)
+  },
+  stepper: {
+    textAlign: 'center',
+    paddingTop: '20px'
+  },
+  selectContainer: {
+    position: 'relative',
+    zIndex: 0,
+    textAlign: 'center'
+  },
+  uploadContainer: {
+    position: 'relative',
+    zIndex: 0,
+    textAlign: 'center'
+  },
+  backdrop: {
+    zIndex: theme.zIndex.drawer + 1,
+    color: '#FFF',
+    position: 'absolute'
+  }
+}))
+
+interface CanvasUploadRecord extends CSVRecord {
+  'Student Name': string
+  'Student ID': string
+  'SIS User ID': string
+  'SIS Login ID': string
+  'Section': string
+}
+const requiredHeaders = ['Student Name', 'Student ID', 'SIS User ID', 'SIS Login ID', 'Section']
+
+const isCanvasUploadRecord = (record: CSVRecord): record is CanvasUploadRecord => {
+  return requiredHeaders.every(rh => typeof record[rh] === 'string')
+}
+
+enum FormatGradebookStep {
+  Select = 0,
+  Upload = 1,
+  Review = 2,
+  Confirmation = 3
+}
+
+interface FormatThirdPartyGradebookProps extends CCMComponentProps {}
+
+export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradebookProps): JSX.Element {
+  const classes = useStyles()
+
+  const [activeStep, setActiveStep] = useState<FormatGradebookStep>(FormatGradebookStep.Select)
+  const [sections, setSections] = useState<SelectableCanvasCourseSection[] | undefined>(undefined)
+  const [selectedSection, setSelectedSection] = useState<SelectableCanvasCourseSection | undefined>(undefined)
+  const [studentLoginIds, setStudentLoginIds] = useState<string[] | undefined>(undefined)
+  const [file, setFile] = useState<File | undefined>(undefined)
+  const [uploadRecords, setUploadRecords] = useState<CanvasUploadRecord[] | undefined>(undefined)
+
+  const [schemaInvalidations, setSchemaInvalidations] = useState<SchemaInvalidation[] | undefined>(undefined)
+
+  const [doGetSections, isGetSectionsLoading, getSectionsError, clearGetSectionsError] = usePromise(
+    async () => await api.getCourseSections(props.globals.course.id),
+    (sections: CanvasCourseSection[]) => setSections(injectCourseName(sections, props.course.name))
+  )
+
+  const [doGetStudents, isGetStudentsLoading, getStudentsError, clearGetStudentsError] = usePromise(
+    async (sectionId: number) => await api.getStudentsEnrolledInSection(sectionId),
+    (studentLoginIds: string[]) => setStudentLoginIds(studentLoginIds)
+  )
+
+  useEffect(() => {
+    void doGetSections()
+  }, [])
+
+  const handleValidation = (headers: string[] | undefined, rowData: CSVRecord[]): void => {
+    const schemaValidator = new CSVSchemaValidator<CanvasUploadRecord>(requiredHeaders, isCanvasUploadRecord)
+    const validationResult = schemaValidator.validate(headers, rowData)
+    if (!validationResult.valid) return setSchemaInvalidations(validationResult.schemaInvalidations)
+    return setUploadRecords(validationResult.validData)
+  }
+
+  const parseFile = (file: File): void => {
+    const csvParser = new FileParserWrapper(
+      Object.assign(FileParserWrapper.defaultParseConfigOptions, { transformHeader: undefined })
+    )
+    csvParser.parseCSV(
+      file,
+      handleValidation,
+      message => setSchemaInvalidations([{ message, type: InvalidationType.Error }])
+    )
+  }
+
+  useEffect(() => {
+    if (file !== undefined) {
+      parseFile(file)
+    }
+  }, [file])
+
+  useEffect(() => {
+    if (selectedSection !== undefined && uploadRecords !== undefined) {
+      void doGetStudents(selectedSection.id)
+    }
+  }, [uploadRecords])
+
+  useEffect(() => {
+    if (uploadRecords !== undefined && studentLoginIds !== undefined) {
+      setActiveStep(FormatGradebookStep.Review)
+    }
+  }, [uploadRecords, studentLoginIds])
+
+  // console.log('uploadRecords')
+  // console.log(uploadRecords)
+
+  // console.log('studentLoginIds')
+  // console.log(studentLoginIds)
+
+  const handleResetUpload = (): void => {
+    setFile(undefined)
+    clearGetStudentsError()
+    setSchemaInvalidations(undefined)
+  }
+
+  const handleNext = (): void => setActiveStep((prevStep) => {
+    if (prevStep < FormatGradebookStep.Confirmation) return prevStep + 1
+    return prevStep
+  })
+
+  const handleBack = (): void => setActiveStep((prevStep) => {
+    if (prevStep > FormatGradebookStep.Select) return prevStep - 1
+    return prevStep
+  })
+
+  const backButton = <Button className={classes.backButton} onClick={handleBack}>Back</Button>
+
+  const renderSchemaInvalidations = (invalidations: SchemaInvalidation[]): JSX.Element => {
+    const messages = invalidations.map(
+      (invalidation, i) => <Typography key={i}>{invalidation.message}</Typography>
+    )
+    return <ErrorAlert messages={messages} tryAgain={handleResetUpload}/>
+  }
+
+  const renderAPIError = (error: Error): JSX.Element => {
+    const message = <Typography key={0}>{error.message}</Typography>
+    return <ErrorAlert messages={[message]} tryAgain={handleResetUpload} />
+  }
+
+  const renderSelect = (): JSX.Element => {
+    if (getSectionsError !== undefined) {
+      return (
+        <ErrorAlert
+          messages={[<Typography key={0}>An error occurred while loading section data from Canvas.</Typography>]}
+          tryAgain={clearGetSectionsError}
+        />
+      )
+    }
+
+    return (
+      <div>
+        <Typography align='left'>Select one section you want to collect grades from your CSV for.</Typography>
+        <div className={classes.selectContainer}>
+          <SectionSelectorWidget
+            height={300}
+            search={[]}
+            multiSelect={false}
+            sections={sections !== undefined ? sections : []}
+            selectedSections={selectedSection !== undefined ? [selectedSection] : []}
+            selectionUpdated={(sections) => setSelectedSection(sections[0])}
+            canUnmerge={false}
+          />
+          <Grid container justify='flex-end' className={classes.buttonGroup}>
+            <Button
+              color='primary'
+              variant='contained'
+              disabled={selectedSection === undefined}
+              aria-label='Select section'
+              onClick={handleNext}
+            >
+              Select
+            </Button>
+          </Grid>
+          <Backdrop className={classes.backdrop} open={isGetSectionsLoading}>
+            <Grid container>
+              <Grid item xs={12}>
+                <CircularProgress color='inherit' />
+              </Grid>
+              <Grid item xs={12}>
+                Loading sections
+              </Grid>
+            </Grid>
+          </Backdrop>
+        </div>
+      </div>
+    )
+  }
+
+  const renderUpload = (): JSX.Element => {
+    if (schemaInvalidations !== undefined) {
+      return renderSchemaInvalidations(schemaInvalidations)
+    } else if (getStudentsError !== undefined) {
+      return renderAPIError(getStudentsError)
+    }
+
+    const gradeUploadDocsLink = 'https://community.canvaslms.com/t5/Instructor-Guide/tkb-p/Instructor#Grades'
+    return (
+      <div>
+        <Typography variant='h6'>Upload your CSV File</Typography>
+        <Typography>
+          This tool creates a new version of the uploaded file so it only includes students in the selected section.
+        </Typography>
+        <Typography><strong>Requirements</strong></Typography>
+        <ol>
+          <li>
+            <Typography>
+              The file includes the necessary columns and a &quot;Points Possible&quot;
+              row <Link href={gradeUploadDocsLink} target='_blank' rel='noopener'>as required by Canvas.</Link>
+              The following headers are required (case sensitive): {requiredHeaders.map(rh => `"${rh}"`).join(', ')}
+            </Typography>
+          </li>
+          <li>
+            <Typography>
+              Your file must include records for at least one student in the selected section
+              (students are identified using the SIS Login ID value).
+            </Typography>
+          </li>
+        </ol>
+        <div className={classes.uploadContainer}>
+          <Grid container>
+            <Grid item xs={12}>
+              <FileUpload onUploadComplete={(file) => setFile(file)} />
+            </Grid>
+          </Grid>
+          <Grid container justify='flex-end' className={classes.buttonGroup}>
+            {backButton}
+          </Grid>
+          <Backdrop className={classes.backdrop} open={isGetStudentsLoading}>
+            <Grid container>
+              <Grid item xs={12}>
+                <CircularProgress color='inherit' />
+              </Grid>
+              <Grid item xs={12}>
+                Loading info about students enrolled in the section
+              </Grid>
+            </Grid>
+          </Backdrop>
+        </div>
+      </div>
+    )
+  }
+
+  const renderStep = (step: FormatGradebookStep): JSX.Element => {
+    switch (step) {
+      case FormatGradebookStep.Select:
+        return renderSelect()
+      case FormatGradebookStep.Upload:
+        return renderUpload()
+      case FormatGradebookStep.Review:
+        return <p>Review table will go here.</p>
+      default:
+        return <div>?</div>
+    }
+  }
+
+  return (
+    <div className={classes.root}>
+      <Typography variant='h5' component='h1'>Convert a Third-Party Gradebook</Typography>
+      <Stepper className={classes.stepper} activeStep={activeStep} alternativeLabel>
+        {
+          Object.entries(FormatGradebookStep)
+            .filter(([key]) => isNaN(Number(key)))
+            .map(([key, value]) => <Step key={value}><StepLabel>{key}</StepLabel></Step>)
+        }
+      </Stepper>
+      <div>{renderStep(activeStep)}</div>
+    </div>
+  )
+}

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -222,7 +222,14 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
     if (getSectionsError !== undefined || getStudentsError !== undefined) {
       return (
         <ErrorAlert
-          messages={[<Typography key={0}>An error occurred while loading section data from Canvas.</Typography>]}
+          messages={[
+            <Typography key={0}>
+              An error occurred while loading
+              {getSectionsError !== undefined && ' section '}
+              {getStudentsError !== undefined && ' student '}
+              data from Canvas.
+            </Typography>
+          ]}
           tryAgain={handleResetSelect}
         />
       )
@@ -255,7 +262,10 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
                 <CircularProgress color='inherit' />
               </Grid>
               <Grid item xs={12}>
-                Loading section data from Canvas
+                Loading
+                {isGetSectionsLoading && ' section '}
+                {isGetStudentsLoading && ' student '}
+                data from Canvas
               </Grid>
             </Grid>
           </Backdrop>
@@ -344,7 +354,9 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
     )
   }
 
-  const renderReview = (processedRecords: GradebookUploadRecord[], assignmentHeader: string, file: File): JSX.Element => {
+  const renderReview = (
+    processedRecords: GradebookUploadRecord[], assignmentHeader: string, file: File
+  ): JSX.Element => {
     const recordsToReview = (processedRecords).map((r, i) => ({ rowNumber: i + 2, ...r }))
     const dataToDownload = 'data:text/csv;charset=utf-8,' + csvParser.createCSV({
       fields: [...REQUIRED_ORDERED_HEADERS, assignmentHeader],

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -78,7 +78,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
   const classes = useStyles()
 
   const csvParser = new FileParserWrapper(
-    Object.assign(FileParserWrapper.defaultParseConfigOptions, { transformHeader: undefined })
+    Object.assign({ ...FileParserWrapper.defaultParseConfigOptions }, { transformHeader: undefined })
   )
 
   const [activeStep, setActiveStep] = useState<FormatGradebookStep>(FormatGradebookStep.Select)

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -161,14 +161,16 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
   }, [records])
 
   const handleResetSelect = (): void => {
+    setSections(undefined)
     clearGetSectionsError()
     setSelectedSections(undefined)
+    setStudentLoginIds(undefined)
     clearGetStudentsError()
   }
 
   const handleResetUpload = (): void => {
     setFile(undefined)
-    clearGetStudentsError()
+    setRecords(undefined)
     setSchemaInvalidations(undefined)
     setProcessedRecords(undefined)
     setGradebookInvalidations(undefined)
@@ -278,7 +280,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
             aria-label='Select section'
             onClick={handleSelectClick}
           >
-            Select {selectedSections !== undefined ? `(${selectedSections.length})` : ''}
+            Select{selectedSections !== undefined ? ` (${selectedSections.length})` : ''}
           </Button>
         </Grid>
       </div>
@@ -365,7 +367,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
 
     return (
       <div className={classes.reviewContainer}>
-        {file !== undefined && <CSVFileName file={file} />}
+        <CSVFileName file={file} />
         <Grid container>
           <Box clone order={{ xs: 2, sm: 2, md: 1, lg: 1 }}>
             <Grid item xs={12} sm={12} md={9} className={classes.table}>

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -107,10 +107,10 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
   )
 
   useEffect(() => {
-    if (getSectionsError === undefined) {
+    if (sections === undefined) {
       void doGetSections()
     }
-  }, [getSectionsError])
+  }, [sections, getSectionsError])
 
   useEffect(() => {
     if (studentLoginIds !== undefined) {

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -264,7 +264,7 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
     const warningIcon = <WarningIcon className={confirmationClasses.dialogWarningIcon} fontSize='large' />
     const warningText = (
       "Some assignment grades may be missing, but you've supplied an override grade. " +
-      'If you wish to continue with the download, click "Submit"'
+      'If you wish to continue with the download, click "Submit".'
     )
 
     return (

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -189,7 +189,7 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
 
   const renderUploadHeader = (): JSX.Element => {
     return <div className={classes.uploadHeader}>
-      <Typography variant='h6'>Upload your CSV File</Typography>
+      <Typography variant='h6' component='h2'>Upload your CSV File</Typography>
       <Typography>This tool reformats an exported Canvas gradebook file for upload to Faculty Center.</Typography>
       <br/>
       <Typography><strong>Requirements</strong></Typography>

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -13,9 +13,10 @@ import GradebookUploadConfirmationTable, { StudentGrade } from '../components/Gr
 import { CurrentAndFinalGradeMatchGradebookValidator, GradebookRowInvalidation } from '../components/GradebookCanvasValidators'
 import { canvasGradebookFormatterProps } from '../models/feature'
 import { CCMComponentProps } from '../models/FeatureUIData'
-import { InvalidationType } from '../models/models'
+import { DownloadData, InvalidationType } from '../models/models'
 import CSVSchemaValidator, { SchemaInvalidation } from '../utils/CSVSchemaValidator'
 import FileParserWrapper, { CSVRecord } from '../utils/FileParserWrapper'
+import { createOutputFileName } from '../utils/fileUtils'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -80,11 +81,6 @@ enum GradebookCanvasPageState {
   Done
 }
 
-interface DownloadData {
-  data: string
-  fileName: string
-}
-
 const convertEmptyCellToUndefined = (cell: string | undefined): string | undefined => {
   if (cell !== undefined && cell.trim().length === 0) return undefined
   return cell
@@ -124,12 +120,10 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
     setPageState({ state: GradebookCanvasPageState.Upload })
   }
 
+  // Would be nice to rework this so we know file is defined
   const getOutputFilename = (file: File | undefined): string => {
     if (file === undefined) return ''
-    const splitName = file.name.split('.')
-    const filenameIndex = splitName.length >= 2 ? splitName.length - 2 : 0
-    splitName[filenameIndex] = splitName[filenameIndex] + '-geff'
-    return splitName.join('.')
+    return createOutputFileName(file, '-geff')
   }
 
   const getGradeForExport = (record: GradebookRecord): string => {

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react'
-import { Box, Button, Grid, Link, makeStyles, Paper, Typography } from '@material-ui/core'
-import CloudDoneIcon from '@material-ui/icons/CloudDone'
+import { Box, Grid, Link, makeStyles, Typography } from '@material-ui/core'
 import WarningIcon from '@material-ui/icons/Warning'
 
+import ConfirmDialog from '../components/ConfirmDialog'
 import CSVFileName from '../components/CSVFileName'
 import ErrorAlert from '../components/ErrorAlert'
 import FileUpload from '../components/FileUpload'
@@ -32,21 +32,12 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 const useConfirmationStyles = makeStyles((theme) => ({
-  dialog: {
-    textAlign: 'center',
-    marginBottom: 15,
-    paddingLeft: 10,
-    paddingRight: 10
-  },
   table: {
     paddingLeft: 10,
     paddingRight: 10
   },
-  dialogIcon: {
-    color: '#3F648E'
-  },
   dialogWarningIcon: {
-    color: '#e2cf2a'
+    color: '#E2CF2A'
   }
 }))
 
@@ -270,23 +261,13 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
     }
   }
 
-  const renderConfirmIcon = (isWarning: boolean): JSX.Element => {
-    if (isWarning) {
-      return (<WarningIcon className={confirmationClasses.dialogWarningIcon} fontSize='large'/>)
-    } else {
-      return (<CloudDoneIcon className={confirmationClasses.dialogIcon} fontSize='large'/>)
-    }
-  }
-
-  const renderConfirmText = (isWarning: boolean): JSX.Element => {
-    if (isWarning) {
-      return (<Typography>Some assignment grades may be missing, but you’ve supplied an override grade. Continue?</Typography>)
-    } else {
-      return (<Typography>File validation successful.</Typography>)
-    }
-  }
-
   const renderConfirm = (grades: StudentGrade[], overideGradeMismatchWarning: boolean): JSX.Element => {
+    const warningIcon = <WarningIcon className={confirmationClasses.dialogWarningIcon} fontSize='large'/>
+    const warningText = (
+      "Some assignment grades may be missing, but you've supplied an override grade. " +
+      'If you wish to continue with the download, click "Submit"'
+    )
+
     return (
       <div>
         {file !== undefined && <CSVFileName file={file} />}
@@ -297,15 +278,14 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
             </Grid>
           </Box>
           <Box clone order={{ xs: 1, sm: 2 }}>
-            <Grid item xs={12} sm={3} className={confirmationClasses.dialog}>
-              <Paper role='status'>
-                {renderConfirmIcon(overideGradeMismatchWarning)}
-                {renderConfirmText(overideGradeMismatchWarning)}
-                <Button variant="outlined" onClick={(e) => resetPageState()}>Cancel</Button>
-                <Link href={downloadData?.data} download={downloadData?.fileName}>
-                  <Button disabled={downloadData === undefined} variant='outlined' color='primary'>Download</Button>
-                </Link>
-              </Paper>
+            <Grid item xs={12} sm={3}>
+              <ConfirmDialog
+                message={overideGradeMismatchWarning ? warningText : undefined}
+                icon={overideGradeMismatchWarning ? warningIcon : undefined}
+                cancel={resetPageState}
+                submit={() => undefined}
+                download={downloadData}
+              />
             </Grid>
           </Box>
         </Grid>

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -114,7 +114,7 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
   // Would be nice to rework this so we know file is defined
   const getOutputFilename = (file: File | undefined): string => {
     if (file === undefined) return ''
-    return createOutputFileName(file, '-geff')
+    return createOutputFileName(file.name, '-geff')
   }
 
   const getGradeForExport = (record: GradebookRecord): string => {

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -227,8 +227,7 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
         {file !== undefined && <CSVFileName file={file} />}
         <RowLevelErrorsContent
           table={<ValidationErrorTable invalidations={invalidations} />}
-          title='Some errors occurred'
-          errorType='error'
+          title='Review your CSV file'
           message={(
             <Typography>
               There are likely blank cells in the course&apos;s gradebook.
@@ -262,7 +261,7 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
   }
 
   const renderConfirm = (grades: StudentGrade[], overideGradeMismatchWarning: boolean): JSX.Element => {
-    const warningIcon = <WarningIcon className={confirmationClasses.dialogWarningIcon} fontSize='large'/>
+    const warningIcon = <WarningIcon className={confirmationClasses.dialogWarningIcon} fontSize='large' />
     const warningText = (
       "Some assignment grades may be missing, but you've supplied an override grade. " +
       'If you wish to continue with the download, click "Submit"'

--- a/ccm_web/client/src/utils/FileParserWrapper.ts
+++ b/ccm_web/client/src/utils/FileParserWrapper.ts
@@ -19,16 +19,16 @@ export default class FileParserWrapper {
   parseConfig?: Papa.ParseConfig
   unparseConfig?: Papa.UnparseConfig
 
-  static defaultParseConfigOptions: Papa.ParseConfig = {
+  static readonly defaultParseConfigOptions: Papa.ParseConfig = Object.freeze({
     header: true,
     transform: value => value.trim(),
     transformHeader: header => header.toUpperCase()
-  }
+  })
 
   constructor (parseConfig?: Papa.ParseConfig, unparseConfig?: Papa.UnparseConfig) {
     this.parseConfig = parseConfig !== undefined
       ? parseConfig
-      : FileParserWrapper.defaultParseConfigOptions
+      : { ...FileParserWrapper.defaultParseConfigOptions }
     this.unparseConfig = unparseConfig !== undefined ? unparseConfig : undefined
   }
 

--- a/ccm_web/client/src/utils/FileParserWrapper.ts
+++ b/ccm_web/client/src/utils/FileParserWrapper.ts
@@ -47,7 +47,7 @@ export default class FileParserWrapper {
     )
   }
 
-  createCSV (data: Array<Record<string, unknown>> | string[][]): string {
+  createCSV (data: Array<Record<string, unknown>> | string[][] | Papa.UnparseObject): string {
     return Papa.unparse(data, this.unparseConfig)
   }
 }

--- a/ccm_web/client/src/utils/GradebookProcessor.tsx
+++ b/ccm_web/client/src/utils/GradebookProcessor.tsx
@@ -1,0 +1,141 @@
+import { CSVRecord } from '../utils/FileParserWrapper'
+import { InvalidationType } from '../models/models'
+
+export interface GradebookUploadRecord extends CSVRecord {
+  'SIS Login ID': string
+}
+
+export const REQUIRED_LOGIN_ID_HEADER = 'SIS Login ID'
+const OTHER_REQUIRED_HEADERS = ['Student Name', 'Student ID', 'SIS User ID', 'Section']
+export const REQUIRED_ORDERED_HEADERS = [
+  ...OTHER_REQUIRED_HEADERS.slice(0, 3), REQUIRED_LOGIN_ID_HEADER, OTHER_REQUIRED_HEADERS[3]
+]
+
+export const isGradebookUploadRecord = (record: CSVRecord): record is GradebookUploadRecord => {
+  return typeof record['SIS Login ID'] === 'string'
+}
+
+export interface GradebookInvalidation {
+  message: string
+  type: InvalidationType
+}
+
+interface ProcessResultSuccess {
+  valid: true
+  processedRecords: GradebookUploadRecord[]
+  assignmentHeader: string
+  invalidations: GradebookInvalidation[]
+}
+
+interface ProcessResultFailure {
+  valid: false
+  invalidations: GradebookInvalidation[]
+}
+
+export type ProcessResult = ProcessResultSuccess | ProcessResultFailure
+
+export default class GradebookProcessor {
+  studentLoginIds: string[]
+
+  constructor (studentLoginIds: string[]) {
+    this.studentLoginIds = studentLoginIds
+  }
+
+  static detectPointsPossible (firstRecord: GradebookUploadRecord): GradebookInvalidation | undefined {
+    if (!Object.values(firstRecord).includes('Points Possible')) {
+      return {
+        message: 'The file you uploaded is missing a Points Possible row.',
+        type: InvalidationType.Error
+      }
+    }
+  }
+
+  static detectAssignment (oneRecord: GradebookUploadRecord): [string, undefined] | [undefined, GradebookInvalidation] {
+    const otherKeys = Object.keys(oneRecord).filter(k => !REQUIRED_ORDERED_HEADERS.includes(k))
+    if (otherKeys.length === 1) return [otherKeys[0], undefined]
+    let message: string | undefined
+    if (otherKeys.length === 0) {
+      message = 'No assignment column was found.'
+    } else {
+      message = 'Multiple assignment columns were found; only one assignment column at a time is supported.'
+    }
+    return [undefined, { message, type: InvalidationType.Error }]
+  }
+
+  static addEmptyPropertyToData (data: GradebookUploadRecord[], newHeader: string): GradebookUploadRecord[] {
+    return data.map(r => {
+      const newObj = { ...r }
+      if (!Object.keys(newObj).includes(newHeader)) {
+        newObj[newHeader] = ''
+      }
+      return newObj
+    })
+  }
+
+  static addRequiredCanvasHeaders (records: GradebookUploadRecord[]): GradebookUploadRecord[] {
+    let updatedRecords = records
+    for (const header of OTHER_REQUIRED_HEADERS) {
+      updatedRecords = GradebookProcessor.addEmptyPropertyToData(updatedRecords, header)
+    }
+    return updatedRecords
+  }
+
+  process (uploadRecords: GradebookUploadRecord[]): ProcessResult {
+    const filteredRecords: GradebookUploadRecord[] = []
+    const studentsWithoutRecords: string[] = []
+    const invalidations: GradebookInvalidation[] = []
+
+    const pointsPossibleResult = GradebookProcessor.detectPointsPossible(uploadRecords[0])
+    if (pointsPossibleResult !== undefined) invalidations.push(pointsPossibleResult)
+
+    const [assignmentHeader, assignmentInvalidation] = GradebookProcessor.detectAssignment(uploadRecords[1])
+    if (assignmentInvalidation !== undefined) invalidations.push(assignmentInvalidation)
+    // Is there a better way to do this that doesn't require the assignmentHeader assertion?
+    if (invalidations.length > 0 || assignmentHeader === undefined) return { valid: false, invalidations }
+
+    const pointsPossibleRecord = uploadRecords[0]
+    const recordToFilter = uploadRecords.slice(1)
+
+    for (const loginId of this.studentLoginIds) {
+      const filterResult = recordToFilter.filter(r => r['SIS Login ID'] === loginId)
+      if (filterResult.length === 1) {
+        filteredRecords.push(filterResult[0])
+      } else if (filterResult.length > 1) {
+        invalidations.push({
+          message: `Student with SIS Login ID ${loginId} found multiple times in file.`,
+          type: InvalidationType.Error
+        })
+      } else {
+        studentsWithoutRecords.push(loginId)
+      }
+    }
+
+    if (studentsWithoutRecords.length > 0) {
+      invalidations.push({
+        message: (
+          'One or more students from the section you selected were not present in the provided file: ' +
+            studentsWithoutRecords.join(', ')
+        ),
+        type: InvalidationType.Warning
+      })
+    }
+    if (filteredRecords.length === 0) {
+      invalidations.push({
+        message: 'None of the students from the section you selected were present in the provided file.',
+        type: InvalidationType.Error
+      })
+    }
+
+    const errorCount = invalidations.filter(i => i.type === InvalidationType.Error).length
+    if (errorCount > 0) {
+      return { valid: false, invalidations }
+    }
+
+    const newRecords = GradebookProcessor.addRequiredCanvasHeaders([pointsPossibleRecord].concat(filteredRecords))
+    // Move Points Possible
+    newRecords[0][REQUIRED_LOGIN_ID_HEADER] = ''
+    newRecords[0][REQUIRED_ORDERED_HEADERS[0]] = 'Points Possible'
+
+    return { valid: true, processedRecords: newRecords, invalidations, assignmentHeader }
+  }
+}

--- a/ccm_web/client/src/utils/GradebookProcessor.tsx
+++ b/ccm_web/client/src/utils/GradebookProcessor.tsx
@@ -113,7 +113,7 @@ export default class GradebookProcessor {
     if (studentsWithoutRecords.length > 0) {
       invalidations.push({
         message: (
-          'One or more students from the section you selected were not present in the provided file: ' +
+          'One or more students from the section(s) you selected were not present in the provided file: ' +
             studentsWithoutRecords.join(', ')
         ),
         type: InvalidationType.Warning
@@ -121,7 +121,7 @@ export default class GradebookProcessor {
     }
     if (filteredRecords.length === 0) {
       invalidations.push({
-        message: 'None of the students from the section you selected were present in the provided file.',
+        message: 'None of the students from the section(s) you selected were present in the provided file.',
         type: InvalidationType.Error
       })
     }

--- a/ccm_web/client/src/utils/ThirdPartyGradebookProcessor.tsx
+++ b/ccm_web/client/src/utils/ThirdPartyGradebookProcessor.tsx
@@ -49,7 +49,7 @@ export default class ThirdPartyGradebookProcessor {
   static detectPointsPossible (firstRecord: GradebookUploadRecord): GradebookInvalidation | undefined {
     if (!Object.values(firstRecord).includes(POINTS_POS_TEXT)) {
       return {
-        message: `The file you uploaded is missing a ${POINTS_POS_TEXT} row.`,
+        message: `The file you uploaded is missing a "${POINTS_POS_TEXT}" row.`,
         type: InvalidationType.Error
       }
     }

--- a/ccm_web/client/src/utils/fileUtils.ts
+++ b/ccm_web/client/src/utils/fileUtils.ts
@@ -1,5 +1,13 @@
-function createOutputFileName (file: File, newfileEnding: string): string {
-  const splitName = file.name.split('.')
+/*
+Takes a file name and replaces the string segment without a period
+just before the file name extension with that segment plus a new provided ending.
+Examples:
+  createOutputFileName('old-file-name.csv', '-puff') returns 'old-file-name-puff.csv'
+  createOutputFileName('old-file-name', '-puff') returns 'old-file-name-puff
+  createOutputFileName('old.file.name.csv', '-puff') returns 'old.file.name-puff.csv'
+*/
+function createOutputFileName (oldFileName: string, newfileEnding: string): string {
+  const splitName = oldFileName.split('.')
   const filenameIndex = splitName.length >= 2 ? splitName.length - 2 : 0
   splitName[filenameIndex] = splitName[filenameIndex] + newfileEnding
   return splitName.join('.')

--- a/ccm_web/client/src/utils/fileUtils.ts
+++ b/ccm_web/client/src/utils/fileUtils.ts
@@ -1,0 +1,8 @@
+function createOutputFileName (file: File, newfileEnding: string): string {
+  const splitName = file.name.split('.')
+  const filenameIndex = splitName.length >= 2 ? splitName.length - 2 : 0
+  splitName[filenameIndex] = splitName[filenameIndex] + newfileEnding
+  return splitName.join('.')
+}
+
+export { createOutputFileName }

--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -73,8 +73,8 @@ export class APIController {
 
   @UseInterceptors(InvalidTokenInterceptor)
   @Get('sections/:id/students')
-  async getStudentEnrollments (@Param('id', ParseIntPipe) sectionId: number, @UserDec() user: User): Promise<CanvasEnrollment[]> {
-    const result = await this.apiService.getStudentEnrollments(user, sectionId)
+  async getStudentsEnrolledInSection (@Param('id', ParseIntPipe) sectionId: number, @UserDec() user: User): Promise<string[]> {
+    const result = await this.apiService.getStudentsEnrolledInSection(user, sectionId)
     if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
     return result
   }

--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -72,6 +72,14 @@ export class APIController {
   }
 
   @UseInterceptors(InvalidTokenInterceptor)
+  @Get('sections/:id/students')
+  async getStudentEnrollments (@Param('id', ParseIntPipe) sectionId: number, @UserDec() user: User): Promise<CanvasEnrollment[]> {
+    const result = await this.apiService.getStudentEnrollments(user, sectionId)
+    if (isAPIErrorData(result)) throw new HttpException(result, result.statusCode)
+    return result
+  }
+
+  @UseInterceptors(InvalidTokenInterceptor)
   @ApiSecurity('CSRF-Token')
   @Post('sections/:id/enroll')
   async enrollSectionUsers (@Param('id', ParseIntPipe) sectionId: number, @Body() sectionUsersData: SectionUsersDto, @UserDec() user: User): Promise<CanvasEnrollment[]> {

--- a/ccm_web/server/src/api/api.section.handler.ts
+++ b/ccm_web/server/src/api/api.section.handler.ts
@@ -3,7 +3,9 @@ import CanvasRequestor from '@kth/canvas-api'
 import { APIErrorData } from './api.interfaces'
 import { handleAPIError, HttpMethod, makeResponse } from './api.utils'
 import { SectionUserDto } from './dtos/api.section.users.dto'
-import { CanvasCourseSection, CanvasCourseSectionBase, CanvasEnrollment, UserEnrollmentType } from '../canvas/canvas.interfaces'
+import {
+  CanvasCourseSection, CanvasCourseSectionBase, CanvasEnrollment, CanvasEnrollmentWithUser, UserEnrollmentType
+} from '../canvas/canvas.interfaces'
 
 import baseLogger from '../logger'
 
@@ -36,7 +38,7 @@ export class SectionApiHandler {
     try {
       const endpoint = `sections/${this.sectionId}/enrollments`
       logger.debug(`Sending request to Canvas endpoint: "${endpoint}"; method: "${HttpMethod.Get}"`)
-      enrollmentsResult = await this.requestor.list<CanvasEnrollment>(endpoint, queryParams).toArray()
+      enrollmentsResult = await this.requestor.list<CanvasEnrollmentWithUser>(endpoint, queryParams).toArray()
       logger.debug('Received response (status code unknown)')
     } catch (error) {
       const errResponse = handleAPIError(error)
@@ -78,8 +80,7 @@ export class SectionApiHandler {
         course_id,
         course_section_id,
         user_id,
-        type,
-        user: { login_id: response.body.user.login_id }
+        type
       }
     } catch (error) {
       const errorResponse = handleAPIError(error, `Login ID: ${user.loginId}; Role: ${user.type}`)

--- a/ccm_web/server/src/api/api.section.handler.ts
+++ b/ccm_web/server/src/api/api.section.handler.ts
@@ -30,26 +30,19 @@ export class SectionApiHandler {
     }
   }
 
-  async getStudentEnrollments (): Promise<CanvasEnrollment[] | APIErrorData> {
+  async getStudentsEnrolled (): Promise<string[] | APIErrorData> {
     const queryParams = { type: [UserEnrollmentType.StudentEnrollment] }
-    let result
+    let enrollmentsResult
     try {
       const endpoint = `sections/${this.sectionId}/enrollments`
       logger.debug(`Sending request to Canvas endpoint: "${endpoint}"; method: "${HttpMethod.Get}"`)
-      result = await this.requestor.list<CanvasEnrollment>(endpoint, queryParams).toArray()
+      enrollmentsResult = await this.requestor.list<CanvasEnrollment>(endpoint, queryParams).toArray()
       logger.debug('Received response (status code unknown)')
     } catch (error) {
       const errResponse = handleAPIError(error)
       return { statusCode: errResponse.canvasStatusCode, errors: [errResponse] }
     }
-    return result.map(e => ({
-      id: e.id,
-      course_section_id: e.course_section_id,
-      course_id: e.course_id,
-      user_id: e.user_id,
-      user: { login_id: e.user.login_id },
-      type: e.type
-    }))
+    return enrollmentsResult.map(e => e.user.login_id)
   }
 
   async enrollUser (user: SectionUserDto): Promise<CanvasEnrollment | APIErrorData> {

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -103,10 +103,10 @@ export class APIService {
     return await courseHandler.createSections(sections)
   }
 
-  async getStudentEnrollments (user: User, sectionId: number): Promise<CanvasEnrollment[] | APIErrorData> {
+  async getStudentsEnrolledInSection (user: User, sectionId: number): Promise<string[] | APIErrorData> {
     const requestor = await this.canvasService.createRequestorForUser(user, '/api/v1/')
     const sectionHandler = new SectionApiHandler(requestor, sectionId)
-    return await sectionHandler.getStudentEnrollments()
+    return await sectionHandler.getStudentsEnrolled()
   }
 
   async enrollSectionUsers (user: User, sectionId: number, sectionUsers: SectionUserDto[]): Promise<CanvasEnrollment[] | APIErrorData> {

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -103,6 +103,12 @@ export class APIService {
     return await courseHandler.createSections(sections)
   }
 
+  async getStudentEnrollments (user: User, sectionId: number): Promise<CanvasEnrollment[] | APIErrorData> {
+    const requestor = await this.canvasService.createRequestorForUser(user, '/api/v1/')
+    const sectionHandler = new SectionApiHandler(requestor, sectionId)
+    return await sectionHandler.getStudentEnrollments()
+  }
+
   async enrollSectionUsers (user: User, sectionId: number, sectionUsers: SectionUserDto[]): Promise<CanvasEnrollment[] | APIErrorData> {
     const requestor = await this.canvasService.createRequestorForUser(user, '/api/v1/')
     const sectionHandler = new SectionApiHandler(requestor, sectionId)

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -80,6 +80,7 @@ export interface CanvasEnrollment {
   course_section_id: number
   user_id: number
   type: UserEnrollmentType
+  user: { login_id: string }
 }
 
 export interface CanvasAccount {

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -80,6 +80,9 @@ export interface CanvasEnrollment {
   course_section_id: number
   user_id: number
   type: UserEnrollmentType
+}
+
+export interface CanvasEnrollmentWithUser {
   user: { login_id: string }
 }
 

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -82,7 +82,7 @@ export interface CanvasEnrollment {
   type: UserEnrollmentType
 }
 
-export interface CanvasEnrollmentWithUser {
+export interface CanvasEnrollmentWithUser extends CanvasEnrollment {
   user: { login_id: string }
 }
 

--- a/ccm_web/server/src/canvas/canvas.scopes.ts
+++ b/ccm_web/server/src/canvas/canvas.scopes.ts
@@ -16,6 +16,7 @@ const canvasScopes = [
   'url:POST|/api/v1/sections/:id/crosslist/:new_course_id',
   'url:DELETE|/api/v1/sections/:id/crosslist',
   // Enrollments
+  'url:GET|/api/v1/sections/:section_id/enrollments',
   'url:POST|/api/v1/sections/:section_id/enrollments',
   // Accounts
   'url:GET|/api/v1/accounts',


### PR DESCRIPTION
This PR implements the third-party gradebook formatting feature, which involved changes to the server and client. The main UI file is `client/src/pages/FormatThirdPartyGradebook.tsx`, but some filtering and validation logic was off-loaded to `client/src/utils/GradebookProcessor.tsx`.

In addition, while implementing the UI, I refactored `ErrorAlert` so that it uses a base `Alert` so I could create a `WarningAlert` and `ErrorAlert` could be used in `RowLevelErrorsContent`; I created a `ConfirmDialog` component that allows for file downloads; and I changed the `ExampleFileDownloadHeader` component to fit multiple use cases. Other miscellaneous changes are included.

**Note to reviewers**: you will need to add a new scope to your Canvas configuration (if you are enforcing scopes) for "url:GET|/api/v1/sections/:section_id/enrollments".

The PR aims to resolve #21 and #229.

Tasks:
- [x] Allow multiple section selection
- [x] Reuse `ConfirmDialog`
- [x] Modify `Alert`, `WarningAlert`, and `ErrorAlert`, so `ErrorAlert` can be used in `RowLevelErrorsContent`
- [x] Provide example file download
- [x] Give more specific API error and loading messages
- [x] Review all code carefully