### PR TITLE
Allow for client-side routing, set up `/access-denied` (#48, #209)

### DIFF
--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -12,6 +12,7 @@ import usePromise from './hooks/usePromise'
 import { CanvasCourseBase } from './models/canvas'
 import allFeatures from './models/FeatureUIData'
 import Home from './pages/Home'
+import NotFound from './pages/NotFound'
 import redirect from './utils/redirect'
 
 const useStyles = makeStyles((theme) => ({
@@ -95,7 +96,7 @@ function App (): JSX.Element {
             </Route>
           )
         })}
-        <Route><div><em>Under Construction</em></div></Route>
+        <Route><NotFound /></Route>
       </Switch>
       {
         globals?.environment === 'development' &&

--- a/ccm_web/client/src/App.tsx
+++ b/ccm_web/client/src/App.tsx
@@ -3,15 +3,16 @@ import { Route, Switch, useLocation } from 'react-router-dom'
 import { Link, makeStyles } from '@material-ui/core'
 
 import { getCourse, getCSRFToken } from './api'
+import './App.css'
 import AuthorizePrompt from './components/AuthorizePrompt'
 import Breadcrumbs from './components/Breadcrumbs'
+import ResponsiveHelper from './components/ResponsiveHelper'
 import useGlobals from './hooks/useGlobals'
 import usePromise from './hooks/usePromise'
 import { CanvasCourseBase } from './models/canvas'
 import allFeatures from './models/FeatureUIData'
 import Home from './pages/Home'
-import './App.css'
-import ResponsiveHelper from './components/ResponsiveHelper'
+import redirect from './utils/redirect'
 
 const useStyles = makeStyles((theme) => ({
   swaggerLink: {
@@ -49,11 +50,8 @@ function App (): JSX.Element {
   if (globalsError !== undefined) console.error(globalsError)
   if (csrfTokenCookieError !== undefined) console.error(csrfTokenCookieError)
   if (globals === undefined || !isAuthenticated) {
-    return (
-      <div className='App'>
-        <p>You were not properly authenticated to the application.</p>
-      </div>
-    )
+    redirect('/access-denied')
+    return (loading)
   }
 
   if (!globals.user.hasCanvasToken) {

--- a/ccm_web/client/src/components/Breadcrumbs.tsx
+++ b/ccm_web/client/src/components/Breadcrumbs.tsx
@@ -55,7 +55,9 @@ function Breadcrumbs (props: BreadcrumbsProps): JSX.Element {
             pathnames.map((value, index) => {
               const last = index === pathnames.length - 1
               const to = `/${pathnames.slice(0, index + 1).join('/')}`
-              const feature = features.filter(f => { return f.route.substring(1) === value })[0]
+              const matches = features.filter(f => f.route.substring(1) === value)
+              if (matches.length === 0) return undefined
+              const feature = matches[0]
               const titleTypographyProps: TitleTypographyProps = last ? { to: to } : {}
               return (
                 <Typography className={classes.breadcrumbs} color='textPrimary' key={to} {...titleTypographyProps}>

--- a/ccm_web/client/src/components/InlineErrorAlert.tsx
+++ b/ccm_web/client/src/components/InlineErrorAlert.tsx
@@ -29,7 +29,7 @@ export default function InlineErrorAlert (props: InlineAlertProps): JSX.Element 
   const classes = useStyles()
   return (
     <Paper className={classes.alert} elevation={0} role='alert'>
-      <Grid container spacing={2} alignItems='center' direction='row'>
+      <Grid container spacing={2} alignItems='center' direction='row' wrap='nowrap'>
         <Grid item><ErrorIcon className={classes.icon} /></Grid>
         <Grid item>{props.children}</Grid>
       </Grid>

--- a/ccm_web/client/src/index.tsx
+++ b/ccm_web/client/src/index.tsx
@@ -1,11 +1,12 @@
 import { SnackbarProvider } from 'notistack'
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter, Route, Switch } from 'react-router-dom'
 import { ThemeProvider } from '@material-ui/core'
 
 import ccmTheme from './theme'
 import App from './App'
+import AccessDenied from './pages/AccessDenied'
 import './index.css'
 
 ReactDOM.render(
@@ -13,7 +14,12 @@ ReactDOM.render(
    <ThemeProvider theme={ccmTheme}>
     <SnackbarProvider maxSnack={3}>
       <BrowserRouter>
-        <App />
+        <Switch>
+          <Route exact={true} path='/access-denied'>
+            <AccessDenied forHelpLink='https://its.umich.edu/help' />
+          </Route>
+          <Route><App /></Route>
+        </Switch>
       </BrowserRouter>
     </SnackbarProvider>
    </ThemeProvider>

--- a/ccm_web/client/src/index.tsx
+++ b/ccm_web/client/src/index.tsx
@@ -4,10 +4,10 @@ import ReactDOM from 'react-dom'
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
 import { ThemeProvider } from '@material-ui/core'
 
-import ccmTheme from './theme'
 import App from './App'
-import AccessDenied from './pages/AccessDenied'
 import './index.css'
+import ccmTheme from './theme'
+import AccessDenied from './pages/AccessDenied'
 
 ReactDOM.render(
   <React.StrictMode>

--- a/ccm_web/client/src/index.tsx
+++ b/ccm_web/client/src/index.tsx
@@ -16,7 +16,7 @@ ReactDOM.render(
       <BrowserRouter>
         <Switch>
           <Route exact={true} path='/access-denied'>
-            <AccessDenied forHelpLink='https://its.umich.edu/help' />
+            <AccessDenied email='4help@umich.edu' helpLink='https://its.umich.edu/help' />
           </Route>
           <Route><App /></Route>
         </Switch>

--- a/ccm_web/client/src/pages/AccessDenied.tsx
+++ b/ccm_web/client/src/pages/AccessDenied.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
+import { Link, makeStyles, Typography } from '@material-ui/core'
 
 import InlineErrorAlert from '../components/InlineErrorAlert'
-
-import { Link, makeStyles, Typography } from '@material-ui/core'
 
 const useStyles = makeStyles((theme) => ({
   container: {

--- a/ccm_web/client/src/pages/AccessDenied.tsx
+++ b/ccm_web/client/src/pages/AccessDenied.tsx
@@ -7,9 +7,6 @@ import { Link, makeStyles, Typography } from '@material-ui/core'
 const useStyles = makeStyles((theme) => ({
   container: {
     margin: theme.spacing(2)
-  },
-  link: {
-    textDecoration: 'underline'
   }
 }))
 
@@ -20,9 +17,9 @@ interface AccessDeniedProps {
 
 export default function AccessDenied (props: AccessDeniedProps): JSX.Element {
   const classes = useStyles()
-  const emailLink = <Link className={classes.link} href={`mailto:${props.email}`}>{props.email}</Link>
+  const emailLink = <Link href={`mailto:${props.email}`}>{props.email}</Link>
   const forHelpLink = (
-    <Link className={classes.link} href={props.helpLink} target='_blank' rel='noopener'>
+    <Link href={props.helpLink} target='_blank' rel='noopener'>
       ITS Help Page
     </Link>
   )

--- a/ccm_web/client/src/pages/AccessDenied.tsx
+++ b/ccm_web/client/src/pages/AccessDenied.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+import InlineErrorAlert from '../components/InlineErrorAlert'
+
+import { Link, makeStyles, Typography } from '@material-ui/core'
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    margin: theme.spacing(2)
+  }
+}))
+
+interface AccessDeniedProps {
+  forHelpLink: string
+}
+
+export default function AccessDenied (props: AccessDeniedProps): JSX.Element {
+  const classes = useStyles()
+  const emailLink = (
+    <Link style={{ textDecoration: 'underline' }} href={props.forHelpLink} target='_blank' rel='noopener'>
+      4help@umich.edu
+    </Link>
+  )
+  return (
+    <div className={classes.container}>
+      <InlineErrorAlert>
+      <Typography>
+        To use Canvas Course Manager you must have a course management role in this course.
+      </Typography>
+      <Typography>
+        If you believe this message is in error, please contact {emailLink}.
+      </Typography>
+      </InlineErrorAlert>
+    </div>
+  )
+}

--- a/ccm_web/client/src/pages/AccessDenied.tsx
+++ b/ccm_web/client/src/pages/AccessDenied.tsx
@@ -7,29 +7,36 @@ import { Link, makeStyles, Typography } from '@material-ui/core'
 const useStyles = makeStyles((theme) => ({
   container: {
     margin: theme.spacing(2)
+  },
+  link: {
+    textDecoration: 'underline'
   }
 }))
 
 interface AccessDeniedProps {
-  forHelpLink: string
+  email: string
+  helpLink: string
 }
 
 export default function AccessDenied (props: AccessDeniedProps): JSX.Element {
   const classes = useStyles()
-  const emailLink = (
-    <Link style={{ textDecoration: 'underline' }} href={props.forHelpLink} target='_blank' rel='noopener'>
-      4help@umich.edu
+  const emailLink = <Link className={classes.link} href={`mailto:${props.email}`}>{props.email}</Link>
+  const forHelpLink = (
+    <Link className={classes.link} href={props.helpLink} target='_blank' rel='noopener'>
+      ITS Help Page
     </Link>
   )
+
   return (
     <div className={classes.container}>
       <InlineErrorAlert>
-      <Typography>
-        To use Canvas Course Manager you must have a course management role in this course.
-      </Typography>
-      <Typography>
-        If you believe this message is in error, please contact {emailLink}.
-      </Typography>
+        <Typography variant='subtitle1' component='h1'>Access Denied</Typography>
+        <Typography>
+          To use Canvas Course Manager, you must launch the tool from a Canvas course in which you have a course management role.
+        </Typography>
+        <Typography>
+          If you believe this message is in error, please contact {emailLink} or visit the {forHelpLink}.
+        </Typography>
       </InlineErrorAlert>
     </div>
   )

--- a/ccm_web/client/src/pages/NotFound.tsx
+++ b/ccm_web/client/src/pages/NotFound.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { makeStyles, Typography } from '@material-ui/core'
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    padding: 25,
+    textAlign: 'left'
+  },
+  spacing: {
+    marginBottom: theme.spacing(2)
+  }
+}))
+
+export default function NotFound (): JSX.Element {
+  const classes = useStyles()
+  return (
+    <div className={classes.root}>
+      <Typography variant='h5' component='h1' className={classes.spacing}>Not Found</Typography>
+      <Typography gutterBottom>There is no content at this route.</Typography>
+      <Typography>
+        You can use the &quot;Canvas Course Manager&quot; link above to return to the home page.
+      </Typography>
+    </div>
+  )
+}

--- a/ccm_web/client/src/utils/redirect.ts
+++ b/ccm_web/client/src/utils/redirect.ts
@@ -1,4 +1,4 @@
-type RedirectRoute = '/'
+type RedirectRoute = '/' | '/access-denied'
 
 export default function redirect (route: RedirectRoute): void {
   location.href = route

--- a/ccm_web/package-lock.json
+++ b/ccm_web/package-lock.json
@@ -20,6 +20,7 @@
         "@nestjs/passport": "^8.0.1",
         "@nestjs/platform-express": "^8.2.0",
         "@nestjs/sequelize": "^8.0.0",
+        "@nestjs/serve-static": "^2.2.2",
         "@nestjs/swagger": "^5.1.4",
         "@react-hook/debounce": "^4.0.0",
         "axios": "^0.24.0",
@@ -1934,6 +1935,23 @@
         "sequelize": "^6.3.5",
         "sequelize-typescript": "^2.0.0"
       }
+    },
+    "node_modules/@nestjs/serve-static": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-2.2.2.tgz",
+      "integrity": "sha512-3Mr+Q/npS3N7iGoF3Wd6Lj9QcjMGxbNrSqupi5cviM0IKrZ1BHl5qekW95rWYNATAVqoTmjGROAq+nKKpuUagQ==",
+      "dependencies": {
+        "path-to-regexp": "0.1.7"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@nestjs/core": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@nestjs/serve-static/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "node_modules/@nestjs/swagger": {
       "version": "5.1.4",
@@ -15662,6 +15680,21 @@
       "integrity": "sha512-+hCs/uO1b+Vjt9EmKc31Srr5j9k8MI6eDg+NtSkym/u18hC8eW2RjcxxK+62yn5maxMLyp5fTtAEg3YmicYL4Q==",
       "requires": {
         "uuid": "8.3.2"
+      }
+    },
+    "@nestjs/serve-static": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-2.2.2.tgz",
+      "integrity": "sha512-3Mr+Q/npS3N7iGoF3Wd6Lj9QcjMGxbNrSqupi5cviM0IKrZ1BHl5qekW95rWYNATAVqoTmjGROAq+nKKpuUagQ==",
+      "requires": {
+        "path-to-regexp": "0.1.7"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        }
       }
     },
     "@nestjs/swagger": {

--- a/ccm_web/package-lock.json
+++ b/ccm_web/package-lock.json
@@ -32,7 +32,7 @@
         "express": "^4.17.1",
         "express-session": "^1.17.2",
         "got": "^11.8.2",
-        "helmet": "^4.6.0",
+        "helmet": "^5.0.2",
         "js-cookie": "^3.0.1",
         "keycode-js": "^3.1.0",
         "ltijs": "~5.8.2",
@@ -7088,11 +7088,11 @@
       }
     },
     "node_modules/helmet": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
-      "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-5.0.2.tgz",
+      "integrity": "sha512-QWlwUZZ8BtlvwYVTSDTBChGf8EOcQ2LkGMnQJxSzD1mUu8CCjXJZq/BXP8eWw4kikRnzlhtYo3lCk0ucmYA3Vg==",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/history": {
@@ -9291,6 +9291,14 @@
       },
       "engines": {
         "node": ">=10.19.0"
+      }
+    },
+    "node_modules/ltijs/node_modules/helmet": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
+      "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -19763,9 +19771,9 @@
       "dev": true
     },
     "helmet": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
-      "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-5.0.2.tgz",
+      "integrity": "sha512-QWlwUZZ8BtlvwYVTSDTBChGf8EOcQ2LkGMnQJxSzD1mUu8CCjXJZq/BXP8eWw4kikRnzlhtYo3lCk0ucmYA3Vg=="
     },
     "history": {
       "version": "4.10.1",
@@ -21441,6 +21449,13 @@
         "mongoose": "^6.0.10",
         "parse-link-header": "^1.0.1",
         "rasha": "^1.2.5"
+      },
+      "dependencies": {
+        "helmet": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
+          "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg=="
+        }
       }
     },
     "ltijs-sequelize": {

--- a/ccm_web/package.json
+++ b/ccm_web/package.json
@@ -30,6 +30,7 @@
     "@nestjs/passport": "^8.0.1",
     "@nestjs/platform-express": "^8.2.0",
     "@nestjs/sequelize": "^8.0.0",
+    "@nestjs/serve-static": "^2.2.2",
     "@nestjs/swagger": "^5.1.4",
     "@react-hook/debounce": "^4.0.0",
     "axios": "^0.24.0",

--- a/ccm_web/package.json
+++ b/ccm_web/package.json
@@ -42,7 +42,7 @@
     "express": "^4.17.1",
     "express-session": "^1.17.2",
     "got": "^11.8.2",
-    "helmet": "^4.6.0",
+    "helmet": "^5.0.2",
     "js-cookie": "^3.0.1",
     "keycode-js": "^3.1.0",
     "ltijs": "~5.8.2",

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -30,7 +30,7 @@ export class APIService {
 
   getGlobals (user: User, sessionData: SessionData): Globals {
     return {
-      environment: process.env.NODE_ENV === 'production' ? 'production' : 'development',
+      environment: this.configService.get('server.isDev', { infer: true }) ? 'development' : 'production',
       canvasURL: this.configService.get('canvas.instanceURL', { infer: true }),
       user: {
         loginId: user.loginId,

--- a/ccm_web/server/src/app.module.ts
+++ b/ccm_web/server/src/app.module.ts
@@ -66,9 +66,7 @@ const logger = baseLogger.child({ filePath: __filename })
 export class AppModule implements NestModule {
   private readonly frameDomain: string
 
-  constructor (
-    private readonly configService: ConfigService<Config, true>
-  ) {
+  constructor (private readonly configService: ConfigService<Config, true>) {
     this.frameDomain = this.configService.get('server.frameDomain', { infer: true })
   }
 

--- a/ccm_web/server/src/app.module.ts
+++ b/ccm_web/server/src/app.module.ts
@@ -37,7 +37,7 @@ const logger = baseLogger.child({ filePath: __filename })
             configService.get('server.isDev', { infer: true }) ? path.join('dist', 'client') : 'client'
           )
         ),
-        exclude: ['/api/*', '/canvas/*', '/lti/*', '/auth/*']
+        exclude: ['/api/*', '/auth/*', '/canvas/*', '/lti/*']
       }])
     }),
     UserModule,

--- a/ccm_web/server/src/app.module.ts
+++ b/ccm_web/server/src/app.module.ts
@@ -73,7 +73,6 @@ export class AppModule implements NestModule {
   configure (consumer: MiddlewareConsumer): void {
     consumer.apply(helmet({
       contentSecurityPolicy: {
-        useDefaults: true,
         directives: { 'frame-ancestors': [this.frameDomain] }
       }
     }))

--- a/ccm_web/server/src/app.module.ts
+++ b/ccm_web/server/src/app.module.ts
@@ -37,7 +37,7 @@ const logger = baseLogger.child({ filePath: __filename })
             configService.get('server.isDev', { infer: true }) ? path.join('dist', 'client') : 'client'
           )
         ),
-        exclude: ['/api*', '/canvas*', '/lti*', '/auth*']
+        exclude: ['/api/*', '/canvas/*', '/lti/*', '/auth/*']
       }])
     }),
     UserModule,

--- a/ccm_web/server/src/app.module.ts
+++ b/ccm_web/server/src/app.module.ts
@@ -64,23 +64,19 @@ const logger = baseLogger.child({ filePath: __filename })
   providers: [UserService]
 })
 export class AppModule implements NestModule {
-  private readonly frameSrc: string
+  private readonly frameDomain: string
 
   constructor (
     private readonly configService: ConfigService<Config, true>
   ) {
-    this.frameSrc = this.configService.get('server.frameSrc', { infer: true })
+    this.frameDomain = this.configService.get('server.frameDomain', { infer: true })
   }
 
   configure (consumer: MiddlewareConsumer): void {
     consumer.apply(helmet({
       contentSecurityPolicy: {
-        directives: {
-          'default-src': ["'self'", this.frameSrc],
-          'style-src': ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
-          'frame-src': [this.frameSrc],
-          'frame-ancestors': [this.frameSrc]
-        }
+        useDefaults: true,
+        directives: { 'frame-ancestors': [this.frameDomain] }
       }
     }))
     // Exclude ltijs routes, which are already protected by helmet

--- a/ccm_web/server/src/config.ts
+++ b/ccm_web/server/src/config.ts
@@ -3,8 +3,10 @@ import baseLogger from './logger'
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
 interface ServerConfig {
+  isDev: boolean
   port: number
   domain: string
+  frameSrc: string
   logLevel: LogLevel
   cookieSecret: string
   tokenSecret: string
@@ -97,8 +99,10 @@ export function validateConfig (): Config {
 
   try {
     server = {
+      isDev: env.NODE_ENV !== 'production',
       port: validate<number>('PORT', prepNumber(env.PORT), isNumber, [isNotNan], 4000),
       domain: validate<string>('DOMAIN', env.DOMAIN, isString, [isNotEmpty]),
+      frameSrc: validate<string>('FRAME_SRC', env.FRAME_SRC, isString, [isNotEmpty]),
       logLevel: validate<LogLevel>('LOG_LEVEL', env.LOG_LEVEL, isLogLevel, [], 'debug'),
       tokenSecret: validate<string>('TOKEN_SECRET', env.TOKEN_SECRET, isString, [isNotEmpty], 'TOKENSECRET'),
       cookieSecret: validate<string>('COOKIE_SECRET', env.COOKIE_SECRET, isString, [isNotEmpty], 'COOKIESECRET'),

--- a/ccm_web/server/src/config.ts
+++ b/ccm_web/server/src/config.ts
@@ -6,7 +6,7 @@ interface ServerConfig {
   isDev: boolean
   port: number
   domain: string
-  frameSrc: string
+  frameDomain: string
   logLevel: LogLevel
   cookieSecret: string
   tokenSecret: string
@@ -102,7 +102,7 @@ export function validateConfig (): Config {
       isDev: env.NODE_ENV !== 'production',
       port: validate<number>('PORT', prepNumber(env.PORT), isNumber, [isNotNan], 4000),
       domain: validate<string>('DOMAIN', env.DOMAIN, isString, [isNotEmpty]),
-      frameSrc: validate<string>('FRAME_SRC', env.FRAME_SRC, isString, [isNotEmpty]),
+      frameDomain: validate<string>('FRAME_DOMAIN', env.FRAME_DOMAIN, isString, [isNotEmpty]),
       logLevel: validate<LogLevel>('LOG_LEVEL', env.LOG_LEVEL, isLogLevel, [], 'debug'),
       tokenSecret: validate<string>('TOKEN_SECRET', env.TOKEN_SECRET, isString, [isNotEmpty], 'TOKENSECRET'),
       cookieSecret: validate<string>('COOKIE_SECRET', env.COOKIE_SECRET, isString, [isNotEmpty], 'COOKIESECRET'),

--- a/ccm_web/server/src/lti/lti.service.ts
+++ b/ccm_web/server/src/lti/lti.service.ts
@@ -77,7 +77,7 @@ export class LTIService implements BeforeApplicationShutdown {
           ([key, value]) => value === x)
       )
       if (ltiAllowedRoles.length === 0) {
-        return createLaunchErrorResponse(res, 'your role in this course does not allow access to this tool. If you feel this is in error, please contact 4help@umich.edu.')
+        return res.redirect('/access-denied')
       }
 
       try {

--- a/ccm_web/server/src/main.ts
+++ b/ccm_web/server/src/main.ts
@@ -1,5 +1,3 @@
-import path from 'path'
-
 import cookieParser from 'cookie-parser'
 import ConnectSessionSequelize from 'connect-session-sequelize'
 import { urlencoded, json } from 'express'
@@ -33,12 +31,6 @@ async function bootstrap (): Promise<void> {
 
   const stream = { write: (message: string) => { logger.info(message.trim()) } }
   app.use(morgan('combined', { stream: stream }))
-
-  const staticPath = path.join(
-    path.join(__dirname, '..', '..'),
-    isDev ? path.join('dist', 'client') : 'client'
-  )
-  app.useStaticAssets(staticPath, { prefix: '/' })
 
   app.set('trust proxy', 1)
 

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -11,6 +11,8 @@
 # This app server's hostname. For session configuration and OAuth redirects
 # Note: Use xxxxxxxxxxxx.ngrok.io for local development.
 DOMAIN=
+# The hostname of the frame, for Content Security Policy settings
+FRAME_SRC=
 # One of the following npm log levels: debug, info, warn, error (optional)
 # LOG_LEVEL=debug
 # Secret for securing JWT tokens (optional)

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -12,7 +12,7 @@
 # Note: Use xxxxxxxxxxxx.ngrok.io for local development.
 DOMAIN=
 # The hostname of the frame, for Content Security Policy settings
-FRAME_SRC=
+FRAME_DOMAIN=
 # One of the following npm log levels: debug, info, warn, error (optional)
 # LOG_LEVEL=debug
 # Secret for securing JWT tokens (optional)


### PR DESCRIPTION
The PR aims to resolve #48 and #209. This is somewhat experimental, but I believe it works well. I think it could help us handle some other issues, such as #253 and #312. It also is related to the closed issue #103.

Note(s):
- Switches from `app.useStaticAssets` to using `ServeStaticModule`, which is designed for single-page-applications.
- Because `ServeStaticModule` is now registered in `app.module.ts`, `helmet` and its Content Security Policy (CSP) settings now apply to the static assets served. This is likely a good thing, but means we need to do more CSP configuration (included here). Without them, the iframe was getting blocked in the Canvas test instance.
- Adds a higher-level instance of `Switch` in `client/index.tsx`, so we can have public routes for error messages and redirect effectively to them from the `server` and `client` (see changes to `lti.service.ts` and `App.tsx`).