### PR TITLE
Conditionally enable/disable section creation in `CreateSelectSectionWidget` (#284, #299)

### DIFF
--- a/ccm_web/client/src/components/CreateSelectSectionWidget.tsx
+++ b/ccm_web/client/src/components/CreateSelectSectionWidget.tsx
@@ -30,6 +30,8 @@ const useStyles = makeStyles((theme) => ({
 
 interface WidgetWithoutCreateProps {
   readonly canCreate: false
+  course?: never
+  onSectionCreated?: never
 }
 
 interface WidgetWithCreateProps {

--- a/ccm_web/client/src/components/CreateSelectSectionWidget.tsx
+++ b/ccm_web/client/src/components/CreateSelectSectionWidget.tsx
@@ -28,43 +28,59 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-interface CreateSelectSectionWidgetProps {
+interface WidgetWithoutCreateProps {
+  readonly canCreate: false
+}
+
+interface WidgetWithCreateProps {
+  readonly canCreate: true
   course: CanvasCourseBase
+  onSectionCreated: (section: CanvasCourseSection) => void
+}
+
+export type CreateSelectSectionWidgetCreateProps = WidgetWithoutCreateProps | WidgetWithCreateProps
+
+interface CreateSelectSectionWidgetBaseProps {
   sections: CanvasCourseSectionWithCourseName[]
   selectedSection?: CanvasCourseSectionWithCourseName
   setSelectedSection: (section: CanvasCourseSectionWithCourseName) => void
-  onSectionCreated: (section: CanvasCourseSection) => void
 }
+
+type CreateSelectSectionWidgetProps = CreateSelectSectionWidgetBaseProps & CreateSelectSectionWidgetCreateProps
 
 export default function CreateSelectSectionWidget (props: CreateSelectSectionWidgetProps): JSX.Element {
   const classes = useStyles()
   return (
     <>
-      <div className={classes.createSectionContainer}>
-        <div className={`${classes.newSectionHint} ${classes.spacing}`}>
-          <Typography>Create a new section to add users</Typography>
-          <Tooltip className={classes.tooltip} placement='top' title='Enter a distinct name for this section'>
-            <HelpOutline fontSize='small' />
-          </Tooltip>
+    {
+      props.canCreate && (
+        <div className={classes.createSectionContainer}>
+          <div className={`${classes.newSectionHint} ${classes.spacing}`}>
+            <Typography>Create a new section to add users to</Typography>
+            <Tooltip className={classes.tooltip} placement='top' title='Enter a distinct name for this section'>
+              <HelpOutline fontSize='small' />
+            </Tooltip>
+          </div>
+          <div className={classes.createSectionWidget}>
+            <CreateSectionWidget {...props} />
+          </div>
         </div>
-        <div className={classes.createSectionWidget}>
-          <CreateSectionWidget {...props} />
-        </div>
-      </div>
-      <Typography variant='subtitle1' className={classes.spacing}>
-        Or select an existing section to add users to
-      </Typography>
-      <div className={classes.sectionSelectionContainer}>
-        <SectionSelectorWidget
-          height={300}
-          search={[]}
-          multiSelect={false}
-          sections={props.sections}
-          selectedSections={props.selectedSection !== undefined ? [props.selectedSection] : []}
-          selectionUpdated={(sections) => props.setSelectedSection(sections[0])}
-          canUnmerge={false}
-        />
-      </div>
+      )
+    }
+    <Typography variant='subtitle1' className={classes.spacing}>
+      Select an existing section to add users to
+    </Typography>
+    <div className={classes.sectionSelectionContainer}>
+      <SectionSelectorWidget
+        height={300}
+        search={[]}
+        multiSelect={false}
+        sections={props.sections}
+        selectedSections={props.selectedSection !== undefined ? [props.selectedSection] : []}
+        selectionUpdated={(sections) => props.setSelectedSection(sections[0])}
+        canUnmerge={false}
+      />
+    </div>
     </>
   )
 }

--- a/ccm_web/client/src/components/MultipleUserEnrollmentWorkflow.tsx
+++ b/ccm_web/client/src/components/MultipleUserEnrollmentWorkflow.tsx
@@ -4,7 +4,7 @@ import { Backdrop, Box, Button, CircularProgress, Grid, Link, makeStyles, Typogr
 import BulkApiErrorContent from './BulkApiErrorContent'
 import BulkEnrollExternalUserConfirmationTable from './BulkEnrollExternalUserConfirmationTable'
 import ConfirmDialog from './ConfirmDialog'
-import CreateSelectSectionWidget from './CreateSelectSectionWidget'
+import CreateSelectSectionWidget, { CreateSelectSectionWidgetCreateProps } from './CreateSelectSectionWidget'
 import CSVFileName from './CSVFileName'
 import ErrorAlert from './ErrorAlert'
 import ExampleFileDownloadHeader from './ExampleFileDownloadHeader'
@@ -16,7 +16,9 @@ import WorkflowStepper from './WorkflowStepper'
 import usePromise from '../hooks/usePromise'
 import { CanvasCourseBase, CanvasCourseSection, CanvasCourseSectionWithCourseName, ClientEnrollmentType } from '../models/canvas'
 import { AddNewExternalUserEnrollment, AddNumberedNewExternalUserEnrollment } from '../models/enrollment'
-import { CSVWorkflowStep, InvalidationType } from '../models/models'
+import { createSectionRoles } from '../models/feature'
+import { isAuthorizedForRoles } from '../models/FeatureUIData'
+import { CSVWorkflowStep, InvalidationType, RoleEnum } from '../models/models'
 import CSVSchemaValidator, { SchemaInvalidation } from '../utils/CSVSchemaValidator'
 import {
   DuplicateEmailRowsValidator, EmailRowsValidator, EnrollmentInvalidation, FirstNameRowsValidator,
@@ -70,6 +72,7 @@ interface MultipleUserEnrollmentWorkflowProps {
   readonly rolesUserCanEnroll: ClientEnrollmentType[]
   resetFeature: () => void
   settingsURL: string
+  userCourseRoles: RoleEnum[]
 }
 
 export default function MultipleUserEnrollmentWorkflow (props: MultipleUserEnrollmentWorkflowProps): JSX.Element {
@@ -123,12 +126,18 @@ export default function MultipleUserEnrollmentWorkflow (props: MultipleUserEnrol
   }
 
   const renderSelect = (): JSX.Element => {
+    const canCreate = isAuthorizedForRoles(props.userCourseRoles, createSectionRoles)
+    const createProps: CreateSelectSectionWidgetCreateProps = canCreate
+      ? { canCreate: true, course: props.course, onSectionCreated: props.onSectionCreated }
+      : { canCreate: false }
+
     return (
       <>
       <CreateSelectSectionWidget
-        {...props}
+        sections={props.sections}
         selectedSection={selectedSection}
         setSelectedSection={setSelectedSection}
+        {...createProps}
       />
       <Grid container className={classes.buttonGroup} justifyContent='space-between'>
         <Button

--- a/ccm_web/client/src/models/FeatureUIData.tsx
+++ b/ccm_web/client/src/models/FeatureUIData.tsx
@@ -88,13 +88,13 @@ const allFeatures: FeatureUIGroup[] = [
   { id: 'Sections', title: 'Sections', ordinality: 3, features: [mergeSectionCardProps, createSectionsCardProps] }
 ]
 
-const isAuthorizedForRoles = (userRoles: RoleEnum[], requiredRoles: RoleEnum[], featureDescriptionForLogging: string): boolean => {
+const isAuthorizedForRoles = (userRoles: RoleEnum[], requiredRoles: RoleEnum[]): boolean => {
   const rolesAllowingAccess = userRoles.filter(userRole => requiredRoles.includes(userRole))
   return rolesAllowingAccess.length > 0
 }
 
 const isAuthorizedForFeature = (roles: RoleEnum[], feature: FeatureUIProps): boolean => {
-  return isAuthorizedForRoles(roles, feature.data.roles, feature.route)
+  return isAuthorizedForRoles(roles, feature.data.roles)
 }
 
 const isAuthorizedForAnyFeature = (roles: RoleEnum[], features: FeatureUIProps[]): boolean => {

--- a/ccm_web/client/src/models/feature.ts
+++ b/ccm_web/client/src/models/feature.ts
@@ -9,12 +9,14 @@ interface FeatureDataProps {
   helpURLEnding: string
 }
 
+const adminRoles = [RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant']]
+
 const mergeSectionProps: FeatureDataProps = {
   id: 'MergeSections',
   title: 'Merge Sections',
   description: 'Combine sections into one Canvas site for easier management',
   ordinality: 1,
-  roles: [RoleEnum.Teacher, RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant']],
+  roles: [RoleEnum.Teacher, ...adminRoles],
   helpURLEnding: '/merge-sections.html'
 }
 
@@ -23,7 +25,7 @@ const formatCanvasGradebookProps: FeatureDataProps = {
   title: 'Format Canvas Gradebook',
   description: 'Format the exported Canvas Gradebook CSV file for uploading into Faculty Center\'s Grade Roster',
   ordinality: 2,
-  roles: [RoleEnum.Teacher, RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant'], RoleEnum.TA],
+  roles: [RoleEnum.Teacher, RoleEnum.TA, ...adminRoles],
   helpURLEnding: '/gradebook-canvas.html'
 }
 
@@ -32,7 +34,7 @@ const formatThirdPartyGradebookProps: FeatureDataProps = {
   title: 'Format Third\u2011Party Gradebook',
   description: 'Format a CSV file exported from an external tool for importing grades into the Canvas Gradebook',
   ordinality: 3,
-  roles: [RoleEnum.Teacher, RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant'], RoleEnum.TA],
+  roles: [RoleEnum.Teacher, RoleEnum.TA, ...adminRoles],
   helpURLEnding: '/gradebook-thirdparty.html'
 }
 
@@ -41,7 +43,7 @@ const createSectionsProps: FeatureDataProps = {
   title: 'Create Sections',
   description: 'Create sections through csv files into your own course',
   ordinality: 4,
-  roles: [RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant']],
+  roles: adminRoles,
   helpURLEnding: '/create-sections.html'
 }
 
@@ -50,7 +52,7 @@ const addUMUsersProps: FeatureDataProps = {
   title: 'Add U\u2011M Users',
   description: 'Add U\u2011M users to your available sections',
   ordinality: 5,
-  roles: [RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant']],
+  roles: adminRoles,
   helpURLEnding: '/add-um-users.html'
 }
 
@@ -63,10 +65,11 @@ const addNonUMUsersProps: FeatureDataProps = {
   helpURLEnding: '/add-non-um-users.html'
 }
 
-const courseRenameRoles: RoleEnum[] = [RoleEnum['Account Admin'], RoleEnum['Subaccount admin'], RoleEnum['Support Consultant']]
+const courseRenameRoles: RoleEnum[] = adminRoles
+const createSectionRoles: RoleEnum[] = [RoleEnum.Teacher, ...adminRoles]
 
 export type { FeatureDataProps }
 export {
   mergeSectionProps, formatCanvasGradebookProps, formatThirdPartyGradebookProps,
-  createSectionsProps, addUMUsersProps, addNonUMUsersProps, courseRenameRoles
+  createSectionsProps, addUMUsersProps, addNonUMUsersProps, courseRenameRoles, createSectionRoles
 }

--- a/ccm_web/client/src/models/feature.ts
+++ b/ccm_web/client/src/models/feature.ts
@@ -9,7 +9,9 @@ interface FeatureDataProps {
   helpURLEnding: string
 }
 
-const adminRoles = [RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant']]
+const adminRoles: RoleEnum[] = [RoleEnum['Subaccount admin'], RoleEnum['Account Admin'], RoleEnum['Support Consultant']]
+const courseRenameRoles: RoleEnum[] = adminRoles
+const createSectionRoles: RoleEnum[] = [RoleEnum.Teacher, ...adminRoles]
 
 const mergeSectionProps: FeatureDataProps = {
   id: 'MergeSections',
@@ -65,11 +67,8 @@ const addNonUMUsersProps: FeatureDataProps = {
   helpURLEnding: '/add-non-um-users.html'
 }
 
-const courseRenameRoles: RoleEnum[] = adminRoles
-const createSectionRoles: RoleEnum[] = [RoleEnum.Teacher, ...adminRoles]
-
 export type { FeatureDataProps }
 export {
   mergeSectionProps, formatCanvasGradebookProps, formatThirdPartyGradebookProps,
-  createSectionsProps, addUMUsersProps, addNonUMUsersProps, courseRenameRoles, createSectionRoles
+  createSectionsProps, addUMUsersProps, addNonUMUsersProps, courseRenameRoles, createSectionRoles, adminRoles
 }

--- a/ccm_web/client/src/pages/AddNonUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddNonUMUsers.tsx
@@ -149,6 +149,7 @@ export default function AddNonUMUsers (props: AddNonUMUsersProps): JSX.Element {
             rolesUserCanEnroll={rolesUserCanEnroll}
             resetFeature={resetFeature}
             settingsURL={settingsURL}
+            userCourseRoles={props.globals.course.roles}
           />
         )
       default:

--- a/ccm_web/client/src/pages/AddUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddUMUsers.tsx
@@ -215,10 +215,12 @@ function AddUMUsers (props: AddUMUsersProps): JSX.Element {
         <>
           <div className={classes.createSelectSectionContainer}>
             <CreateSelectSectionWidget
-              {...props}
               sections={sections}
               selectedSection={selectedSection}
               setSelectedSection={setSelectedSection}
+              // Only admins have access to the Add UM Users feature, and they can create sections.
+              canCreate={true}
+              course={props.course}
               onSectionCreated={sectionCreated}
             />
             <Backdrop className={classes.backdrop} open={isGetSectionsLoading}>

--- a/ccm_web/client/src/pages/Home.tsx
+++ b/ccm_web/client/src/pages/Home.tsx
@@ -99,7 +99,7 @@ function Home (props: HomeProps): JSX.Element {
     }
 
     let nameBlock
-    if (isAuthorizedForRoles(props.globals.course.roles, courseRenameRoles, 'Course Rename')) {
+    if (isAuthorizedForRoles(props.globals.course.roles, courseRenameRoles)) {
       nameBlock = (
         <InlineTextEdit
           text={props.course.name}

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -127,7 +127,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   }
 
   const isSubAccountAdminOrAccountAdmin = (): boolean => {
-    return isAuthorizedForRoles([RoleEnum['Subaccount admin'], RoleEnum['Account Admin']], props.globals.course.roles, 'MergeSections')
+    return isAuthorizedForRoles([RoleEnum['Subaccount admin'], RoleEnum['Account Admin']], props.globals.course.roles)
   }
 
   const stageSections = (): void => {

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -5,11 +5,11 @@ import { Button, Grid, LinearProgress, makeStyles, Typography } from '@material-
 import { useSnackbar } from 'notistack'
 
 import { CCMComponentProps, isAuthorizedForRoles } from '../models/FeatureUIData'
+import { adminRoles } from '../models/feature'
 import SectionSelectorWidget, { SelectableCanvasCourseSection } from '../components/SectionSelectorWidget'
 import { CanvasCourseSectionSort_AZ, CanvasCourseSectionSort_UserCount, CanvasCourseSectionSort_ZA, CanvasCourseSectionWithCourseName, ICanvasCourseSectionSort } from '../models/canvas'
 import { mergeSections } from '../api'
 import usePromise from '../hooks/usePromise'
-import { RoleEnum } from '../models/models'
 import { CourseNameSearcher, CourseSectionSearcher, SectionNameSearcher, UniqnameSearcher } from '../utils/SectionSearcher'
 import CourseSectionList from '../components/CourseSectionList'
 import Help from '../components/Help'
@@ -126,8 +126,8 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
     }
   }
 
-  const isSubAccountAdminOrAccountAdmin = (): boolean => {
-    return isAuthorizedForRoles([RoleEnum['Subaccount admin'], RoleEnum['Account Admin']], props.globals.course.roles)
+  const isAdmin = (): boolean => {
+    return isAuthorizedForRoles(adminRoles, props.globals.course.roles)
   }
 
   const stageSections = (): void => {
@@ -158,7 +158,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
             ]
           }
         }}
-        search={ isSubAccountAdminOrAccountAdmin() ? [new CourseNameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle), new UniqnameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle)] : [new SectionNameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle)]}
+        search={ isAdmin() ? [new CourseNameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle), new UniqnameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle)] : [new SectionNameSearcher(props.course.enrollment_term_id, props.globals.course.id, setUnsyncedUnstagedSections, setSectionsTitle)]}
         multiSelect={true}
         showCourseName={true}
         sections={unstagedSections !== undefined ? unstagedSections : []}
@@ -186,7 +186,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
           selectedSections={selectedStagedSections}
           selectionUpdated={setSelectedStagedSections}
           sectionsRemoved={handleUnmergedSections}
-          canUnmerge={isSubAccountAdminOrAccountAdmin()}
+          canUnmerge={isAdmin()}
           highlightUnlocked={true}
           ></SectionSelectorWidget>
       </div>
@@ -223,7 +223,7 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
   }
 
   const getMergeSuccess = (): JSX.Element => {
-    return (<CourseSectionList canUnmerge={isSubAccountAdminOrAccountAdmin()} {...props}/>)
+    return (<CourseSectionList canUnmerge={isAdmin()} {...props}/>)
   }
 
   return (

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -4,8 +4,8 @@ import { Button, Grid, LinearProgress, makeStyles, Typography } from '@material-
 
 import { useSnackbar } from 'notistack'
 
-import { CCMComponentProps, isAuthorizedForRoles } from '../models/FeatureUIData'
 import { adminRoles } from '../models/feature'
+import { CCMComponentProps, isAuthorizedForRoles } from '../models/FeatureUIData'
 import SectionSelectorWidget, { SelectableCanvasCourseSection } from '../components/SectionSelectorWidget'
 import { CanvasCourseSectionSort_AZ, CanvasCourseSectionSort_UserCount, CanvasCourseSectionSort_ZA, CanvasCourseSectionWithCourseName, ICanvasCourseSectionSort } from '../models/canvas'
 import { mergeSections } from '../api'


### PR DESCRIPTION
This PR changes the `CreateSelectSectionWidget` component so that only admins (or equivalent) or teachers can see and use the section creation portion of the component.  The PR aims to resolve #284. @pushyamig also added changes to resolve #299.