### PR TITLE
issue-142 prevent user with wrong roles to access CCM tool

### DIFF
--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -66,7 +66,7 @@ export interface CanvasCourseSection extends CanvasCourseSectionBase {
   total_students: number
 }
 
-export enum CanvasRoles {
+export enum CanvasRole {
   AccountAdmin = 'Account Admin',
   SubAccountAdmin = 'Sub-Account Admin',
   SupportConsultant = 'Support Consultant',
@@ -79,23 +79,23 @@ export enum CanvasRoles {
 }
 
 export enum UserEnrollmentType {
-  DesignerEnrollment = CanvasRoles.DesignerEnrollment,
-  ObserverEnrollment = CanvasRoles.ObserverEnrollment,
-  StudentEnrollment = CanvasRoles.StudentEnrollment,
-  TaEnrollment = CanvasRoles.TaEnrollment,
-  TeacherEnrollment = CanvasRoles.TeacherEnrollment
+  DesignerEnrollment = CanvasRole.DesignerEnrollment,
+  ObserverEnrollment = CanvasRole.ObserverEnrollment,
+  StudentEnrollment = CanvasRole.StudentEnrollment,
+  TaEnrollment = CanvasRole.TaEnrollment,
+  TeacherEnrollment = CanvasRole.TeacherEnrollment
 }
 
 // valid role types for LTI launch
 // as defined in https://docs.google.com/spreadsheets/d/1pm5y9FX0zrDX7Zy3mOyDLxmA-iKoWfmlxvbtNkWg6Zw/edit#gid=1360549473
-export enum LTIEnrollmentTypes {
-  AccountAdmin = CanvasRoles.AccountAdmin,
-  SubAccountAdmin = CanvasRoles.SubAccountAdmin,
-  SupportConsultant = CanvasRoles.SupportConsultant,
-  TeacherEnrollment = CanvasRoles.TeacherEnrollment,
-  DesignerEnrollment = CanvasRoles.DesignerEnrollment,
-  TaEnrollment = CanvasRoles.TaEnrollment,
-  Assistant = CanvasRoles.Assistant
+export enum LTIEnrollmentType {
+  AccountAdmin = CanvasRole.AccountAdmin,
+  SubAccountAdmin = CanvasRole.SubAccountAdmin,
+  SupportConsultant = CanvasRole.SupportConsultant,
+  TeacherEnrollment = CanvasRole.TeacherEnrollment,
+  DesignerEnrollment = CanvasRole.DesignerEnrollment,
+  TaEnrollment = CanvasRole.TaEnrollment,
+  Assistant = CanvasRole.Assistant
 }
 
 export interface CanvasEnrollment {

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -74,6 +74,18 @@ export enum UserEnrollmentType {
   TeacherEnrollment = 'TeacherEnrollment'
 }
 
+// valid role types for LTI launch
+// as defined in https://docs.google.com/spreadsheets/d/1pm5y9FX0zrDX7Zy3mOyDLxmA-iKoWfmlxvbtNkWg6Zw/edit#gid=1360549473
+export const LTIEnrollmentTypes = [
+  'Account Admin',
+  'Sub-Account Admin',
+  'Support Consultant',
+  'TeacherEnrollment',
+  'DesignerEnrollment',
+  'TaEnrollment',
+  'Assistant'
+]
+
 export interface CanvasEnrollment {
   id: number
   course_id: number

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -128,7 +128,7 @@ interface CanvasError {
   message: string
 }
 
-function isCanvasError(value: unknown): value is CanvasError {
+function isCanvasError (value: unknown): value is CanvasError {
   return hasKeys(value, ['message'])
 }
 
@@ -136,7 +136,7 @@ export interface CanvasErrorBody {
   errors: CanvasError[]
 }
 
-export function isCanvasErrorBody(value: unknown): value is CanvasErrorBody {
+export function isCanvasErrorBody (value: unknown): value is CanvasErrorBody {
   if (!hasKeys(value, ['errors']) || !Array.isArray(value.errors)) {
     return false
   } else {

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -28,7 +28,7 @@ export interface TokenCodeResponseBody extends TokenBaseResponseBody {
   refresh_token: string
 }
 
-export interface TokenRefreshResponseBody extends TokenBaseResponseBody {}
+export interface TokenRefreshResponseBody extends TokenBaseResponseBody { }
 
 // Entities
 
@@ -66,7 +66,11 @@ export interface CanvasCourseSection extends CanvasCourseSectionBase {
   total_students: number
 }
 
-export enum UserEnrollmentType {
+export enum CanvasRoles {
+  AccountAdmin = 'Account Admin',
+  SubAccountAdmin = 'Sub-Account Admin',
+  SupportConsultant = 'Support Consultant',
+  Assistant = 'Assistant',
   DesignerEnrollment = 'DesignerEnrollment',
   ObserverEnrollment = 'ObserverEnrollment',
   StudentEnrollment = 'StudentEnrollment',
@@ -74,17 +78,25 @@ export enum UserEnrollmentType {
   TeacherEnrollment = 'TeacherEnrollment'
 }
 
+export enum UserEnrollmentType {
+  DesignerEnrollment = CanvasRoles.DesignerEnrollment,
+  ObserverEnrollment = CanvasRoles.ObserverEnrollment,
+  StudentEnrollment = CanvasRoles.StudentEnrollment,
+  TaEnrollment = CanvasRoles.TaEnrollment,
+  TeacherEnrollment = CanvasRoles.TeacherEnrollment
+}
+
 // valid role types for LTI launch
 // as defined in https://docs.google.com/spreadsheets/d/1pm5y9FX0zrDX7Zy3mOyDLxmA-iKoWfmlxvbtNkWg6Zw/edit#gid=1360549473
-export const LTIEnrollmentTypes = [
-  'Account Admin',
-  'Sub-Account Admin',
-  'Support Consultant',
-  'TeacherEnrollment',
-  'DesignerEnrollment',
-  'TaEnrollment',
-  'Assistant'
-]
+export enum LTIEnrollmentTypes {
+  AccountAdmin = CanvasRoles.AccountAdmin,
+  SubAccountAdmin = CanvasRoles.SubAccountAdmin,
+  SupportConsultant = CanvasRoles.SupportConsultant,
+  TeacherEnrollment = CanvasRoles.TeacherEnrollment,
+  DesignerEnrollment = CanvasRoles.DesignerEnrollment,
+  TaEnrollment = CanvasRoles.TaEnrollment,
+  Assistant = CanvasRoles.Assistant
+}
 
 export interface CanvasEnrollment {
   id: number
@@ -116,7 +128,7 @@ interface CanvasError {
   message: string
 }
 
-function isCanvasError (value: unknown): value is CanvasError {
+function isCanvasError(value: unknown): value is CanvasError {
   return hasKeys(value, ['message'])
 }
 
@@ -124,7 +136,7 @@ export interface CanvasErrorBody {
   errors: CanvasError[]
 }
 
-export function isCanvasErrorBody (value: unknown): value is CanvasErrorBody {
+export function isCanvasErrorBody(value: unknown): value is CanvasErrorBody {
   if (!hasKeys(value, ['errors']) || !Array.isArray(value.errors)) {
     return false
   } else {

--- a/ccm_web/server/src/lti/lti.service.ts
+++ b/ccm_web/server/src/lti/lti.service.ts
@@ -127,7 +127,7 @@ export class LTIService implements BeforeApplicationShutdown {
     this.provider = provider
   }
 
-  getMiddleware(): Express | undefined {
+  getMiddleware (): Express | undefined {
     return this.provider?.app
   }
 

--- a/ccm_web/server/src/lti/lti.service.ts
+++ b/ccm_web/server/src/lti/lti.service.ts
@@ -25,9 +25,9 @@ const createLaunchErrorResponse = (res: Response, action?: string): Response => 
 export class LTIService implements BeforeApplicationShutdown {
   provider: LTIProvider | undefined
 
-  constructor(private readonly configService: ConfigService<Config, true>, private readonly authService: AuthService) { }
+  constructor (private readonly configService: ConfigService<Config, true>, private readonly authService: AuthService) { }
 
-  async setUpLTI(): Promise<void> {
+  async setUpLTI (): Promise<void> {
     const dbConfig = this.configService.get('db', { infer: true })
     const ltiConfig = this.configService.get('lti', { infer: true })
 
@@ -69,12 +69,12 @@ export class LTIService implements BeforeApplicationShutdown {
 
       // check whether the user has at least one of the allowed LTI user roles
       // otherwise block tool access and show error message
-      const rolesArray = roles.length > 0 ? roles.split(',') : []
-      const ltiAllowedRoles = rolesArray.filter(
+      const rolesLTI = roles.length > 0 ? roles.split(',') : []
+      const ltiAllowedRoles = rolesLTI.filter(
         x => Object.entries(LTIEnrollmentTypes).find(
           ([key, value]) => value === x)
       )
-      if (ltiAllowedRoles.length == 0) {
+      if (ltiAllowedRoles.length === 0) {
         return createLaunchErrorResponse(res, 'Your role in this course does not allow access to this tool. If you feel this is in error, please contact 4help@umich.edu.')
       }
 
@@ -131,7 +131,7 @@ export class LTIService implements BeforeApplicationShutdown {
     return this.provider?.app
   }
 
-  beforeApplicationShutdown(): void {
+  beforeApplicationShutdown (): void {
     this.provider?.close()
   }
 }

--- a/ccm_web/server/src/lti/lti.service.ts
+++ b/ccm_web/server/src/lti/lti.service.ts
@@ -20,7 +20,7 @@ const createLaunchErrorResponse = (res: Response, action?: string): Response => 
 }
 
 // the array of user roles that are allowed to use CCM tool
-const allowedRoles = ['TeacherEnrollment','TaEnrollment','ObserverEnrollment','DesignerEnrollment','Account Admin','Sub-Account Admin']
+const allowedRoles = ['TeacherEnrollment', 'TaEnrollment', 'ObserverEnrollment', 'DesignerEnrollment', 'Account Admin', 'Sub-Account Admin']
 
 // ltijs docs: https://cvmcosta.me/ltijs/#/
 @Injectable()
@@ -76,7 +76,7 @@ export class LTIService implements BeforeApplicationShutdown {
       if (roleDiff.length > 0) {
         return createLaunchErrorResponse(res, 'Your role in this course does not allow access to this tool. If you feel this is in error, please contact 4help@umich.edu.')
       }
-      
+
       try {
         await this.authService.loginLTI({
           firstName: token.userInfo.given_name,

--- a/ccm_web/server/src/lti/lti.service.ts
+++ b/ccm_web/server/src/lti/lti.service.ts
@@ -20,7 +20,7 @@ const createLaunchErrorResponse = (res: Response, action?: string): Response => 
 }
 
 // the array of user roles that are allowed to use CCM tool
-const allowedRoles = ['TeacherEnrollment', 'TaEnrollment','ObserverEnrollment','DesignerEnrollment', 'Account Admin','Sub-Account Admin']
+const allowedRoles = ['TeacherEnrollment','TaEnrollment','ObserverEnrollment','DesignerEnrollment','Account Admin','Sub-Account Admin']
 
 // ltijs docs: https://cvmcosta.me/ltijs/#/
 @Injectable()
@@ -72,7 +72,7 @@ export class LTIService implements BeforeApplicationShutdown {
       // check whether the user roles are all included in the allowed roles set
       // otherwise show error message to the user
       const rolesArray = roles.length > 0 ? roles.split(',') : []
-      let roleDiff = rolesArray.filter(x => !allowedRoles.includes(x))
+      const roleDiff = rolesArray.filter(x => !allowedRoles.includes(x))
       if (roleDiff.length > 0) {
         return createLaunchErrorResponse(res, 'Your role in this course does not allow access to this tool. If you feel this is in error, please contact 4help@umich.edu.')
       }

--- a/ccm_web/server/src/lti/lti.service.ts
+++ b/ccm_web/server/src/lti/lti.service.ts
@@ -8,6 +8,7 @@ import { AuthService } from '../auth/auth.service'
 
 import baseLogger from '../logger'
 import { Config } from '../config'
+import { LTIEnrollmentTypes } from '../canvas/canvas.interfaces'
 
 const logger = baseLogger.child({ filePath: __filename })
 
@@ -18,9 +19,6 @@ const createLaunchErrorResponse = (res: Response, action?: string): Response => 
   )
   return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json(message)
 }
-
-// the array of user roles that are allowed to use CCM tool
-const allowedRoles = ['TeacherEnrollment', 'TaEnrollment', 'ObserverEnrollment', 'DesignerEnrollment', 'Account Admin', 'Sub-Account Admin']
 
 // ltijs docs: https://cvmcosta.me/ltijs/#/
 @Injectable()
@@ -69,10 +67,10 @@ export class LTIService implements BeforeApplicationShutdown {
       const roles = customLTIVariables.roles as string
       const isRootAdmin = customLTIVariables.is_root_account_admin as boolean
 
-      // check whether the user roles are all included in the allowed roles set
+      // check whether the user roles are all included in the allowed LTI user roles
       // otherwise show error message to the user
       const rolesArray = roles.length > 0 ? roles.split(',') : []
-      const roleDiff = rolesArray.filter(x => !allowedRoles.includes(x))
+      const roleDiff = rolesArray.filter(x => !LTIEnrollmentTypes.includes(x))
       if (roleDiff.length > 0) {
         return createLaunchErrorResponse(res, 'Your role in this course does not allow access to this tool. If you feel this is in error, please contact 4help@umich.edu.')
       }

--- a/ccm_web/server/src/lti/lti.service.ts
+++ b/ccm_web/server/src/lti/lti.service.ts
@@ -8,7 +8,7 @@ import { AuthService } from '../auth/auth.service'
 
 import baseLogger from '../logger'
 import { Config } from '../config'
-import { LTIEnrollmentTypes } from '../canvas/canvas.interfaces'
+import { LTIEnrollmentType } from '../canvas/canvas.interfaces'
 
 const logger = baseLogger.child({ filePath: __filename })
 
@@ -70,12 +70,13 @@ export class LTIService implements BeforeApplicationShutdown {
       // check whether the user has at least one of the allowed LTI user roles
       // otherwise block tool access and show error message
       const rolesLTI = roles.length > 0 ? roles.split(',') : []
+      const ltiEnrollmentTypeEntries = Object.entries(LTIEnrollmentType)
       const ltiAllowedRoles = rolesLTI.filter(
-        x => Object.entries(LTIEnrollmentTypes).find(
+        x => ltiEnrollmentTypeEntries.find(
           ([key, value]) => value === x)
       )
       if (ltiAllowedRoles.length === 0) {
-        return createLaunchErrorResponse(res, 'Your role in this course does not allow access to this tool. If you feel this is in error, please contact 4help@umich.edu.')
+        return createLaunchErrorResponse(res, 'your role in this course does not allow access to this tool. If you feel this is in error, please contact 4help@umich.edu.')
       }
 
       try {


### PR DESCRIPTION
- [x] defined the allowed role list for using CCM tool as: ['TeacherEnrollment', 'TaEnrollment','ObserverEnrollment','DesignerEnrollment', 'Account Admin','Sub-Account Admin']
- [x] show error message to user when the user has at one role not in the above list

![image](https://user-images.githubusercontent.com/359944/144458898-83396e85-370d-465c-859e-ccb7d465152a.png)
