### PR TITLE
Modify layout, file name, and language in documentation section in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ for more info.
 To deploy the latest changes to the GitHub Pages site, follow the steps below:
 1. Go to the CCM repository, then click "Settings" and then "Pages".
 2. Choose the branch to deploy from, and then specify the `docs` folder.
-3. Click "Save", which will begin a deployment. (It will take a few seconds, and only 10 builds are allowed per hour).
+3. Click "Save", which will begin a deployment. (It will take a few seconds, and only 10 builds are allowed per hour.)
 4. Once the site has been published, navigate to `https://{your_account}.github.io/canvas-course-manager-next`,
 replacing `{your_account}` with your GitHub user or organization name, to view the content.
 

--- a/README.md
+++ b/README.md
@@ -220,19 +220,26 @@ GitHub Pages is used for hosting the CCM feature documentation, and files are pl
 #### Testing locally
 
 In order to test documentation changes locally, follow the steps below:
-    1. `cd docs` folder
-    2. `docker compose -f docker-compose-gh-page.yml up`
-    3. Navigate to `http://locahost:4020` in your browser. Recent changes to files will be automatically deployed; the changes will be displayed after a browser refresh.
+
+1. Navigate to `docs` folder.
+    ```
+    cd docs
+    ```
+2. Start up a local server:
+    ```
+    docker compose -f docker-compose-gh-pages.yml up`
+    ```
+3. Navigate to `http://locahost:4020` in your browser. Recent changes to files will be automatically deployed; the changes will be displayed after a browser refresh.
     
 GitHub follows Jekyll structure for deploying. See [here](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll) for more info.
 
 #### Deploying to GitHub Pages
 
 To deploy the latest changes to the GitHub Pages site, follow the steps below:
-    1. Go to the CCM repository, then click "Settings" and then "Pages".
-    2. Choose the branch to deploy from, and then specify the `docs` folder.
-    3. Click "Save", which will begin a deployment. (It will take a few seconds, and only 10 builds are allowed per hour).
-    4. Once the site has been published, navigate to `https://{your_account}.github.io/canvas-course-manager-next`, replacing `{your_account}` with your GitHub user or organization name, to view the content.
+1. Go to the CCM repository, then click "Settings" and then "Pages".
+2. Choose the branch to deploy from, and then specify the `docs` folder.
+3. Click "Save", which will begin a deployment. (It will take a few seconds, and only 10 builds are allowed per hour).
+4. Once the site has been published, navigate to `https://{your_account}.github.io/canvas-course-manager-next`, replacing `{your_account}` with your GitHub user or organization name, to view the content.
 
 See [here](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll) for more info about this process.
 

--- a/README.md
+++ b/README.md
@@ -215,23 +215,26 @@ Developers have to write `up` and `down` migration steps manually.
 5. For more information, see "[Node.js debugging in VS Code](https://code.visualstudio.com/docs/nodejs/nodejs-debugging)" on the official documentation website.
 
 ### CCM Documentation
-GitHub Pages is used for hosting the CCM feature documentation, and files are placed and served from the `docs` folder.
+GitHub Pages is used for hosting the CCM feature documentation,
+and files are placed and served from the `docs` directory.
 
 #### Testing locally
 
 In order to test documentation changes locally, follow the steps below:
-
-1. Navigate to `docs` folder.
+1. Navigate to the `docs` directory.
     ```
     cd docs
     ```
-2. Start up a local server:
+2. Start up the documentation testing server with Docker:
     ```
     docker compose -f docker-compose-gh-pages.yml up`
     ```
-3. Navigate to `http://locahost:4020` in your browser. Recent changes to files will be automatically deployed; the changes will be displayed after a browser refresh.
+3. Navigate to `http://locahost:4020` in your browser.
+Recent changes to files will be automatically deployed; the changes will be displayed after a browser refresh.
     
-GitHub follows Jekyll structure for deploying. See [here](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll) for more info.
+GitHub follows Jekyll structure for deploying.
+See [here](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll)
+for more info.
 
 #### Deploying to GitHub Pages
 
@@ -239,7 +242,8 @@ To deploy the latest changes to the GitHub Pages site, follow the steps below:
 1. Go to the CCM repository, then click "Settings" and then "Pages".
 2. Choose the branch to deploy from, and then specify the `docs` folder.
 3. Click "Save", which will begin a deployment. (It will take a few seconds, and only 10 builds are allowed per hour).
-4. Once the site has been published, navigate to `https://{your_account}.github.io/canvas-course-manager-next`, replacing `{your_account}` with your GitHub user or organization name, to view the content.
+4. Once the site has been published, navigate to `https://{your_account}.github.io/canvas-course-manager-next`,
+replacing `{your_account}` with your GitHub user or organization name, to view the content.
 
 See [here](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/creating-a-github-pages-site-with-jekyll) for more info about this process.
 


### PR DESCRIPTION
This PR makes small modifications to the "CCM Documentation" section so as to make the formatting more consistent with the rest of the document, fix a sample Docker command that gave the wrong file name, and make instructions clearer. The PR has no associated issue but is related to PR #224.