### PR TITLE
Use `encodeURIComponent` with CSV download data for better character handling (#271)

### DIFF
--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -364,10 +364,12 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
     processedRecords: GradebookUploadRecord[], assignmentHeader: string, file: File
   ): JSX.Element => {
     const recordsToReview = processedRecords.map((r, i) => ({ rowNumber: i + 2, ...r }))
-    const dataToDownload = 'data:text/csv;charset=utf-8,' + csvParser.createCSV<GradebookUploadRecord>({
-      fields: [...REQUIRED_ORDERED_HEADERS, assignmentHeader],
-      data: processedRecords
-    })
+    const dataToDownload = 'data:text/csv;charset=utf-8,' + encodeURIComponent(
+      csvParser.createCSV<GradebookUploadRecord>({
+        fields: [...REQUIRED_ORDERED_HEADERS, assignmentHeader],
+        data: processedRecords
+      })
+    )
 
     return (
       <div className={classes.reviewContainer}>

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -123,8 +123,8 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
 
   const setCSVtoDownload = (data: GradebookRecord[]): void => {
     const csvData = data.map(r => [r['SIS LOGIN ID'], getGradeForExport(r)])
-    const csvString = 'data:text/csv;charset=utf-8,' + fileParser.createCSV<string[]>(csvData)
-    setDownloadData({ data: encodeURI(csvString), fileName: getOutputFilename(file) })
+    const csvString = 'data:text/csv;charset=utf-8,' + encodeURIComponent(fileParser.createCSV<string[]>(csvData))
+    setDownloadData({ data: csvString, fileName: getOutputFilename(file) })
   }
 
   const handleInvalidUpload = (errorMessages?: JSX.Element[], invalidations?: GradebookRowInvalidation[]): void => {


### PR DESCRIPTION
This PR aims to resolve #271.

Resource(s):
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent