### PR TITLE
Improve session (#171)

### DIFF
--- a/ccm_web/server/localTypes/express-session/index.d.ts
+++ b/ccm_web/server/localTypes/express-session/index.d.ts
@@ -8,7 +8,7 @@ declare module 'express-session' {
   }
 
   interface CustomData {
-    state?: string
+    oAuthToken?: string
     course: Course
     isRootAdmin: boolean
   }

--- a/ccm_web/server/localTypes/express-session/index.d.ts
+++ b/ccm_web/server/localTypes/express-session/index.d.ts
@@ -8,6 +8,7 @@ declare module 'express-session' {
   }
 
   interface CustomData {
+    state?: string
     course: Course
     isRootAdmin: boolean
   }

--- a/ccm_web/server/src/api/api.controller.ts
+++ b/ccm_web/server/src/api/api.controller.ts
@@ -13,6 +13,7 @@ import { GetSectionsAdminQueryDto } from './dtos/api.get.sections.admin.dto'
 import { SectionIdsDto } from './dtos/api.section.ids.dto'
 import { SectionUserDto, SectionUsersDto } from './dtos/api.section.users.dto'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { SessionGuard } from '../auth/session.guard'
 import {
   CanvasCourseBase, CanvasCourseSection, CanvasCourseSectionBase, CanvasEnrollment, CourseWithSections
 } from '../canvas/canvas.interfaces'
@@ -20,7 +21,7 @@ import { InvalidTokenInterceptor } from '../canvas/invalid.token.interceptor'
 import { UserDec } from '../user/user.decorator'
 import { User } from '../user/user.model'
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, SessionGuard)
 @Controller('api')
 export class APIController {
   constructor (private readonly apiService: APIService) {}

--- a/ccm_web/server/src/auth/auth.controller.ts
+++ b/ccm_web/server/src/auth/auth.controller.ts
@@ -4,8 +4,9 @@ import { ApiExcludeEndpoint } from '@nestjs/swagger'
 
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { AuthService } from './auth.service'
+import { SessionGuard } from './session.guard'
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, SessionGuard)
 @Controller('auth')
 export class AuthController {
   constructor (private readonly authService: AuthService) {}

--- a/ccm_web/server/src/auth/auth.controller.ts
+++ b/ccm_web/server/src/auth/auth.controller.ts
@@ -2,8 +2,8 @@ import { Request, Response } from 'express'
 import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common'
 import { ApiExcludeEndpoint } from '@nestjs/swagger'
 
-import { JwtAuthGuard } from '../auth/jwt-auth.guard'
 import { AuthService } from './auth.service'
+import { JwtAuthGuard } from './jwt-auth.guard'
 import { SessionGuard } from './session.guard'
 
 @UseGuards(JwtAuthGuard, SessionGuard)

--- a/ccm_web/server/src/auth/session.guard.ts
+++ b/ccm_web/server/src/auth/session.guard.ts
@@ -1,6 +1,6 @@
-import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common'
 import { Request } from 'express'
 import { Observable } from 'rxjs'
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common'
 
 @Injectable()
 export class SessionGuard implements CanActivate {

--- a/ccm_web/server/src/auth/session.guard.ts
+++ b/ccm_web/server/src/auth/session.guard.ts
@@ -1,0 +1,19 @@
+import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common'
+import { Request } from 'express'
+import { Observable } from 'rxjs'
+
+@Injectable()
+export class SessionGuard implements CanActivate {
+  canActivate (
+    context: ExecutionContext
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest<Request>()
+
+    const { expires } = request.session.cookie
+    const curTime = new Date()
+    if ((expires !== undefined && expires < curTime) || request.session.data === undefined) {
+      throw new UnauthorizedException('The session has expired or is missing.')
+    }
+    return true
+  }
+}

--- a/ccm_web/server/src/canvas/canvas.controller.ts
+++ b/ccm_web/server/src/canvas/canvas.controller.ts
@@ -43,7 +43,7 @@ export class CanvasController {
     }
 
     const stateToken = (await generateToken(48)).toString('hex')
-    req.session.data.state = stateToken
+    req.session.data.oAuthToken = stateToken
     const fullURL = `${this.canvasService.getAuthURL()}&state=${stateToken}`
     logger.debug(`Full redirect URL: ${fullURL}`)
     req.session.save(() => { res.redirect(fullURL) })
@@ -77,8 +77,8 @@ export class CanvasController {
       throw new InternalServerErrorException('Session data could not be found.')
     }
 
-    const { state } = req.session.data
-    if (state === undefined || query.state !== state) {
+    const { oAuthToken } = req.session.data
+    if (oAuthToken === undefined || query.state !== oAuthToken) {
       logger.warn(
         'The state variable returned from Canvas did not match that in the session, or ' +
         'the state variable in the session was undefined.'

--- a/ccm_web/server/src/canvas/canvas.controller.ts
+++ b/ccm_web/server/src/canvas/canvas.controller.ts
@@ -7,6 +7,7 @@ import { ApiExcludeEndpoint } from '@nestjs/swagger'
 import { OAuthGoodResponseQuery, OAuthErrorResponseQuery, isOAuthErrorResponseQuery } from './canvas.interfaces'
 import { CanvasService } from './canvas.service'
 import { JwtAuthGuard } from '../auth/jwt-auth.guard'
+import { SessionGuard } from '../auth/session.guard'
 import { UserDec } from '../user/user.decorator'
 import { User } from '../user/user.model'
 
@@ -14,7 +15,7 @@ import baseLogger from '../logger'
 
 const logger = baseLogger.child({ filePath: __filename })
 
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, SessionGuard)
 @Controller('canvas')
 export class CanvasController {
   constructor (private readonly canvasService: CanvasService) {}

--- a/ccm_web/server/src/canvas/canvas.controller.ts
+++ b/ccm_web/server/src/canvas/canvas.controller.ts
@@ -80,8 +80,8 @@ export class CanvasController {
     const { oAuthToken } = req.session.data
     if (oAuthToken === undefined || query.state !== oAuthToken) {
       logger.warn(
-        'The state variable returned from Canvas did not match that in the session, or ' +
-        'the state variable in the session was undefined.'
+        'The state variable returned from Canvas did not match the oAuthToken value in the session, or ' +
+        'the oAuthToken value was undefined.'
       )
       throw new UnauthorizedException('You are not authorized to access this resource.')
     }

--- a/ccm_web/server/src/lti/lti.service.ts
+++ b/ccm_web/server/src/lti/lti.service.ts
@@ -86,7 +86,6 @@ export class LTIService implements BeforeApplicationShutdown {
         roles: (roles.length > 0) ? roles.split(',') : [] // role won't be empty but adding a validation for safety
       }
       const sessionData = {
-        userLoginId: loginId,
         course: course,
         isRootAdmin: isRootAdmin
       }

--- a/ccm_web/server/src/main.ts
+++ b/ccm_web/server/src/main.ts
@@ -63,7 +63,8 @@ async function bootstrap (): Promise<void> {
       cookie: {
         domain: serverConfig.domain,
         secure: true,
-        sameSite: 'none'
+        sameSite: 'none',
+        maxAge: serverConfig.maxAgeInSec * 1000
       }
     })
   )

--- a/ccm_web/server/src/main.ts
+++ b/ccm_web/server/src/main.ts
@@ -49,9 +49,9 @@ async function bootstrap (): Promise<void> {
   sessionStore.sync({ logging: (sql) => logger.info(sql) })
 
   // Controls size limit of data in payload and URL
-  const payload_size_limit = '5mb'
-  app.use(json({ limit: payload_size_limit }))
-  app.use(urlencoded({ extended: true, limit: payload_size_limit }))
+  const payloadSizeLimit = '5mb'
+  app.use(json({ limit: payloadSizeLimit }))
+  app.use(urlencoded({ extended: true, limit: payloadSizeLimit }))
 
   app.use(
     session({


### PR DESCRIPTION
This PR modifies application behavior around use of sessions in order to optimize security and provide better backend error reporting. The PR aims to resolve #171.

Task(s):
- [x] Make session expire (using `MAX_AGE_IN_SEC`).
  - Justification: Session should expire at some point. At the same or nearly the same time as the JWT cookie makes sense to me.
- [x] Elegantly handle missing session using `SessionGuard`.
  - Justification: This is needed as a consequence of the first task to have the backend server throw a better error if the session has expired. In practice, you may never see this, because the JWT cookie will expire before. However, if you manually remove the session cookie in your browser, or set the session cookie to expire earlier, you can get this to trigger, but only if it's a `GET` request. If it's something requiring a CSRF token, you will see a CSRF error since that global middlware (`csurf`) is registered first and will want access to the token it needs in the session.
- [x] With Canvas OAuth, use a custom state secret generated using `crypto` that is stored in the session (rather than the auto-generated session ID)
  - Justification: This *could* be more secure, but that may only be my naivete thinking that. The session ID we were using before is part of the cookie in the browser, so maybe that's easier to fake than a random token stored within the session data that only the backend has access to. Also, when we make the session expire (see the first task), that also means this `state` variable will expire too, which seems good. I couldn't find a great example, but Google seems to suggest [something like this](https://developers.google.com/identity/protocols/oauth2/openid-connect#createxsrftoken).
- [x] Remove setting of `userLoginId` in session data in `lti.service.ts` (since it's no longer used).

Note(s):
- We may want to modify how session/cookie expiration is presented to the user (and tell them to refresh the page, i.e. re-launch), but that could be a separate issue (I've opened #253 to address it). Right now, the error is vague to the user.