### PR TITLE
Add "Back" and "Start Again" buttons where relevant (#238)

### DIFF
--- a/ccm_web/client/src/components/ErrorAlert.tsx
+++ b/ccm_web/client/src/components/ErrorAlert.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme) => ({
 interface ErrorAlertProps {
   // Spacing works out best when you use Material UI Typography components or p tags.
   messages?: JSX.Element[]
-  tryAgain?: () => void
+  tryAgain?: () => void | Promise<void>
   title?: string
   icon?: JSX.Element
   embedded?: boolean

--- a/ccm_web/client/src/components/MethodSelect.tsx
+++ b/ccm_web/client/src/components/MethodSelect.tsx
@@ -14,7 +14,7 @@ interface MethodSelectProps<T extends string> {
   selectedMethod: T
   typeGuard: (v: string) => v is T
   setMethod: (method: T) => void
-  onButtonClick: () => void
+  onButtonClick: () => void | Promise<void>
   disabled: boolean | undefined
 }
 

--- a/ccm_web/client/src/components/MultipleUserEnrollmentWorkflow.tsx
+++ b/ccm_web/client/src/components/MultipleUserEnrollmentWorkflow.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles((theme) => ({
     position: 'absolute',
     textAlign: 'center'
   },
-  confirmContainer: {
+  container: {
     position: 'relative',
     zIndex: 0
   },
@@ -101,6 +101,13 @@ export default function MultipleUserEnrollmentWorkflow (props: MultipleUserEnrol
     setRowInvalidations(undefined)
   }
 
+  const getSectionsErrorAlert = (
+    <ErrorAlert
+      messages={[<Typography key={0}>An error occurred while loading section data from Canvas.</Typography>]}
+      tryAgain={props.doGetSections}
+    />
+  )
+
   const renderSchemaInvalidations = (invalidations: SchemaInvalidation[]): JSX.Element => {
     const messages = invalidations.map(
       (invalidation, i) => <Typography key={i}>{invalidation.message}</Typography>
@@ -122,6 +129,8 @@ export default function MultipleUserEnrollmentWorkflow (props: MultipleUserEnrol
   }
 
   const renderSelect = (): JSX.Element => {
+    if (props.getSectionsError !== undefined) return getSectionsErrorAlert
+
     const canCreate = isAuthorizedForRoles(props.userCourseRoles, createSectionRoles)
     const createProps: CreateSelectSectionWidgetCreateProps = canCreate
       ? { canCreate: true, course: props.course, onSectionCreated: props.onSectionCreated }
@@ -129,12 +138,20 @@ export default function MultipleUserEnrollmentWorkflow (props: MultipleUserEnrol
 
     return (
       <>
-      <CreateSelectSectionWidget
-        sections={props.sections}
-        selectedSection={selectedSection}
-        setSelectedSection={setSelectedSection}
-        {...createProps}
-      />
+      <div className={classes.container}>
+        <CreateSelectSectionWidget
+          sections={props.sections}
+          selectedSection={selectedSection}
+          setSelectedSection={setSelectedSection}
+          {...createProps}
+        />
+        <Backdrop className={classes.backdrop} open={props.isGetSectionsLoading}>
+          <Grid container>
+            <Grid item xs={12}><CircularProgress color='inherit' /></Grid>
+            <Grid item xs={12}>Loading section data from Canvas</Grid>
+          </Grid>
+        </Backdrop>
+      </div>
       <Grid container className={classes.buttonGroup} justifyContent='space-between'>
         <Button
           variant='outlined'
@@ -272,7 +289,7 @@ export default function MultipleUserEnrollmentWorkflow (props: MultipleUserEnrol
 
   const renderReview = (sectionId: number, enrollments: AddNumberedNewExternalUserEnrollment[]): JSX.Element => {
     return (
-      <div className={classes.confirmContainer}>
+      <div className={classes.container}>
         {file !== undefined && <CSVFileName file={file} />}
         <Grid container>
           <Box clone order={{ xs: 2, sm: 1 }}>
@@ -297,12 +314,8 @@ export default function MultipleUserEnrollmentWorkflow (props: MultipleUserEnrol
         </Grid>
         <Backdrop className={classes.backdrop} open={isAddExternalEnrollmentsLoading}>
           <Grid container>
-            <Grid item xs={12}>
-              <CircularProgress color='inherit' />
-            </Grid>
-            <Grid item xs={12}>
-              Loading...
-            </Grid>
+            <Grid item xs={12}><CircularProgress color='inherit' /></Grid>
+            <Grid item xs={12}>Loading...</Grid>
             <Grid item xs={12}>
               Please stay on the page. This may take up to a couple of minutes for larger files.
             </Grid>

--- a/ccm_web/client/src/components/MultipleUserEnrollmentWorkflow.tsx
+++ b/ccm_web/client/src/components/MultipleUserEnrollmentWorkflow.tsx
@@ -202,6 +202,7 @@ export default function MultipleUserEnrollmentWorkflow (props: MultipleUserEnrol
 
     const handleBackClick = async (): Promise<void> => {
       handleResetUpload()
+      setSelectedSection(undefined)
       setActiveStep(CSVWorkflowStep.Select)
       await props.doGetSections()
     }

--- a/ccm_web/client/src/components/MultipleUserEnrollmentWorkflow.tsx
+++ b/ccm_web/client/src/components/MultipleUserEnrollmentWorkflow.tsx
@@ -17,7 +17,7 @@ import usePromise from '../hooks/usePromise'
 import { CanvasCourseBase, CanvasCourseSection, CanvasCourseSectionWithCourseName, ClientEnrollmentType } from '../models/canvas'
 import { AddNewExternalUserEnrollment, AddNumberedNewExternalUserEnrollment } from '../models/enrollment'
 import { createSectionRoles } from '../models/feature'
-import { isAuthorizedForRoles } from '../models/FeatureUIData'
+import { AddNonUMUsersLeafProps, isAuthorizedForRoles } from '../models/FeatureUIData'
 import { CSVWorkflowStep, InvalidationType, RoleEnum } from '../models/models'
 import CSVSchemaValidator, { SchemaInvalidation } from '../utils/CSVSchemaValidator'
 import {
@@ -65,13 +65,9 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-interface MultipleUserEnrollmentWorkflowProps {
+interface MultipleUserEnrollmentWorkflowProps extends AddNonUMUsersLeafProps {
   course: CanvasCourseBase
-  sections: CanvasCourseSectionWithCourseName[]
   onSectionCreated: (newSection: CanvasCourseSection) => void
-  readonly rolesUserCanEnroll: ClientEnrollmentType[]
-  resetFeature: () => void
-  settingsURL: string
   userCourseRoles: RoleEnum[]
 }
 
@@ -332,7 +328,9 @@ export default function MultipleUserEnrollmentWorkflow (props: MultipleUserEnrol
       <>
       <SuccessCard {...{ message, nextAction }} />
       <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
-        <Button variant='outlined' onClick={props.resetFeature}>Start Again</Button>
+        <Button variant='outlined' aria-label={`Start ${props.featureTitle} again`} onClick={props.resetFeature}>
+          Start Again
+        </Button>
       </Grid>
       </>
     )

--- a/ccm_web/client/src/components/MultipleUserEnrollmentWorkflow.tsx
+++ b/ccm_web/client/src/components/MultipleUserEnrollmentWorkflow.tsx
@@ -147,7 +147,7 @@ export default function MultipleUserEnrollmentWorkflow (props: MultipleUserEnrol
           variant='contained'
           color='primary'
           aria-label='Select section'
-          disabled={selectedSection === undefined}
+          disabled={selectedSection === undefined || props.isGetSectionsLoading}
           onClick={() => setActiveStep(CSVWorkflowStep.Upload)}
         >
           Select
@@ -200,9 +200,10 @@ export default function MultipleUserEnrollmentWorkflow (props: MultipleUserEnrol
       'jdoe@example.edu,student,jane,doe'
     )
 
-    const handleBackClick = (): void => {
+    const handleBackClick = async (): Promise<void> => {
       handleResetUpload()
       setActiveStep(CSVWorkflowStep.Select)
+      await props.doGetSections()
     }
 
     const handleValidation = (headers: string[] | undefined, rowData: CSVRecord[]): void => {

--- a/ccm_web/client/src/components/UserEnrollmentForm.tsx
+++ b/ccm_web/client/src/components/UserEnrollmentForm.tsx
@@ -11,6 +11,7 @@ import * as api from '../api'
 import usePromise from '../hooks/usePromise'
 import { CanvasCourseSectionWithCourseName, ClientEnrollmentType, getCanvasRole } from '../models/canvas'
 import { AddExternalUserEnrollment, AddNewExternalUserEnrollment } from '../models/enrollment'
+import { AddNonUMUsersLeafProps } from '../models/FeatureUIData'
 import { CanvasError } from '../utils/handleErrors'
 import { emailSchema, firstNameSchema, lastNameSchema, validateString, ValidationResult } from '../utils/validation'
 
@@ -41,12 +42,7 @@ interface APIErrorWithContext {
   context: string
 }
 
-interface UserEnrollmentFormProps {
-  sections: CanvasCourseSectionWithCourseName[]
-  readonly rolesUserCanEnroll: ClientEnrollmentType[]
-  resetFeature: () => void
-  settingsURL: string
-}
+interface UserEnrollmentFormProps extends AddNonUMUsersLeafProps {}
 
 export default function UserEnrollmentForm (props: UserEnrollmentFormProps): JSX.Element {
   const classes = useStyles()
@@ -374,7 +370,9 @@ export default function UserEnrollmentForm (props: UserEnrollmentFormProps): JSX
       <>
       <SuccessCard message={<Typography>{messageText}</Typography>} nextAction={nextAction} />
       <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
-        <Button variant='outlined' onClick={props.resetFeature}>Start Again</Button>
+        <Button variant='outlined' aria-label={`Start ${props.featureTitle} again`} onClick={props.resetFeature}>
+          Start Again
+        </Button>
       </Grid>
       </>
     )

--- a/ccm_web/client/src/components/UserEnrollmentForm.tsx
+++ b/ccm_web/client/src/components/UserEnrollmentForm.tsx
@@ -116,12 +116,13 @@ export default function UserEnrollmentForm (props: UserEnrollmentFormProps): JSX
     clearAddNewExternalEnrollmentError()
   }
 
-  const resetAll = (): void => {
+  const resetAll = async (): Promise<void> => {
     setEmail(undefined)
     setRole(undefined)
     setSelectedSection(undefined)
     resetNameEntryState()
     resetErrors()
+    await props.doGetSections()
   }
 
   const handleSearchClick = async (): Promise<void> => {

--- a/ccm_web/client/src/components/UserEnrollmentForm.tsx
+++ b/ccm_web/client/src/components/UserEnrollmentForm.tsx
@@ -91,6 +91,7 @@ export default function UserEnrollmentForm (props: UserEnrollmentFormProps): JSX
   )
 
   const errorsWithContext = [
+    { error: props.getSectionsError, context: 'loading section data' },
     { error: searchForUserError, context: 'searching for the user' },
     { error: addEnrollmentError, context: 'enrolling the user in a section' },
     { error: addNewExternalEnrollmentError, context: 'adding the new external user' }
@@ -308,21 +309,29 @@ export default function UserEnrollmentForm (props: UserEnrollmentFormProps): JSX
             showIncompleteAlerts && selectedSection === undefined &&
               <InlineErrorAlert>You must select one section from the list below.</InlineErrorAlert>
           }
-          <SectionSelectorWidget
-            height={300}
-            search={[]}
-            multiSelect={false}
-            sections={props.sections}
-            selectedSections={selectedSection !== undefined ? [selectedSection] : []}
-            selectionUpdated={(sections) => {
-              if (sections.length === 0) {
-                setSelectedSection(undefined)
-              } else {
-                setSelectedSection(sections[0])
-              }
-            }}
-            canUnmerge={false}
-          />
+          <div className={classes.container}>
+            <SectionSelectorWidget
+              height={300}
+              search={[]}
+              multiSelect={false}
+              sections={props.sections}
+              selectedSections={selectedSection !== undefined ? [selectedSection] : []}
+              selectionUpdated={(sections) => {
+                if (sections.length === 0) {
+                  setSelectedSection(undefined)
+                } else {
+                  setSelectedSection(sections[0])
+                }
+              }}
+              canUnmerge={false}
+            />
+            <Backdrop className={classes.backdrop} open={props.isGetSectionsLoading}>
+              <Grid container>
+                <Grid item xs={12}><CircularProgress color='inherit' /></Grid>
+                <Grid item xs={12}>Loading section data from Canvas</Grid>
+              </Grid>
+            </Backdrop>
+          </div>
           <Grid container className={classes.buttonGroup} justifyContent='space-between'>
             <Button
               variant='outlined'

--- a/ccm_web/client/src/components/UserEnrollmentForm.tsx
+++ b/ccm_web/client/src/components/UserEnrollmentForm.tsx
@@ -97,7 +97,7 @@ export default function UserEnrollmentForm (props: UserEnrollmentFormProps): JSX
   ].filter(d => d.error !== undefined) as APIErrorWithContext[]
 
   const isEnrollmentLoading = isAddEnrollmentLoading || isAddNewExternalEnrollmentLoading
-  const isLoading = isSearchForUserLoading || isEnrollmentLoading
+  const isLoading = props.isGetSectionsLoading || isSearchForUserLoading || isEnrollmentLoading
 
   // Handlers
 
@@ -297,7 +297,7 @@ export default function UserEnrollmentForm (props: UserEnrollmentFormProps): JSX
               roles={props.rolesUserCanEnroll}
               selectedRole={role}
               onRoleChange={setRole}
-              disabled={isEnrollmentLoading}
+              disabled={isLoading}
             />
           </div>
           <Typography className={classes.spacing}>

--- a/ccm_web/client/src/models/FeatureUIData.tsx
+++ b/ccm_web/client/src/models/FeatureUIData.tsx
@@ -17,7 +17,7 @@ import FormatThirdPartyGradebook from '../pages/FormatThirdPartyGradebook'
 import ConvertCanvasGradebook from '../pages/GradebookCanvas'
 import MergeSections from '../pages/MergeSections'
 import { Globals, RoleEnum } from './models'
-import { CanvasCourseBase } from './canvas'
+import { CanvasCourseBase, CanvasCourseSectionWithCourseName, ClientEnrollmentType } from './canvas'
 
 export interface CCMComponentProps {
   globals: Globals
@@ -38,6 +38,14 @@ interface FeatureUIProps {
   icon: JSX.Element
   component: ComponentType<CCMComponentProps>
   route: string
+}
+
+interface AddNonUMUsersLeafProps {
+  sections: CanvasCourseSectionWithCourseName[]
+  readonly rolesUserCanEnroll: ClientEnrollmentType[]
+  featureTitle: string
+  resetFeature: () => void
+  settingsURL: string
 }
 
 const mergeSectionCardProps: FeatureUIProps = {
@@ -102,5 +110,5 @@ const isAuthorizedForAnyFeature = (roles: RoleEnum[], features: FeatureUIProps[]
 }
 
 export type { FeatureUIGroup, FeatureUIProps }
-export { isAuthorizedForAnyFeature, isAuthorizedForFeature, isAuthorizedForRoles }
+export { AddNonUMUsersLeafProps, isAuthorizedForAnyFeature, isAuthorizedForFeature, isAuthorizedForRoles }
 export default allFeatures

--- a/ccm_web/client/src/models/FeatureUIData.tsx
+++ b/ccm_web/client/src/models/FeatureUIData.tsx
@@ -32,6 +32,8 @@ export interface AddNonUMUsersLeafProps {
   featureTitle: string
   resetFeature: () => void
   settingsURL: string
+  doGetSections: () => Promise<void>
+  isGetSectionsLoading: boolean
 }
 
 interface FeatureUIGroup {

--- a/ccm_web/client/src/models/FeatureUIData.tsx
+++ b/ccm_web/client/src/models/FeatureUIData.tsx
@@ -28,12 +28,12 @@ export interface CCMComponentProps {
 
 export interface AddNonUMUsersLeafProps {
   sections: CanvasCourseSectionWithCourseName[]
-  readonly rolesUserCanEnroll: ClientEnrollmentType[]
-  featureTitle: string
-  resetFeature: () => void
-  settingsURL: string
   doGetSections: () => Promise<void>
   isGetSectionsLoading: boolean
+  readonly rolesUserCanEnroll: ClientEnrollmentType[]
+  featureTitle: string
+  settingsURL: string
+  resetFeature: () => void
 }
 
 interface FeatureUIGroup {

--- a/ccm_web/client/src/models/FeatureUIData.tsx
+++ b/ccm_web/client/src/models/FeatureUIData.tsx
@@ -30,6 +30,7 @@ export interface AddNonUMUsersLeafProps {
   sections: CanvasCourseSectionWithCourseName[]
   doGetSections: () => Promise<void>
   isGetSectionsLoading: boolean
+  getSectionsError: Error | undefined
   readonly rolesUserCanEnroll: ClientEnrollmentType[]
   featureTitle: string
   settingsURL: string

--- a/ccm_web/client/src/models/FeatureUIData.tsx
+++ b/ccm_web/client/src/models/FeatureUIData.tsx
@@ -26,6 +26,14 @@ export interface CCMComponentProps {
   helpURLEnding: string
 }
 
+export interface AddNonUMUsersLeafProps {
+  sections: CanvasCourseSectionWithCourseName[]
+  readonly rolesUserCanEnroll: ClientEnrollmentType[]
+  featureTitle: string
+  resetFeature: () => void
+  settingsURL: string
+}
+
 interface FeatureUIGroup {
   id: string
   title: string
@@ -38,14 +46,6 @@ interface FeatureUIProps {
   icon: JSX.Element
   component: ComponentType<CCMComponentProps>
   route: string
-}
-
-interface AddNonUMUsersLeafProps {
-  sections: CanvasCourseSectionWithCourseName[]
-  readonly rolesUserCanEnroll: ClientEnrollmentType[]
-  featureTitle: string
-  resetFeature: () => void
-  settingsURL: string
 }
 
 const mergeSectionCardProps: FeatureUIProps = {
@@ -110,5 +110,5 @@ const isAuthorizedForAnyFeature = (roles: RoleEnum[], features: FeatureUIProps[]
 }
 
 export type { FeatureUIGroup, FeatureUIProps }
-export { AddNonUMUsersLeafProps, isAuthorizedForAnyFeature, isAuthorizedForFeature, isAuthorizedForRoles }
+export { isAuthorizedForAnyFeature, isAuthorizedForFeature, isAuthorizedForRoles }
 export default allFeatures

--- a/ccm_web/client/src/pages/AddNonUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddNonUMUsers.tsx
@@ -106,15 +106,15 @@ export default function AddNonUMUsers (props: AddNonUMUsersProps): JSX.Element {
 
     const commonProps = {
       sections: sections ?? [],
-      rolesUserCanEnroll,
-      featureTitle: props.title,
-      resetFeature,
-      settingsURL,
       doGetSections: async () => {
         setSections(undefined)
         await doGetSections()
       },
-      isGetSectionsLoading
+      isGetSectionsLoading,
+      rolesUserCanEnroll,
+      featureTitle: props.title,
+      settingsURL,
+      resetFeature
     }
 
     const onSectionCreated = (newSection: CanvasCourseSection): void => {

--- a/ccm_web/client/src/pages/AddNonUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddNonUMUsers.tsx
@@ -120,35 +120,29 @@ export default function AddNonUMUsers (props: AddNonUMUsersProps): JSX.Element {
   const resetFeature = (): void => setActivePageState(PageState.SelectInputMethod)
 
   const renderActivePageState = (state: PageState): JSX.Element => {
+    const commonProps = {
+      sections: sections ?? [], rolesUserCanEnroll, featureTitle: props.title, resetFeature, settingsURL
+    }
+
+    const onSectionCreated = (newSection: CanvasCourseSection): void => {
+      if (sections !== undefined) {
+        setSections(
+          sortSections(sections.concat(injectCourseName([newSection], props.course.name)))
+        )
+      }
+    }
+
     switch (state) {
       case PageState.SelectInputMethod:
         return renderSelectInputMethod()
       case PageState.AddSingleUser:
-        return (
-          <UserEnrollmentForm
-            sections={sections ?? []}
-            rolesUserCanEnroll={rolesUserCanEnroll}
-            resetFeature={resetFeature}
-            settingsURL={settingsURL}
-          />
-        )
+        return <UserEnrollmentForm {...commonProps} />
       case PageState.AddCSVUsers:
         return (
           <MultipleUserEnrollmentWorkflow
+            {...commonProps}
             course={props.course}
-            sections={sections ?? []}
-            onSectionCreated={
-              (newSection) => {
-                if (sections !== undefined) {
-                  setSections(
-                    sortSections(sections.concat(injectCourseName([newSection], props.course.name)))
-                  )
-                }
-              }
-            }
-            rolesUserCanEnroll={rolesUserCanEnroll}
-            resetFeature={resetFeature}
-            settingsURL={settingsURL}
+            onSectionCreated={onSectionCreated}
             userCourseRoles={props.globals.course.roles}
           />
         )

--- a/ccm_web/client/src/pages/AddNonUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddNonUMUsers.tsx
@@ -97,6 +97,7 @@ export default function AddNonUMUsers (props: AddNonUMUsersProps): JSX.Element {
   }
 
   const resetFeature = (): void => {
+    setSections(undefined)
     setActivePageState(PageState.SelectInputMethod)
   }
 
@@ -109,7 +110,10 @@ export default function AddNonUMUsers (props: AddNonUMUsersProps): JSX.Element {
       featureTitle: props.title,
       resetFeature,
       settingsURL,
-      doGetSections,
+      doGetSections: async () => {
+        setSections(undefined)
+        await doGetSections()
+      },
       isGetSectionsLoading
     }
 
@@ -133,7 +137,6 @@ export default function AddNonUMUsers (props: AddNonUMUsersProps): JSX.Element {
             course={props.course}
             onSectionCreated={onSectionCreated}
             userCourseRoles={props.globals.course.roles}
-            doGetSections={doGetSections}
           />
         )
       default:

--- a/ccm_web/client/src/pages/AddNonUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddNonUMUsers.tsx
@@ -117,7 +117,10 @@ export default function AddNonUMUsers (props: AddNonUMUsersProps): JSX.Element {
     )
   }
 
-  const resetFeature = (): void => setActivePageState(PageState.SelectInputMethod)
+  const resetFeature = (): void => {
+    setSections(undefined)
+    setActivePageState(PageState.SelectInputMethod)
+  }
 
   const renderActivePageState = (state: PageState): JSX.Element => {
     const commonProps = {

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -220,7 +220,7 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
         <ErrorAlert
           messages={[<Typography key={0}>An error occurred while loading section data from Canvas.</Typography>]}
           tryAgain={async () => {
-            clearGetSectionsError()
+            handleSectionsReset()
             await doGetSections()
           }}
         />

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -293,6 +293,7 @@ designer,userd`
             variant='outlined'
             aria-label='Back to Select Section'
             onClick={async () => {
+              handleSectionsReset()
               setActiveStep(CSVWorkflowStep.Select)
               await doGetSections()
             }}

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -429,8 +429,8 @@ designer,userd`
     <div className={classes.root}>
       <Help baseHelpURL={props.globals.baseHelpURL} helpURLEnding={props.helpURLEnding} />
       <Typography variant='h5' component='h1'>{props.title}</Typography>
-      <WorkflowStepper allSteps={Object(CSVWorkflowStep)} activeStep={activeStep} />
       <div className={classes.container}>
+        <WorkflowStepper allSteps={Object(CSVWorkflowStep)} activeStep={activeStep} />
         {getStepContent(activeStep)}
         <Backdrop className={classes.backdrop} open={isGetSectionsLoading}>
           <Grid container>

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -130,7 +130,7 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
 
   const sectionCreated = (newSection: CanvasCourseSection): void => {
     const newSectionWithCourseName = injectCourseName([newSection], props.course.name)[0]
-    const existingSections = sections !== undefined ? sections : []
+    const existingSections = sections ?? []
     updateSections(existingSections.concat(newSectionWithCourseName))
     setSelectedSection(newSectionWithCourseName)
   }

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -408,7 +408,7 @@ designer,userd`
       <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
         <Button
           variant='outlined'
-          aria-label='Start Add U-M Users again'
+          aria-label={`Start ${props.title} again`}
           onClick={handleFullReset}
         >
           Start Again

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -224,15 +224,23 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
     } else {
       return (
         <>
-        <CreateSelectSectionWidget
-          sections={sections ?? []}
-          selectedSection={selectedSection}
-          setSelectedSection={setSelectedSection}
-          // Only admins have access to the Add UM Users feature, and they can create sections.
-          canCreate={true}
-          course={props.course}
-          onSectionCreated={sectionCreated}
-        />
+        <div className={classes.container}>
+          <CreateSelectSectionWidget
+            sections={sections ?? []}
+            selectedSection={selectedSection}
+            setSelectedSection={setSelectedSection}
+            // Only admins have access to the Add UM Users feature, and they can create sections.
+            canCreate={true}
+            course={props.course}
+            onSectionCreated={sectionCreated}
+          />
+          <Backdrop className={classes.backdrop} open={isGetSectionsLoading}>
+            <Grid container>
+              <Grid item xs={12}><CircularProgress color='inherit' /></Grid>
+              <Grid item xs={12}>Loading section data from Canvas</Grid>
+            </Grid>
+          </Backdrop>
+        </div>
         <Grid container className={classes.buttonGroup} justifyContent='flex-end'>
           <Button
             variant='contained'
@@ -429,16 +437,8 @@ designer,userd`
     <div className={classes.root}>
       <Help baseHelpURL={props.globals.baseHelpURL} helpURLEnding={props.helpURLEnding} />
       <Typography variant='h5' component='h1'>{props.title}</Typography>
-      <div className={classes.container}>
-        <WorkflowStepper allSteps={Object(CSVWorkflowStep)} activeStep={activeStep} />
-        {getStepContent(activeStep)}
-        <Backdrop className={classes.backdrop} open={isGetSectionsLoading}>
-          <Grid container>
-            <Grid item xs={12}><CircularProgress color='inherit' /></Grid>
-            <Grid item xs={12}>Loading section data from Canvas</Grid>
-          </Grid>
-        </Backdrop>
-      </div>
+      <WorkflowStepper allSteps={Object(CSVWorkflowStep)} activeStep={activeStep} />
+      {getStepContent(activeStep)}
     </div>
   )
 }

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -408,11 +408,7 @@ designer,userd`
       <>
       <SuccessCard {...{ message, nextAction }} />
       <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
-        <Button
-          variant='outlined'
-          aria-label={`Start ${props.title} again`}
-          onClick={handleFullReset}
-        >
+        <Button variant='outlined' aria-label={`Start ${props.title} again`} onClick={handleFullReset}>
           Start Again
         </Button>
       </Grid>

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -225,6 +225,7 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
       )
     } else {
       return (
+        <>
         <div className={classes.createSelectSectionContainer}>
           <CreateSelectSectionWidget
             sections={sections ?? []}
@@ -245,17 +246,18 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
               </Grid>
             </Grid>
           </Backdrop>
-          <Grid container className={classes.buttonGroup} justifyContent='flex-end'>
-            <Button
-              variant='contained'
-              color='primary'
-              disabled={selectedSection === undefined || isGetSectionsLoading}
-              onClick={() => setActiveStep(CSVWorkflowStep.Upload)}
-            >
-              Select
-            </Button>
-          </Grid>
         </div>
+        <Grid container className={classes.buttonGroup} justifyContent='flex-end'>
+          <Button
+            variant='contained'
+            color='primary'
+            disabled={selectedSection === undefined || isGetSectionsLoading}
+            onClick={() => setActiveStep(CSVWorkflowStep.Upload)}
+          >
+            Select
+          </Button>
+        </Grid>
+        </>
       )
     }
   }

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -438,7 +438,7 @@ designer,userd`
       <Help baseHelpURL={props.globals.baseHelpURL} helpURLEnding={props.helpURLEnding} />
       <Typography variant='h5' component='h1'>{props.title}</Typography>
       <WorkflowStepper allSteps={Object(CSVWorkflowStep)} activeStep={activeStep} />
-      {getStepContent(activeStep)}
+      <div>{getStepContent(activeStep)}</div>
     </div>
   )
 }

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -103,7 +103,7 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
     setSections(sortSections(sections))
   }
 
-  const [doGetSections, isGetSectionsLoading, getSectionsError] = usePromise(
+  const [doGetSections, isGetSectionsLoading, getSectionsError, clearGetSectionsError] = usePromise(
     async () => await getCourseSections(props.globals.course.id),
     (sections: CanvasCourseSection[]) => {
       updateSections(injectCourseName(sections, props.course.name))
@@ -155,6 +155,7 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
   const handleSectionsReset = (): void => {
     setSections(undefined)
     setSelectedSection(undefined)
+    clearGetSectionsError()
   }
 
   const handleEnrollmentsReset = (): void => {
@@ -218,7 +219,10 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
       return (
         <ErrorAlert
           messages={[<Typography key={0}>An error occurred while loading section data from Canvas.</Typography>]}
-          tryAgain={doGetSections}
+          tryAgain={async () => {
+            clearGetSectionsError()
+            await doGetSections()
+          }}
         />
       )
     } else {

--- a/ccm_web/client/src/pages/BulkSectionCreate.tsx
+++ b/ccm_web/client/src/pages/BulkSectionCreate.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Backdrop, Box, CircularProgress, Grid, Link, makeStyles, Typography } from '@material-ui/core'
+import { Backdrop, Box, Button, CircularProgress, Grid, Link, makeStyles, Typography } from '@material-ui/core'
 
 import { addCourseSections, getCourseSections } from '../api'
 import BulkApiErrorContent from '../components/BulkApiErrorContent'
@@ -28,10 +28,7 @@ import { getRowNumber } from '../utils/fileUtils'
 const useStyles = makeStyles((theme) => ({
   root: {
     padding: 25,
-    textAlign: 'left',
-    '& button': {
-      margin: 5
-    }
+    textAlign: 'left'
   },
   confirmContainer: {
     position: 'relative',
@@ -57,6 +54,9 @@ const useStyles = makeStyles((theme) => ({
   table: {
     paddingLeft: 10,
     paddingRight: 10
+  },
+  buttonGroup: {
+    marginTop: theme.spacing(1)
   }
 }))
 
@@ -368,7 +368,20 @@ Section 001`
         See your sections on the <Link href={settingsURL} target='_parent'>Canvas Settings page</Link> for your course.
       </span>
     )
-    return <SuccessCard {...{ message, nextAction }} />
+    return (
+      <>
+      <SuccessCard {...{ message, nextAction }} />
+      <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
+        <Button
+          variant='outlined'
+          aria-label='Start creating sections again'
+          onClick={resetPageState}
+        >
+          Start Again
+        </Button>
+      </Grid>
+      </>
+    )
   }
 
   const renderComponent = (): JSX.Element | undefined => {

--- a/ccm_web/client/src/pages/BulkSectionCreate.tsx
+++ b/ccm_web/client/src/pages/BulkSectionCreate.tsx
@@ -372,11 +372,7 @@ Section 001`
       <>
       <SuccessCard {...{ message, nextAction }} />
       <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
-        <Button
-          variant='outlined'
-          aria-label={`Start ${props.title} again`}
-          onClick={resetPageState}
-        >
+        <Button variant='outlined' aria-label={`Start ${props.title} again`} onClick={resetPageState}>
           Start Again
         </Button>
       </Grid>

--- a/ccm_web/client/src/pages/BulkSectionCreate.tsx
+++ b/ccm_web/client/src/pages/BulkSectionCreate.tsx
@@ -374,7 +374,7 @@ Section 001`
       <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
         <Button
           variant='outlined'
-          aria-label='Start creating sections again'
+          aria-label={`Start ${props.title} again`}
           onClick={resetPageState}
         >
           Start Again

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -406,7 +406,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
         <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
           <Button
             variant='outlined'
-            aria-label='Start Format Third-Party Gradebook again'
+            aria-label={`Start ${props.title} again`}
             onClick={handleFullReset}
           >
             Start Again

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -155,9 +155,9 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
 
   const handleResetSelect = (): void => {
     setSections(undefined)
+    clearGetSectionsError()
     setSelectedSections(undefined)
     setStudentLoginIds(undefined)
-    clearGetSectionsError()
     clearGetStudentsError()
   }
 

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -85,7 +85,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
   const [schemaInvalidations, setSchemaInvalidations] = useState<SchemaInvalidation[] | undefined>(undefined)
   const [gradebookInvalidations, setGradebookInvalidations] = useState<GradebookInvalidation[] | undefined>(undefined)
 
-  const [doGetSections, isGetSectionsLoading, getSectionsError] = usePromise(
+  const [doGetSections, isGetSectionsLoading, getSectionsError, clearGetSectionsError] = usePromise(
     async () => await api.getCourseSections(props.globals.course.id),
     (sections: CanvasCourseSection[]) => setSections(injectCourseName(sections, props.course.name))
   )
@@ -157,6 +157,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
     setSections(undefined)
     setSelectedSections(undefined)
     setStudentLoginIds(undefined)
+    clearGetSectionsError()
     clearGetStudentsError()
   }
 

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -180,13 +180,6 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
     setActiveStep(CSVWorkflowStep.Select)
   }
 
-  const handleBack = (): void => setActiveStep((prevStep) => {
-    if (prevStep > CSVWorkflowStep.Select) return prevStep - 1
-    return prevStep
-  })
-
-  const backButton = <Button className={classes.backButton} onClick={handleBack}>Back</Button>
-
   const renderSchemaInvalidations = (invalidations: SchemaInvalidation[]): JSX.Element => {
     const messages = invalidations.map(
       (invalidation, i) => <Typography key={i}>{invalidation.message}</Typography>
@@ -347,7 +340,14 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
             </Grid>
           </Grid>
           <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
-            {backButton}
+            <Button
+              className={classes.backButton}
+              variant='outlined'
+              aria-label='Back to Select Section'
+              onClick={() => setActiveStep(CSVWorkflowStep.Select)}
+            >
+              Back
+            </Button>
           </Grid>
         </div>
       </div>
@@ -408,7 +408,13 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
           message={<Typography>The formatted gradebook file has been downloaded to your computer!</Typography>}
         />
         <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
-          <Button variant='outlined' onClick={handleFullReset}>Start Again</Button>
+          <Button
+            variant='outlined'
+            aria-label='Start Format Third-Party Gradebook again'
+            onClick={handleFullReset}
+          >
+            Start Again
+          </Button>
         </Grid>
       </div>
     )

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -404,11 +404,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
           message={<Typography>The formatted gradebook file has been downloaded to your computer!</Typography>}
         />
         <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
-          <Button
-            variant='outlined'
-            aria-label={`Start ${props.title} again`}
-            onClick={handleFullReset}
-          >
+          <Button variant='outlined' aria-label={`Start ${props.title} again`} onClick={handleFullReset}>
             Start Again
           </Button>
         </Grid>

--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -35,9 +35,6 @@ const useStyles = makeStyles((theme) => ({
   buttonGroup: {
     marginTop: theme.spacing(1)
   },
-  backButton: {
-    marginRight: theme.spacing(1)
-  },
   stepper: {
     textAlign: 'center',
     paddingTop: '20px'
@@ -341,7 +338,6 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
           </Grid>
           <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
             <Button
-              className={classes.backButton}
               variant='outlined'
               aria-label='Back to Select Section'
               onClick={() => setActiveStep(CSVWorkflowStep.Select)}

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Box, Grid, Link, makeStyles, Typography } from '@material-ui/core'
+import { Box, Button, Grid, Link, makeStyles, Typography } from '@material-ui/core'
 import WarningIcon from '@material-ui/icons/Warning'
 
 import ConfirmDialog from '../components/ConfirmDialog'
@@ -21,13 +21,13 @@ import { createOutputFileName } from '../utils/fileUtils'
 const useStyles = makeStyles((theme) => ({
   root: {
     padding: 25,
-    textAlign: 'left',
-    '& button': {
-      margin: 5
-    }
+    textAlign: 'left'
   },
   uploadHeader: {
     paddingTop: 15
+  },
+  buttonGroup: {
+    marginTop: theme.spacing(1)
   }
 }))
 
@@ -294,7 +294,20 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
 
   const renderSuccess = (): JSX.Element => {
     const message = <Typography>Your gradebook has been successfully converted and downloaded to your computer!</Typography>
-    return <SuccessCard message={message} />
+    return (
+      <>
+      <SuccessCard message={message} />
+        <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
+        <Button
+          variant='outlined'
+          aria-label='Start Format Canvas Gradebook again'
+          onClick={resetPageState}
+        >
+          Start Again
+        </Button>
+      </Grid>
+      </>
+    )
   }
 
   const gradeBookRecordToStudentGrade = (grades: GradebookRecord[] | undefined): StudentGrade[] => {

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -298,11 +298,7 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
       <>
       <SuccessCard message={message} />
       <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
-        <Button
-          variant='outlined'
-          aria-label={`Start ${props.title} again`}
-          onClick={resetPageState}
-        >
+        <Button variant='outlined' aria-label={`Start ${props.title} again`} onClick={resetPageState}>
           Start Again
         </Button>
       </Grid>

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -297,10 +297,10 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
     return (
       <>
       <SuccessCard message={message} />
-        <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
+      <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
         <Button
           variant='outlined'
-          aria-label='Start Format Canvas Gradebook again'
+          aria-label={`Start ${props.title} again`}
           onClick={resetPageState}
         >
           Start Again

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -37,6 +37,9 @@ const useStyles = makeStyles((theme) => ({
   },
   submitButton: {
     float: 'right'
+  },
+  buttonGroup: {
+    marginTop: theme.spacing(1)
   }
 }))
 
@@ -209,21 +212,44 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   const getSelectSections = (): JSX.Element => {
     return (
       <>
-        <Grid container spacing={5} style={{ marginBottom: '0px', marginTop: '0px' }}>
-          <Grid className={classes.sectionSelectionContainer} item xs={12} sm={6}>
-            {getSelectSectionsUnstaged()}
-          </Grid>
-          <Grid className={classes.sectionSelectionContainer} item xs={12} sm={6}>
-            {getSelectSectionsStaged()}
-          </Grid>
+      <Grid container spacing={5} style={{ marginBottom: '0px', marginTop: '0px' }}>
+        <Grid className={classes.sectionSelectionContainer} item xs={12} sm={6}>
+          {getSelectSectionsUnstaged()}
         </Grid>
-        <Button className={classes.submitButton} onClick={submit} variant='contained' color='primary' disabled={!canMerge()}>{mergeButtonText(mergableSections())}</Button>
+        <Grid className={classes.sectionSelectionContainer} item xs={12} sm={6}>
+          {getSelectSectionsStaged()}
+        </Grid>
+      </Grid>
+      <Grid container className={classes.buttonGroup} justifyContent='flex-end'>
+        <Button
+          className={classes.submitButton}
+          onClick={submit}
+          variant='contained'
+          color='primary'
+          disabled={!canMerge()}
+        >
+          {mergeButtonText(mergableSections())}
+        </Button>
+      </Grid>
       </>
     )
   }
 
   const getMergeSuccess = (): JSX.Element => {
-    return (<CourseSectionList canUnmerge={isAdmin()} {...props}/>)
+    return (
+      <>
+      <CourseSectionList canUnmerge={isAdmin()} {...props}/>
+      <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
+        <Button
+          variant='outlined'
+          aria-label='Start Merge Sections again'
+          onClick={() => setPageState(PageState.SelectSections)}
+        >
+          Start Again
+        </Button>
+      </Grid>
+      </>
+    )
   }
 
   return (

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -242,7 +242,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
       <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
         <Button
           variant='outlined'
-          aria-label='Start Merge Sections again'
+          aria-label={`Start ${props.title} again`}
           onClick={() => setPageState(PageState.SelectSections)}
         >
           Start Again

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -238,7 +238,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   const getMergeSuccess = (): JSX.Element => {
     return (
       <>
-      <CourseSectionList canUnmerge={isAdmin()} {...props}/>
+      <CourseSectionList canUnmerge={isAdmin()} {...props} />
       <Grid container className={classes.buttonGroup} justifyContent='flex-start'>
         <Button
           variant='outlined'


### PR DESCRIPTION
This PR adds any missing "Back" and "Start Again" buttons to features. In addition, 1) it makes some changes to the Add Non-UM Users feature so as to establish a common leaf component interface for `UserEnrollmentForm` and `MultipleUserEnrollmentWorkflow`, and 2) it ensures section data is reloaded whenever the user navigates to a section selection list, so accurate section and student number data are presented. The PR aims to resolve #238.