### PR TITLE
Add check whether `getSectionsError` is `undefined` in "Format Third-Party Gradebook" (#249)

### DIFF
--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -111,7 +111,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
   )
 
   useEffect(() => {
-    if (sections === undefined) {
+    if (sections === undefined && getSectionsError === undefined) {
       void doGetSections()
     }
   }, [sections, getSectionsError])


### PR DESCRIPTION
This PR aims to resolve #249.