### PR TITLE
Refactor `InlineTextEdit` and course name usage to improve usability/accessibility (#240)

### DIFF
--- a/ccm_web/client/src/components/InlineTextEdit.tsx
+++ b/ccm_web/client/src/components/InlineTextEdit.tsx
@@ -100,10 +100,18 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
                       <Button
                         className={classes.button}
                         disabled={props.text === tempTextValue || props.isSaving}
-                        onClick={save}>
+                        onClick={save}
+                        aria-label='Save course name'>
                           Save
                       </Button>
-                      <Button className={classes.button} disabled={props.isSaving} onClick={cancel}>Cancel</Button>
+                      <Button
+                        className={classes.button}
+                        disabled={props.isSaving}
+                        onClick={cancel}
+                        aria-label='Cancel editing course name'
+                      >
+                        Cancel
+                      </Button>
                     </Grid>
                   </Grid>
                 </form>
@@ -111,7 +119,7 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
             : (
                 <>
                 <Typography className={classes.buttonSep} variant='inherit'>{props.text}</Typography>
-                <Button onClick={toggleEdit} disabled={props.isSaving}>
+                <Button onClick={toggleEdit} disabled={props.isSaving} aria-label='Edit course name'>
                   <EditIcon className={classes.editIcon} style={{ fontSize: props.fontSize }} />
                 </Button>
                 </>

--- a/ccm_web/client/src/components/InlineTextEdit.tsx
+++ b/ccm_web/client/src/components/InlineTextEdit.tsx
@@ -41,6 +41,7 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
   const [tempTextValue, setTempTextValue] = useState(props.text)
   const textInput = useRef(null)
 
+  // Resets tempTextValue in case when save fails
   useEffect(() => {
     if (isEditing) setTempTextValue(props.text)
   }, [isEditing])

--- a/ccm_web/client/src/components/InlineTextEdit.tsx
+++ b/ccm_web/client/src/components/InlineTextEdit.tsx
@@ -45,15 +45,15 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
     if (isEditing) setTempTextValue(props.text)
   }, [isEditing])
 
-  const cancel = (): void => {
-    setIsEditing(false)
-    setTempTextValue(props.text)
-  }
-
   const save = async (): Promise<void> => {
     if (props.text === tempTextValue) return
     await props.save(tempTextValue)
     setIsEditing(false)
+  }
+
+  const cancel = (): void => {
+    setIsEditing(false)
+    setTempTextValue(props.text)
   }
 
   const toggleEdit = (): void => {

--- a/ccm_web/client/src/components/InlineTextEdit.tsx
+++ b/ccm_web/client/src/components/InlineTextEdit.tsx
@@ -14,9 +14,6 @@ interface InlineTextEditProps {
 
 const useStyles = makeStyles(() => ({
   root: {
-    textAlign: 'left',
-    padding: '5px',
-    whiteSpace: 'pre-wrap',
     '& .MuiInputBase-root.Mui-disabled': {
       color: 'rgba(0, 0, 0, 0.6)' // (default alpha is 0.38)
     },
@@ -73,62 +70,60 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
   }
 
   return (
-    <Grid className={classes.root} container alignItems='center'>
-      <Grid item md={8} sm={8} xs={12}>
-        {
-          isEditing
-            ? (
-                <form noValidate autoComplete='off'>
-                  <Grid container>
-                    <Grid item md={9} sm={7} xs={7}>
-                      <TextField
-                        className={classes.buttonSep}
-                        aria-readonly={false}
-                        onClick={toggleEdit}
-                        fullWidth={true}
-                        inputProps={{ style: { fontSize: props.fontSize } }}
-                        ref={textInput}
-                        id='standard-basic'
-                        autoFocus={true}
-                        placeholder={props.placeholderText}
-                        value={tempTextValue}
-                        onKeyDown={keyPress}
-                        onChange={(e) => setTempTextValue(e.target.value)}
-                        disabled={!isEditing && props.isSaving}
-                      />
-                    </Grid>
-                    <Grid item md={3} sm={5} xs={5}>
-                      <Button
-                        className={classes.button}
-                        disabled={props.text === tempTextValue || props.isSaving}
-                        onClick={save}
-                        aria-label='Save course name'
-                      >
-                        Save
-                      </Button>
-                      <Button
-                        className={classes.button}
-                        disabled={props.isSaving}
-                        onClick={cancel}
-                        aria-label='Cancel editing course name'
-                      >
-                        Cancel
-                      </Button>
-                    </Grid>
+    <div className={classes.root}>
+      {
+        isEditing
+          ? (
+              <form noValidate autoComplete='off'>
+                <Grid container>
+                  <Grid item md={9} sm={7} xs={7}>
+                    <TextField
+                      className={classes.buttonSep}
+                      aria-readonly={false}
+                      onClick={toggleEdit}
+                      fullWidth={true}
+                      inputProps={{ style: { fontSize: props.fontSize } }}
+                      ref={textInput}
+                      id='standard-basic'
+                      autoFocus={true}
+                      placeholder={props.placeholderText}
+                      value={tempTextValue}
+                      onKeyDown={keyPress}
+                      onChange={(e) => setTempTextValue(e.target.value)}
+                      disabled={!isEditing && props.isSaving}
+                    />
                   </Grid>
-                </form>
-              )
-            : (
-                <>
-                <Typography className={classes.buttonSep} variant='inherit'>{props.text}</Typography>
-                <Button onClick={toggleEdit} disabled={props.isSaving} aria-label='Edit course name'>
-                  <EditIcon className={classes.editIcon} style={{ fontSize: props.fontSize }} />
-                </Button>
-                </>
-              )
-        }
-      </Grid>
-    </Grid>
+                  <Grid item md={3} sm={5} xs={5}>
+                    <Button
+                      className={classes.button}
+                      disabled={props.text === tempTextValue || props.isSaving}
+                      onClick={save}
+                      aria-label='Save course name'
+                    >
+                      Save
+                    </Button>
+                    <Button
+                      className={classes.button}
+                      disabled={props.isSaving}
+                      onClick={cancel}
+                      aria-label='Cancel editing course name'
+                    >
+                      Cancel
+                    </Button>
+                  </Grid>
+                </Grid>
+              </form>
+            )
+          : (
+              <>
+              <Typography className={classes.buttonSep} variant='inherit'>{props.text}</Typography>
+              <Button onClick={toggleEdit} disabled={props.isSaving} aria-label='Edit course name'>
+                <EditIcon className={classes.editIcon} style={{ fontSize: props.fontSize }} />
+              </Button>
+              </>
+            )
+      }
+    </div>
   )
 }
 

--- a/ccm_web/client/src/components/InlineTextEdit.tsx
+++ b/ccm_web/client/src/components/InlineTextEdit.tsx
@@ -102,8 +102,9 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
                         className={classes.button}
                         disabled={props.text === tempTextValue || props.isSaving}
                         onClick={save}
-                        aria-label='Save course name'>
-                          Save
+                        aria-label='Save course name'
+                      >
+                        Save
                       </Button>
                       <Button
                         className={classes.button}

--- a/ccm_web/client/src/pages/Home.tsx
+++ b/ccm_web/client/src/pages/Home.tsx
@@ -25,6 +25,10 @@ const useStyles = makeStyles((theme) => ({
   featureCardContainer: {
     padding: 5
   },
+  courseNameContainer: {
+    marginBottom: 15,
+    wordWrap: 'break-word'
+  },
   courseName: {
     textAlign: 'left',
     padding: 5
@@ -91,7 +95,17 @@ function Home (props: HomeProps): JSX.Element {
     if (props.course === undefined) {
       return (<div className={classes.courseName}>Error getting course name</div>)
     } else if (isAuthorizedForRoles(props.globals.course.roles, courseRenameRoles, 'Course Rename')) {
-      return (<InlineTextEdit {...{ text: props.course.name, save: doSetCourseName, placeholderText: 'Course name', isSaving: setCourseNameLoading }}/>)
+      return (
+        <Typography variant='h5' component='h1'>
+          <InlineTextEdit
+            text={props.course.name}
+            placeholderText='Course name'
+            fontSize='1.5rem'
+            save={doSetCourseName}
+            isSaving={setCourseNameLoading}
+          />
+        </Typography>
+      )
     } else {
       return (<Typography className={classes.courseName} variant='h5' component='h1'>{props.course.name}</Typography>)
     }
@@ -102,7 +116,9 @@ function Home (props: HomeProps): JSX.Element {
     return (
       <>
         <Help baseHelpURL={props.globals.baseHelpURL} />
-        {renderCourseRename()}
+        <div className={classes.courseNameContainer}>
+          {renderCourseRename()}
+        </div>
         <Grid container spacing={3}>
           {features.sort((a, b) => (a.ordinality < b.ordinality) ? -1 : 1).filter(featureGroup => {
             return isAuthorizedForAnyFeature(props.globals.course.roles, featureGroup.features)
@@ -110,7 +126,8 @@ function Home (props: HomeProps): JSX.Element {
             return (renderFeatureGroup(featureGroup))
           })}
         </Grid>
-      </>)
+      </>
+    )
   }
 
   return (

--- a/ccm_web/client/src/pages/Home.tsx
+++ b/ccm_web/client/src/pages/Home.tsx
@@ -26,10 +26,11 @@ const useStyles = makeStyles((theme) => ({
     padding: 5
   },
   courseNameContainer: {
-    marginBottom: 15,
-    wordWrap: 'break-word'
+    marginBottom: 15
   },
   courseName: {
+    whiteSpace: 'pre-wrap',
+    wordWrap: 'break-word',
     textAlign: 'left',
     padding: 5
   }
@@ -94,21 +95,32 @@ function Home (props: HomeProps): JSX.Element {
   const renderCourseRename = (): JSX.Element => {
     if (props.course === undefined) {
       return (<div className={classes.courseName}>Error getting course name</div>)
-    } else if (isAuthorizedForRoles(props.globals.course.roles, courseRenameRoles, 'Course Rename')) {
-      return (
-        <Typography variant='h5' component='h1'>
-          <InlineTextEdit
-            text={props.course.name}
-            placeholderText='Course name'
-            fontSize='1.5rem'
-            save={doSetCourseName}
-            isSaving={setCourseNameLoading}
-          />
-        </Typography>
+    }
+
+    let nameBlock
+    if (isAuthorizedForRoles(props.globals.course.roles, courseRenameRoles, 'Course Rename')) {
+      nameBlock = (
+        <InlineTextEdit
+          text={props.course.name}
+          placeholderText='Course name'
+          fontSize='1.5rem'
+          save={doSetCourseName}
+          isSaving={setCourseNameLoading}
+        />
       )
     } else {
-      return (<Typography className={classes.courseName} variant='h5' component='h1'>{props.course.name}</Typography>)
+      nameBlock = props.course.name
     }
+
+    return (
+      <Grid className={classes.courseNameContainer} container alignItems='center'>
+        <Grid item md={8} sm={8} xs={12}>
+          <Typography className={classes.courseName} variant='h5' component='h1'>
+            {nameBlock}
+          </Typography>
+        </Grid>
+      </Grid>
+    )
   }
 
   const renderFeatures = (): JSX.Element => {


### PR DESCRIPTION
This PR refactors the `InlineTextEdit` component to provide a few improvements (see below), mainly the accessibility features suggested in issue #240. The PR aims to resolve issue #240 and maybe #151.

Improvements
- Pencil edit button is keyboard-accessible (changed underlying component to `Button`).
- Text field receives focus when the edit button is clicked.
- Text field has been made larger so edits are easier to see visually.
- The course name text is now an `h1` instead of a disabled text field when in not-editing mode. This also allows for display of long course names (which now wrap). It may also resolve other accessibility issues related to a missing `h1` on the home page.
- ARIA labels have been added to all involved buttons.
- When a request fails (because of a bad connection, or a Canvas validation error), the revised version is not retained in the component's state when editing begins again. This could be seen as a problem, but it seemed more logical to have the `h1` text and the temp text always match when a user begins editing. Let me know your thoughts.
- Text field remains in a disabled state while the change is being saved to Canvas.