### PR TITLE
Modify `CustomTable` so table semantics are used by screenreaders (#259)

### DIFF
--- a/ccm_web/client/src/components/CustomTable.tsx
+++ b/ccm_web/client/src/components/CustomTable.tsx
@@ -51,7 +51,7 @@ function CustomTable<T extends TableEntity> (props: TableProps<T>): JSX.Element 
         <TableBody>
           {tableRows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((row) => {
             return (
-              <TableRow hover role="checkbox" tabIndex={-1} key={row.rowNumber}>
+              <TableRow hover key={row.rowNumber}>
                 {columns.map((column) => {
                   const value = row[column.id]
                   return (


### PR DESCRIPTION
The PR aims to resolve #259.