### PR TITLE
Add help link to "Format Third-Party Gradebook", tweak gradebook tools' language (#228, #233)

### DIFF
--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -86,9 +86,28 @@ function App (): JSX.Element {
             </Route>
           </div>
           <Switch>
-            <Route exact={true} path="/" render={() => (<Home globals={globals} course={course} setCourse={setCourse} getCourseError={getCourseError} />)} />
+            <Route
+              exact={true}
+              path='/'
+              render={() => (
+                <Home globals={globals} course={course} setCourse={setCourse} getCourseError={getCourseError} />
+              )}
+            />
             {features.map(feature => {
-              return <Route key={feature.data.id} path={feature.route} component={() => <feature.component globals={globals} course={course} helpURLEnding={feature.data.helpURLEnding} />}/>
+              return (
+                <Route
+                  key={feature.data.id}
+                  path={feature.route}
+                  component={() => (
+                    <feature.component
+                      globals={globals}
+                      course={course}
+                      title={feature.data.title}
+                      helpURLEnding={feature.data.helpURLEnding}
+                    />
+                  )}
+                />
+              )
             })}
             <Route render={() => (<div><em>Under Construction</em></div>)} />
           </Switch>

--- a/ccm_web/client/src/models/FeatureUIData.tsx
+++ b/ccm_web/client/src/models/FeatureUIData.tsx
@@ -7,7 +7,7 @@ import PersonAddOutlinedIcon from '@material-ui/icons/PersonAddOutlined'
 import PostAddOutlinedIcon from '@material-ui/icons/PostAddOutlined'
 
 import {
-  FeatureDataProps, mergeSectionProps, canvasGradebookFormatterProps, externalToolsGradebookFormatterProps,
+  FeatureDataProps, mergeSectionProps, formatCanvasGradebookProps, formatThirdPartyGradebookProps,
   createSectionsProps, addUMUsersProps, addNonUMUsersProps
 } from './feature'
 import AddUMUsers from '../pages/AddUMUsers'
@@ -21,6 +21,7 @@ import { CanvasCourseBase } from './canvas'
 export interface CCMComponentProps {
   globals: Globals
   course: CanvasCourseBase
+  title: string
   helpURLEnding: string
 }
 
@@ -47,15 +48,15 @@ const mergeSectionCardProps: FeatureUIProps = {
   route: '/merge-sections'
 }
 
-const canvasGradebookFormatterCardProps: FeatureUIProps = {
-  data: canvasGradebookFormatterProps,
+const formatCanvasGradebookCardProps: FeatureUIProps = {
+  data: formatCanvasGradebookProps,
   icon: <LibraryBooksOutlinedIcon fontSize='large' />,
   component: ConvertCanvasGradebook,
   route: '/gradebook-canvas'
 }
 
-const externalToolsGradebookFormatterCardProps: FeatureUIProps = {
-  data: externalToolsGradebookFormatterProps,
+const formatThirdPartyGradebookCardProps: FeatureUIProps = {
+  data: formatThirdPartyGradebookProps,
   icon: <PostAddOutlinedIcon fontSize='large' />,
   component: FormatThirdPartyGradebook,
   route: '/gradebook-thirdparty'
@@ -83,7 +84,7 @@ const addNonUMUsersCardProps: FeatureUIProps = {
 }
 
 const allFeatures: FeatureUIGroup[] = [
-  { id: 'GradebookTools', title: 'Gradebook Tools', ordinality: 1, features: [canvasGradebookFormatterCardProps, externalToolsGradebookFormatterCardProps] },
+  { id: 'GradebookTools', title: 'Gradebook Tools', ordinality: 1, features: [formatCanvasGradebookCardProps, formatThirdPartyGradebookCardProps] },
   { id: 'Users', title: 'Users', ordinality: 2, features: [addUMUsersCardProps, addNonUMUsersCardProps] },
   { id: 'Sections', title: 'Sections', ordinality: 3, features: [mergeSectionCardProps, createSectionsCardProps] }
 ]

--- a/ccm_web/client/src/models/feature.ts
+++ b/ccm_web/client/src/models/feature.ts
@@ -18,19 +18,19 @@ const mergeSectionProps: FeatureDataProps = {
   helpURLEnding: '/merge-sections.html'
 }
 
-const canvasGradebookFormatterProps: FeatureDataProps = {
-  id: 'CanvasGradebookFormatter',
-  title: 'Canvas Gradebook Formatter',
-  description: 'Formats the exported Canvas Gradebook CSV file for uploading into Faculty Center\'s Grade Roster.',
+const formatCanvasGradebookProps: FeatureDataProps = {
+  id: 'FormatCanvasGradebook',
+  title: 'Format Canvas Gradebook',
+  description: 'Format the exported Canvas Gradebook CSV file for uploading into Faculty Center\'s Grade Roster.',
   ordinality: 2,
   roles: [RoleEnum.Teacher, RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant'], RoleEnum.TA],
   helpURLEnding: '/gradebook-canvas.html'
 }
 
-const externalToolsGradebookFormatterProps: FeatureDataProps = {
-  id: 'ExternalToolsGradebookFormatter',
-  title: 'External Tools Gradebook Formatter',
-  description: 'Formats a CSV file exported from an external tool for importing grades into the Canvas Gradebook.',
+const formatThirdPartyGradebookProps: FeatureDataProps = {
+  id: 'FormatThirdPartyGradebook',
+  title: 'Format Third-Party Gradebook',
+  description: 'Format a CSV file exported from an external tool for importing grades into the Canvas Gradebook.',
   ordinality: 3,
   roles: [RoleEnum.Teacher, RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant'], RoleEnum.TA],
   helpURLEnding: '/gradebook-thirdparty.html'
@@ -67,6 +67,6 @@ const courseRenameRoles: RoleEnum[] = [RoleEnum['Account Admin'], RoleEnum['Suba
 
 export type { FeatureDataProps }
 export {
-  mergeSectionProps, canvasGradebookFormatterProps, externalToolsGradebookFormatterProps,
+  mergeSectionProps, formatCanvasGradebookProps, formatThirdPartyGradebookProps,
   createSectionsProps, addUMUsersProps, addNonUMUsersProps, courseRenameRoles
 }

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -21,7 +21,6 @@ import SuccessCard from '../components/SuccessCard'
 import ValidationErrorTable, { RowValidationError } from '../components/ValidationErrorTable'
 import usePromise from '../hooks/usePromise'
 import { CanvasCourseSection, injectCourseName, CanvasCourseSectionWithCourseName, getCanvasRole, isValidRole } from '../models/canvas'
-import { addUMUsersProps } from '../models/feature'
 import { CCMComponentProps } from '../models/FeatureUIData'
 import { InvalidationType } from '../models/models'
 import { CanvasError } from '../utils/handleErrors'
@@ -475,7 +474,7 @@ designer,userd`
   return (
     <div className={classes.root}>
       <Help baseHelpURL={props.globals.baseHelpURL} helpURLEnding={props.helpURLEnding} />
-      <Typography variant='h5' component='h1'>{addUMUsersProps.title}</Typography>
+      <Typography variant='h5' component='h1'>{props.title}</Typography>
       <Stepper activeStep={activeStep} alternativeLabel>
         {steps.map(label => <Step key={label}><StepLabel>{label}</StepLabel></Step>)}
       </Stepper>

--- a/ccm_web/client/src/pages/BulkSectionCreate.tsx
+++ b/ccm_web/client/src/pages/BulkSectionCreate.tsx
@@ -19,7 +19,6 @@ import SuccessCard from '../components/SuccessCard'
 import ValidationErrorTable from '../components/ValidationErrorTable'
 import usePromise from '../hooks/usePromise'
 import { CanvasCourseSection } from '../models/canvas'
-import { createSectionsProps } from '../models/feature'
 import { CCMComponentProps } from '../models/FeatureUIData'
 import { InvalidationType } from '../models/models'
 import CSVSchemaValidator, { SchemaInvalidation } from '../utils/CSVSchemaValidator'
@@ -424,7 +423,7 @@ Section 001`
   return (
     <div className={classes.root}>
       <Help baseHelpURL={props.globals.baseHelpURL} helpURLEnding={props.helpURLEnding} />
-      <Typography variant='h5' component='h1'>{createSectionsProps.title}</Typography>
+      <Typography variant='h5' component='h1'>{props.title}</Typography>
       {renderComponent()}
     </div>
   )

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -439,7 +439,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
   return (
     <div className={classes.root}>
       <Help baseHelpURL={props.globals.baseHelpURL} helpURLEnding={props.helpURLEnding} />
-      <Typography variant='h5' component='h1'>Convert a Third-Party Gradebook</Typography>
+      <Typography variant='h5' component='h1'>{props.title}</Typography>
       <Stepper className={classes.stepper} activeStep={activeStep} alternativeLabel>
         {
           Object.entries(FormatGradebookStep)

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -9,6 +9,7 @@ import CSVFileName from '../components/CSVFileName'
 import ErrorAlert from '../components/ErrorAlert'
 import ExampleFileDownloadHeader from '../components/ExampleFileDownloadHeader'
 import FileUpload from '../components/FileUpload'
+import Help from '../components/Help'
 import SectionSelectorWidget, { SelectableCanvasCourseSection } from '../components/SectionSelectorWidget'
 import SuccessCard from '../components/SuccessCard'
 import ThirdPartyGradebookConfirmationTable from '../components/ThirdPartyGradebookConfirmationTable'
@@ -437,6 +438,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
 
   return (
     <div className={classes.root}>
+      <Help baseHelpURL={props.globals.baseHelpURL} helpURLEnding={props.helpURLEnding} />
       <Typography variant='h5' component='h1'>Convert a Third-Party Gradebook</Typography>
       <Stepper className={classes.stepper} activeStep={activeStep} alternativeLabel>
         {

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -11,7 +11,6 @@ import RowLevelErrorsContent from '../components/RowLevelErrorsContent'
 import ValidationErrorTable from '../components/ValidationErrorTable'
 import GradebookUploadConfirmationTable, { StudentGrade } from '../components/GradebookUploadConfirmationTable'
 import { CurrentAndFinalGradeMatchGradebookValidator, GradebookRowInvalidation } from '../components/GradebookCanvasValidators'
-import { canvasGradebookFormatterProps } from '../models/feature'
 import { CCMComponentProps } from '../models/FeatureUIData'
 import { DownloadData, InvalidationType } from '../models/models'
 import CSVSchemaValidator, { SchemaInvalidation } from '../utils/CSVSchemaValidator'
@@ -325,7 +324,7 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
   return (
     <div className={classes.root}>
       <Help baseHelpURL={props.globals.baseHelpURL} helpURLEnding={props.helpURLEnding} />
-      <Typography variant='h5' component='h1'>{canvasGradebookFormatterProps.title}</Typography>
+      <Typography variant='h5' component='h1'>{props.title}</Typography>
       {renderComponent()}
     </div>
   )

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -5,7 +5,6 @@ import { Button, Grid, LinearProgress, makeStyles, Typography } from '@material-
 import { useSnackbar } from 'notistack'
 
 import { CCMComponentProps, isAuthorizedForRoles } from '../models/FeatureUIData'
-import { mergeSectionProps } from '../models/feature'
 import SectionSelectorWidget, { SelectableCanvasCourseSection } from '../components/SectionSelectorWidget'
 import { CanvasCourseSectionSort_AZ, CanvasCourseSectionSort_UserCount, CanvasCourseSectionSort_ZA, CanvasCourseSectionWithCourseName, ICanvasCourseSectionSort } from '../models/canvas'
 import { mergeSections } from '../api'
@@ -230,7 +229,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   return (
     <div className={classes.root}>
       <Help baseHelpURL={props.globals.baseHelpURL} helpURLEnding={props.helpURLEnding} />
-      <Typography variant='h5' component='h1'>{mergeSectionProps.title}</Typography>
+      <Typography variant='h5' component='h1'>{props.title}</Typography>
       {renderComponent()}
     </div>
   )


### PR DESCRIPTION
This PR adds a missing help link to the "Format Third-Party Gradebook" feature and tweaks the language of both gradebook tools to be action-oriented. In addition, it made sense (at least to me) to tweak how title data is passed to each feature so it works the same as the `helpURLEnding` and `{feature}Props` don't have to be separately imported to each feature component.

The PR resolves #228 and #233.