### PR TITLE
Add `yup` for basic string validation, implement field validation in `InlineTextEdit` (#244, #276)

### DIFF
--- a/ccm_web/client/src/components/BulkSectionCreateValidators.ts
+++ b/ccm_web/client/src/components/BulkSectionCreateValidators.ts
@@ -43,7 +43,7 @@ class SectionNameLengthValidator implements SectionRowsValidator {
       const result = validateString(sectionName, sectionNameSchema)
       if (!result.isValid) {
         invalidations.push({
-          message: result.messages.length > 0 ? result.messages[0] : 'Section name is invalid.',
+          message: result.messages.length > 0 ? result.messages[0] : 'The section name is invalid.',
           rowNumber: row + 2,
           type: InvalidationType.Error
         })

--- a/ccm_web/client/src/components/BulkSectionCreateValidators.ts
+++ b/ccm_web/client/src/components/BulkSectionCreateValidators.ts
@@ -43,7 +43,7 @@ class SectionNameLengthValidator implements SectionRowsValidator {
       const result = validateString(sectionName, sectionNameSchema)
       if (!result.isValid) {
         invalidations.push({
-          message: result.messages.length > 0 ? result.messages[0] : 'The section name is invalid.',
+          message: result.messages.length > 0 ? result.messages[0] : 'Value for the section name is invalid.',
           rowNumber: row + 2,
           type: InvalidationType.Error
         })

--- a/ccm_web/client/src/components/BulkSectionCreateValidators.ts
+++ b/ccm_web/client/src/components/BulkSectionCreateValidators.ts
@@ -1,4 +1,5 @@
 import { InvalidationType } from '../models/models'
+import { sectionNameSchema, validateString } from '../utils/validation'
 
 // For validating row level issues
 interface SectionsRowInvalidation {
@@ -35,24 +36,17 @@ class DuplicateSectionInFileSectionRowsValidator implements SectionRowsValidator
   }
 }
 
-class EmptySectionNameValidator implements SectionRowsValidator {
+class SectionNameLengthValidator implements SectionRowsValidator {
   validate = (sectionNames: string[]): SectionsRowInvalidation[] => {
     const invalidations: SectionsRowInvalidation[] = []
     sectionNames.forEach((sectionName, row) => {
-      if (sectionName.trim().length === 0) {
-        invalidations.push({ message: 'Empty section name is not allowed', rowNumber: row + 2, type: InvalidationType.Error })
-      }
-    })
-    return invalidations
-  }
-}
-
-class SectionNameTooLongValidator implements SectionRowsValidator {
-  validate = (sectionNames: string[]): SectionsRowInvalidation[] => {
-    const invalidations: SectionsRowInvalidation[] = []
-    sectionNames.forEach((sectionName, row) => {
-      if (sectionName.trim().length > 255) {
-        invalidations.push({ message: 'Section name must be 255 characters or less', rowNumber: row + 2, type: InvalidationType.Error })
+      const result = validateString(sectionName, sectionNameSchema)
+      if (!result.isValid) {
+        invalidations.push({
+          message: result.messages.length > 0 ? result.messages[0] : 'Section name is invalid.',
+          rowNumber: row + 2,
+          type: InvalidationType.Error
+        })
       }
     })
     return invalidations
@@ -60,4 +54,4 @@ class SectionNameTooLongValidator implements SectionRowsValidator {
 }
 
 export type { SectionsRowInvalidation, SectionRowsValidator }
-export { InvalidationType, DuplicateSectionInFileSectionRowsValidator, EmptySectionNameValidator, SectionNameTooLongValidator }
+export { InvalidationType, DuplicateSectionInFileSectionRowsValidator, SectionNameLengthValidator }

--- a/ccm_web/client/src/components/InlineTextEdit.tsx
+++ b/ccm_web/client/src/components/InlineTextEdit.tsx
@@ -80,9 +80,11 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
   }
 
   const error = validationResult !== undefined && !validationResult.isValid
-  const helpMessage = validationResult !== undefined && validationResult.messages.length > 0
-    ? validationResult.messages[0]
-    : undefined
+  const helpMessage = validationResult === undefined || validationResult.isValid
+    ? undefined
+    : validationResult.messages.length > 0
+      ? validationResult.messages[0]
+      : 'Value for the field is invalid.'
 
   return (
     <div className={classes.root}>

--- a/ccm_web/client/src/components/InlineTextEdit.tsx
+++ b/ccm_web/client/src/components/InlineTextEdit.tsx
@@ -4,11 +4,14 @@ import { Button, Grid, TextField, Typography } from '@material-ui/core'
 import { Edit as EditIcon } from '@material-ui/icons'
 import { CODE_ENTER, CODE_NUMPAD_ENTER, CODE_ESCAPE } from 'keycode-js'
 
+import { ValidationResult } from '../utils/validation'
+
 interface InlineTextEditProps {
   text: string
   placeholderText: string
   fontSize: string
   isSaving: boolean
+  validate: (value: string | undefined) => ValidationResult
   save: (text: string) => Promise<void>
 }
 
@@ -36,6 +39,8 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
   const classes = useStyles()
   const [isEditing, setIsEditing] = useState(false)
   const [tempTextValue, setTempTextValue] = useState(props.text)
+  const [validationResult, setValidationResult] = useState<ValidationResult | undefined>(undefined)
+
   const textInput = useRef(null)
 
   // Resets tempTextValue in case when save fails
@@ -45,6 +50,10 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
 
   const save = async (): Promise<void> => {
     if (props.text === tempTextValue) return
+    const result = props.validate(tempTextValue)
+    if (!result.isValid) {
+      return setValidationResult(result)
+    }
     await props.save(tempTextValue)
     setIsEditing(false)
   }
@@ -52,6 +61,7 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
   const cancel = (): void => {
     setIsEditing(false)
     setTempTextValue(props.text)
+    setValidationResult(undefined)
   }
 
   const toggleEdit = (): void => {
@@ -68,6 +78,11 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
       cancel()
     }
   }
+
+  const error = validationResult !== undefined && !validationResult.isValid
+  const helpMessage = validationResult !== undefined && validationResult.messages.length > 0
+    ? validationResult.messages[0]
+    : undefined
 
   return (
     <div className={classes.root}>
@@ -89,8 +104,13 @@ function InlineTextEdit (props: InlineTextEditProps): JSX.Element {
                       placeholder={props.placeholderText}
                       value={tempTextValue}
                       onKeyDown={keyPress}
-                      onChange={(e) => setTempTextValue(e.target.value)}
+                      onChange={(e) => {
+                        setValidationResult(undefined)
+                        setTempTextValue(e.target.value)
+                      }}
                       disabled={!isEditing && props.isSaving}
+                      error={error}
+                      helperText={helpMessage}
                     />
                   </Grid>
                   <Grid item md={3} sm={5} xs={5}>

--- a/ccm_web/client/src/pages/BulkSectionCreate.tsx
+++ b/ccm_web/client/src/pages/BulkSectionCreate.tsx
@@ -5,7 +5,7 @@ import { addCourseSections, getCourseSections } from '../api'
 import ErrorAlert from '../components/ErrorAlert'
 import BulkSectionCreateUploadConfirmationTable, { Section } from '../components/BulkSectionCreateUploadConfirmationTable'
 import {
-  DuplicateSectionInFileSectionRowsValidator, EmptySectionNameValidator, SectionNameTooLongValidator,
+  DuplicateSectionInFileSectionRowsValidator, SectionNameLengthValidator,
   SectionRowsValidator, SectionsRowInvalidation
 } from '../components/BulkSectionCreateValidators'
 import CanvasAPIErrorsTable from '../components/CanvasAPIErrorsTable'
@@ -223,10 +223,8 @@ function BulkSectionCreate (props: CCMComponentProps): JSX.Element {
 
     const duplicateNamesInFileValidator: SectionRowsValidator = new DuplicateSectionInFileSectionRowsValidator()
     rowInvalidations.push(...duplicateNamesInFileValidator.validate(sectionNames))
-    const emptyNamesInFileValidator: EmptySectionNameValidator = new EmptySectionNameValidator()
-    rowInvalidations.push(...emptyNamesInFileValidator.validate(sectionNames))
-    const sectionNamesTooLongValidator: SectionNameTooLongValidator = new SectionNameTooLongValidator()
-    rowInvalidations.push(...sectionNamesTooLongValidator.validate(sectionNames))
+    const sectionNamesLengthValidator = new SectionNameLengthValidator()
+    rowInvalidations.push(...sectionNamesLengthValidator.validate(sectionNames))
 
     return rowInvalidations
   }

--- a/ccm_web/client/src/pages/Home.tsx
+++ b/ccm_web/client/src/pages/Home.tsx
@@ -12,6 +12,7 @@ import { courseRenameRoles } from '../models/feature'
 import { Globals } from '../models/models'
 import { CanvasCourseBase } from '../models/canvas'
 import usePromise from '../hooks/usePromise'
+import { courseNameSchema, validateString } from '../utils/validation'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -104,6 +105,7 @@ function Home (props: HomeProps): JSX.Element {
           text={props.course.name}
           placeholderText='Course name'
           fontSize='1.5rem'
+          validate={(value) => validateString(value, courseNameSchema)}
           save={doSetCourseName}
           isSaving={setCourseNameLoading}
         />

--- a/ccm_web/client/src/utils/ThirdPartyGradebookProcessor.tsx
+++ b/ccm_web/client/src/utils/ThirdPartyGradebookProcessor.tsx
@@ -61,7 +61,7 @@ export default class ThirdPartyGradebookProcessor {
       if (result.isValid) {
         return [assignmentName, undefined]
       } else {
-        errorMessage = result.messages.length > 0 ? result.messages[0] : 'The assignment header is invalid.'
+        errorMessage = result.messages.length > 0 ? result.messages[0] : 'Value for the assignment header is invalid.'
       }
     } else if (otherKeys.length === 0) {
       errorMessage = 'No assignment column was found.'

--- a/ccm_web/client/src/utils/ThirdPartyGradebookProcessor.tsx
+++ b/ccm_web/client/src/utils/ThirdPartyGradebookProcessor.tsx
@@ -1,5 +1,6 @@
 import { CSVRecord } from '../utils/FileParserWrapper'
 import { InvalidationType } from '../models/models'
+import { assignmentHeaderSchema, validateString } from './validation'
 
 export interface GradebookUploadRecord extends CSVRecord {
   'SIS Login ID': string
@@ -33,10 +34,6 @@ interface ProcessResultFailure {
   invalidations: GradebookInvalidation[]
 }
 
-const isCanvasEntityNameLengthValid = (value: string): boolean => {
-  return value.length > 0 && value.length <= 255
-}
-
 export type ProcessResult = ProcessResultSuccess | ProcessResultFailure
 
 export default class ThirdPartyGradebookProcessor {
@@ -60,13 +57,11 @@ export default class ThirdPartyGradebookProcessor {
     const otherKeys = Object.keys(oneRecord).filter(k => !REQUIRED_ORDERED_HEADERS.includes(k))
     if (otherKeys.length === 1) {
       const assignmentName = otherKeys[0]
-      if (isCanvasEntityNameLengthValid(assignmentName)) {
+      const result = validateString(assignmentName, assignmentHeaderSchema)
+      if (result.isValid) {
         return [assignmentName, undefined]
       } else {
-        errorMessage = (
-          'The length of the assignment header is invalid. ' +
-          'Canvas requires assignment names to be at least one character and at most 255 characters.'
-        )
+        errorMessage = result.messages.length > 0 ? result.messages[0] : 'The assignment header is invalid.'
       }
     } else if (otherKeys.length === 0) {
       errorMessage = 'No assignment column was found.'

--- a/ccm_web/client/src/utils/canvasSectionNameValidator.ts
+++ b/ccm_web/client/src/utils/canvasSectionNameValidator.ts
@@ -1,3 +1,4 @@
+import { sectionNameSchema, validateString } from './validation'
 import { getCourseSections } from '../api'
 import { CanvasCourseSection } from '../models/canvas'
 import { Course } from '../models/models'
@@ -19,10 +20,11 @@ class DuplicateSectionNameValidator implements IValidator {
   }
 }
 
-class SectionNameTooLongValidator implements IValidator {
+class SectionNameLengthValidator implements IValidator {
   validate = (sections: CanvasCourseSection[], sectionName: string): ICanvasSectionNameInvalidError | undefined => {
-    if (sectionName.length > 255) {
-      return { reason: 'Section name must be 255 characters or less' }
+    const result = validateString(sectionName, sectionNameSchema)
+    if (!result.isValid) {
+      return { reason: result.messages.length > 0 ? result.messages[0] : 'The section name is invalid.' }
     }
     return undefined
   }
@@ -31,7 +33,7 @@ class SectionNameTooLongValidator implements IValidator {
 export class CanvasCoursesSectionNameValidator {
   course: Course
   _this = this
-  validators: IValidator[] = [new DuplicateSectionNameValidator(), new SectionNameTooLongValidator()]
+  validators: IValidator[] = [new DuplicateSectionNameValidator(), new SectionNameLengthValidator()]
 
   constructor (course: Course) {
     this.course = course

--- a/ccm_web/client/src/utils/validation.ts
+++ b/ccm_web/client/src/utils/validation.ts
@@ -10,9 +10,10 @@ const createExceededMessage = (fieldName: string, max: number): string => {
 
 const createBlankMessage = (fieldName: string): string => `Value for the ${fieldName} may not be blank.`
 
+const canvasMaxNameLength = 255
 const createCanvasEntityNameSchema = (fieldName: string): StringSchema => {
   return string().required(createBlankMessage(fieldName))
-    .max(255, ({ max }) => createExceededMessage(fieldName, max))
+    .max(canvasMaxNameLength, ({ max }) => createExceededMessage(fieldName, max))
 }
 
 export const courseNameSchema = createCanvasEntityNameSchema('course name')

--- a/ccm_web/client/src/utils/validation.ts
+++ b/ccm_web/client/src/utils/validation.ts
@@ -1,0 +1,46 @@
+import { string, StringSchema, ValidationError } from 'yup'
+
+// Yup: https://github.com/jquense/yup
+
+// Schemas
+
+const createExceededMessage = (fieldName: string, max: number): string => {
+  return `Value for the ${fieldName} must be ${max} characters in length or less.`
+}
+
+const createBlankMessage = (fieldName: string): string => `Value for the ${fieldName} may not be blank.`
+
+const createCanvasNamedEntitySchema = (fieldName: string): StringSchema => {
+  return string().required(createBlankMessage(fieldName))
+    .max(255, ({ max }) => createExceededMessage(fieldName, max))
+}
+
+export const courseNameSchema = createCanvasNamedEntitySchema('course name')
+export const assignmentHeaderSchema = createCanvasNamedEntitySchema('assignment header')
+export const sectionNameSchema = createCanvasNamedEntitySchema('section name')
+
+// Type validator(s)
+
+export interface ValidationResult {
+  transformedValue: string | undefined
+  isValid: boolean
+  messages: readonly string[]
+}
+
+export function validateString (value: string | undefined, schema: StringSchema): ValidationResult {
+  let transformedValue: string | undefined
+  let isValid = true
+  let messages: string[] = []
+  try {
+    transformedValue = schema.validateSync(value)
+  } catch (error) {
+    if (!(error instanceof ValidationError)) {
+      throw new Error(String(error))
+    } else {
+      transformedValue = error.value as string | undefined
+      isValid = false
+      messages = error.errors
+    }
+  }
+  return { transformedValue, isValid, messages }
+}

--- a/ccm_web/client/src/utils/validation.ts
+++ b/ccm_web/client/src/utils/validation.ts
@@ -10,14 +10,14 @@ const createExceededMessage = (fieldName: string, max: number): string => {
 
 const createBlankMessage = (fieldName: string): string => `Value for the ${fieldName} may not be blank.`
 
-const createCanvasNamedEntitySchema = (fieldName: string): StringSchema => {
+const createCanvasEntityNameSchema = (fieldName: string): StringSchema => {
   return string().required(createBlankMessage(fieldName))
     .max(255, ({ max }) => createExceededMessage(fieldName, max))
 }
 
-export const courseNameSchema = createCanvasNamedEntitySchema('course name')
-export const assignmentHeaderSchema = createCanvasNamedEntitySchema('assignment header')
-export const sectionNameSchema = createCanvasNamedEntitySchema('section name')
+export const courseNameSchema = createCanvasEntityNameSchema('course name')
+export const assignmentHeaderSchema = createCanvasEntityNameSchema('assignment header')
+export const sectionNameSchema = createCanvasEntityNameSchema('section name')
 
 // Type validator(s)
 

--- a/ccm_web/package-lock.json
+++ b/ccm_web/package-lock.json
@@ -51,7 +51,8 @@
         "swagger-ui-express": "^4.1.6",
         "umzug": "^3.0.0-beta.16",
         "wait-port": "^0.2.9",
-        "winston": "^3.3.3"
+        "winston": "^3.3.3",
+        "yup": "^0.32.11"
       },
       "devDependencies": {
         "@nestjs/testing": "^8.2.0",
@@ -2567,6 +2568,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.177",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
+      "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
     },
     "node_modules/@types/material-ui": {
       "version": "0.21.12",
@@ -9096,6 +9102,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -9745,6 +9756,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "node_modules/nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
     },
     "node_modules/nanoid": {
       "version": "3.1.30",
@@ -11105,6 +11121,11 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/property-expr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.4.tgz",
+      "integrity": "sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -12955,6 +12976,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
+    },
     "node_modules/toposort-class": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
@@ -14231,6 +14257,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     }
   },
@@ -16149,6 +16192,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/lodash": {
+      "version": "4.14.177",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
+      "integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
     },
     "@types/material-ui": {
       "version": "0.21.12",
@@ -21209,6 +21257,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -21744,6 +21797,11 @@
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
       }
+    },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
     },
     "nanoid": {
       "version": "3.1.30",
@@ -22777,6 +22835,11 @@
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
+    },
+    "property-expr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.4.tgz",
+      "integrity": "sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -24168,6 +24231,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
+    },
     "toposort-class": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
@@ -25109,6 +25177,20 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      }
     }
   }
 }

--- a/ccm_web/package.json
+++ b/ccm_web/package.json
@@ -61,7 +61,8 @@
     "swagger-ui-express": "^4.1.6",
     "umzug": "^3.0.0-beta.16",
     "wait-port": "^0.2.9",
-    "winston": "^3.3.3"
+    "winston": "^3.3.3",
+    "yup": "^0.32.11"
   },
   "devDependencies": {
     "@nestjs/testing": "^8.2.0",


### PR DESCRIPTION
This PR tries to enhance and simplify validation in the front-end by leveraging the [`yup` library](https://github.com/jquense/yup#stringrequiredmessage-string--function-schema) to create schemas (encapsulating multiple tests and associated error messages) and use them to validate strings. The resulting `validation` module is used for field validation in `InlineTextEdit` and to replace identical basic string length validation in a couple other modules. The PR aims to resolve #244 and #276.

Note(s):
- This builds on -- but does not exactly reproduce work -- I did in ROHQ: https://github.com/tl-its-umich-edu/remote-office-hours-queue/blob/master/src/assets/src/validation.ts In ROHQ, I fired validation on each keystroke and reported remaining characters; in the interest of speed and simplicity, I did not do that here (could be done later).
- Includes a new package, so testers need to re-build their Docker images.