### PR TITLE
Add `aria-live` to `TablePagination`, remove it from `AddNonUMUsers` container (#258)

### DIFF
--- a/ccm_web/client/src/components/CustomTable.tsx
+++ b/ccm_web/client/src/components/CustomTable.tsx
@@ -82,6 +82,7 @@ function CustomTable<T extends TableEntity> (props: TableProps<T>): JSX.Element 
               }}
               onPageChange={handleChangePage}
               ActionsComponent={TablePaginationActions}
+              aria-live='polite'
             />
           </TableRow>
         </TableFooter>

--- a/ccm_web/client/src/pages/AddNonUMUsers.tsx
+++ b/ccm_web/client/src/pages/AddNonUMUsers.tsx
@@ -127,7 +127,7 @@ export default function AddNonUMUsers (props: AddNonUMUsersProps): JSX.Element {
   }
 
   return (
-    <div className={classes.root} aria-live='polite'>
+    <div className={classes.root}>
       <Help baseHelpURL={props.globals.baseHelpURL} helpURLEnding={props.helpURLEnding} />
       <Typography variant='h5' component='h1' className={classes.spacing}>{props.title}</Typography>
       <div>{renderActivePageState(activePageState)}</div>


### PR DESCRIPTION
Per feedback received on #258 to use `aria-live` more granularly, this PR proposes two changes to `aria-live` usage in the application:

1) add `aria-live='polite'` as instructed to the container for the table pagination footer where the displayed rows are reported
2) remove `aria-live='polite'` that was added provisionally to the `AddNonUMUsers` container, as high-level usages like this are probably noisy and discouraged.

The PR seeks to resolve #258.