### PR TITLE
Change list structure and otherwise improve `SectionSelectorWidget` (#230, #260)

### DIFF
--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -35,12 +35,21 @@ const useStyles = makeStyles((theme) => ({
       }
     }
   },
+  listItemRoot: {
+    paddingTop: '0px',
+    paddingBottom: '0px'
+  },
   listButton: {
     width: '100%',
     height: '100%',
     textAlign: 'left',
     paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2)
+    paddingRight: theme.spacing(2),
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover
+    }
   },
   buttonFocusVisible: {
     backgroundColor: theme.palette.action.focus
@@ -513,9 +522,10 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
             const isSelected = isSectionSelected(section.id)
             return (
               <ListItem
+                key={section.id}
                 divider
                 disableGutters
-                key={section.id}
+                classes={{ root: classes.listItemRoot }}
                 disabled={section.locked}
                 selected={isSelected}
                 className={(section.locked !== true && props.highlightUnlocked === true) ? classes.highlighted : ''}

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -323,7 +323,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   const listItemText = (section: SelectableCanvasCourseSection): JSX.Element => {
     const isSelected = isSectionSelected(section.id)
     return (
-      <ListItemText primary={section.name} style={isSelected ? { color: '#3777c5' } : { }}
+      <ListItemText primary={section.name} style={isSelected ? { color: '#3777c5' } : {}}
         secondary={
           <React.Fragment>
             {
@@ -502,13 +502,15 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
       <Grid item xs={12} className={classes.sectionSelectionContainer}>
         <List className={classes.listContainer} style={{ maxHeight: props.height }}>
           {internalSections.map((section) => {
+            const isSelected = isSectionSelected(section.id)
             return (
               <ListItem
                 divider
                 key={section.id}
                 button
                 disabled={section.locked}
-                selected={isSectionSelected(section.id)}
+                selected={isSelected}
+                aria-pressed={isSelected}
                 onClick={() => handleListItemClick(section.id)}
                 className={(section.locked !== true && props.highlightUnlocked === true) ? classes.highlighted : ''}
               >

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -498,7 +498,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
           </Grid>
         </Grid>
       <Grid item xs={12} className={classes.sectionSelectionContainer}>
-        <List className={classes.listContainer} style={{ maxHeight: props.height }}>
+        <List component='div' className={classes.listContainer} style={{ maxHeight: props.height }} >
           {internalSections.map((section) => {
             const isSelected = isSectionSelected(section.id)
             return (
@@ -506,6 +506,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
                 divider
                 key={section.id}
                 button
+                component='button'
                 disabled={section.locked}
                 selected={isSelected}
                 aria-pressed={isSelected}

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import { useSnackbar } from 'notistack'
 import {
-  Backdrop, Button, Checkbox, CircularProgress, FormControl, FormControlLabel,
-  FormGroup, Grid, GridSize, InputLabel, List, ListItem, ListItemText, makeStyles,
-  Menu, MenuItem, Select, TextField, Typography, useMediaQuery, useTheme
+  Backdrop, Button, Checkbox, CircularProgress, FormControl, FormControlLabel, FormGroup, Grid,
+  GridSize, InputLabel, List, ListItem, ListItemText, makeStyles, Menu, MenuItem, Select, TextField,
+  Typography, useMediaQuery, useTheme
 } from '@material-ui/core'
 import ClearIcon from '@material-ui/icons/Clear'
 import SortIcon from '@material-ui/icons/Sort'
@@ -397,7 +397,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     action: { xs: hasSort() ? 4 : 8, sm: hasSort() ? 6 : 12, md: 3 }
   }
 
-  const sortButton = (): JSX.Element => {
+  const sortButton = (): JSX.Element | undefined => {
     if (props.header?.sort !== undefined && props.header.sort?.sorters.length > 0) {
       return (
         <Grid item {...gridSpacing.sort}>
@@ -423,8 +423,6 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
           </Menu>
         </Grid>
       )
-    } else {
-      return (<></>)
     }
   }
 

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -333,7 +333,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
               )
             }
             {unmergeButton(section)}
-            <span style={props.showCourseName === true ? { float: 'right' } : {}}>
+            <span style={props.showCourseName === true ? { float: 'right' } : undefined}>
               {`${section.total_students ?? '?'} students`}
             </span>
           </React.Fragment>

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -437,7 +437,9 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   // Passing in the height in the props seems like the wrong solution, but wanted to move on from solving that for now
   return (
     <>
-      <span aria-live='polite' aria-atomic='true' className={classes.srOnly}>{props.selectedSections.length} section{props.selectedSections.length === 1 ? '' : 's' } selected</span>
+      <span aria-live='polite' aria-atomic='true' className={classes.srOnly}>
+        {props.selectedSections.length} {'section' + (props.selectedSections.length === 1 ? '' : 's')} selected
+      </span>
       <Grid container>
         <Grid className={classes.header} container item xs={12}>
           {

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -462,64 +462,64 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   // Passing in the height in the props seems like the wrong solution, but wanted to move on from solving that for now
   return (
     <>
-      <span aria-live='polite' aria-atomic='true' className={classes.srOnly}>
-        {props.selectedSections.length} {'section' + (props.selectedSections.length === 1 ? '' : 's')} selected
-      </span>
-      <Grid container>
-        <Grid className={classes.header} container item xs={12}>
+    <span aria-live='polite' aria-atomic='true' className={classes.srOnly}>
+      {props.selectedSections.length} {'section' + (props.selectedSections.length === 1 ? '' : 's')} selected
+    </span>
+    <Grid container>
+      <Grid className={classes.header} container item xs={12}>
+        {
+          searcher?.isInteractive === true && (
+            <Grid item container className={classes.searchContainer} xs={12}>
+              <TextField
+                className={classes.searchTextField}
+                disabled={isSearching || isIniting}
+                onChange={searchChange}
+                value={searchFieldText}
+                id='textField_Search'
+                size='small'
+                label={searchFieldLabel}
+                variant='outlined'
+                inputProps={{ maxLength: 256 }}
+                InputProps={{ endAdornment: getSearchTextFieldEndAdornment(searchFieldText.length > 0) }}
+              />
+            </Grid>
+          )
+        }
+        <Grid item container style={{ paddingLeft: '16px' }}>
           {
-            searcher?.isInteractive === true && (
-              <Grid item container className={classes.searchContainer} xs={12}>
-                <TextField
-                  className={classes.searchTextField}
-                  disabled={isSearching || isIniting}
-                  onChange={searchChange}
-                  value={searchFieldText}
-                  id='textField_Search'
-                  size='small'
-                  label={searchFieldLabel}
-                  variant='outlined'
-                  inputProps={{ maxLength: 256 }}
-                  InputProps={{ endAdornment: getSearchTextFieldEndAdornment(searchFieldText.length > 0) }}
-                />
+            props.header?.title !== undefined && (
+              <Grid item {...gridSpacing.title} className={classes.title}>
+                <Typography variant='h6' component='h2'>
+                  {props.header.title}
+                  {props.selectedSections.length > 0 && <span> ({props.selectedSections.length})</span>}
+                </Typography>
               </Grid>
             )
           }
-          <Grid item container style={{ paddingLeft: '16px' }}>
-            {
-              props.header?.title !== undefined && (
-                <Grid item {...gridSpacing.title} className={classes.title}>
-                  <Typography variant='h6' component='h2'>
-                    {props.header.title}
-                    {props.selectedSections.length > 0 && <span> ({props.selectedSections.length})</span>}
-                  </Typography>
-                </Grid>
-              )
-            }
-            {
-              props.multiSelect && (
-                <Grid item {...gridSpacing['select all']}>
-                  <FormGroup row style={checkboxStyle()}>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={isSelectAllChecked}
-                          onChange={handleSelectAllClicked}
-                          name='selectAllUnstagedCB'
-                          color='primary'
-                        />
-                      }
-                      disabled={selectableSections().length === 0}
-                      label='Select All'
-                    />
-                  </FormGroup>
-                </Grid>
-              )
-            }
-            {sortButton()}
-            {actionButton()}
-          </Grid>
+          {
+            props.multiSelect && (
+              <Grid item {...gridSpacing['select all']}>
+                <FormGroup row style={checkboxStyle()}>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={isSelectAllChecked}
+                        onChange={handleSelectAllClicked}
+                        name='selectAllUnstagedCB'
+                        color='primary'
+                      />
+                    }
+                    disabled={selectableSections().length === 0}
+                    label='Select All'
+                  />
+                </FormGroup>
+              </Grid>
+            )
+          }
+          {sortButton()}
+          {actionButton()}
         </Grid>
+      </Grid>
       <Grid item xs={12} className={classes.sectionSelectionContainer}>
         <List className={classes.listContainer} style={{ maxHeight: props.height }} >
           {internalSections.map((section) => {

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: theme.palette.action.hover
     }
   },
-  buttonFocusVisible: {
+  listButtonFocusVisible: {
     backgroundColor: theme.palette.action.focus
   },
   searchContainer: {
@@ -110,6 +110,9 @@ const useStyles = makeStyles((theme) => ({
     borderLeftStyle: 'solid',
     borderLeftColor: '#3777c5',
     borderLeftWidth: '1px'
+  },
+  button: {
+    margin: theme.spacing(1)
   }
 }))
 
@@ -322,6 +325,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     if (section.nonxlist_course_id !== null && props.canUnmerge && (section.locked ?? false)) {
       return (
         <Button
+          className={classes.button}
           color='primary'
           variant='contained'
           disabled={isUnmerging}
@@ -366,6 +370,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
       return (
       <Grid item {...gridSpacing.action}>
         <Button
+          className={classes.button}
           style={{ float: 'right' }}
           variant='contained'
           color='primary'
@@ -424,6 +429,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
       return (
         <Grid item {...gridSpacing.sort}>
           <Button
+            className={classes.button}
             style={{ float: 'left' }}
             aria-controls='simple-menu'
             aria-haspopup='true'
@@ -532,7 +538,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
                   onClick={() => handleListItemClick(section.id)}
                   disabled={section.locked}
                   aria-pressed={isSelected}
-                  focusVisibleClassName={classes.buttonFocusVisible}
+                  focusVisibleClassName={classes.listButtonFocusVisible}
                 >
                   {listItemText(section)}
                 </ButtonBase>

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useSnackbar } from 'notistack'
 import {
-  Backdrop, Button, Checkbox, CircularProgress, FormControl, FormControlLabel, FormGroup, Grid,
+  Backdrop, Button, ButtonBase, Checkbox, CircularProgress, FormControl, FormControlLabel, FormGroup, Grid,
   GridSize, InputLabel, List, ListItem, ListItemText, makeStyles, Menu, MenuItem, Select, TextField,
   Typography, useMediaQuery, useTheme
 } from '@material-ui/core'
@@ -34,6 +34,16 @@ const useStyles = makeStyles((theme) => ({
         }
       }
     }
+  },
+  listButton: {
+    width: '100%',
+    height: '100%',
+    textAlign: 'left',
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2)
+  },
+  buttonFocusVisible: {
+    backgroundColor: theme.palette.action.focus
   },
   searchContainer: {
     textAlign: 'left'
@@ -498,22 +508,27 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
           </Grid>
         </Grid>
       <Grid item xs={12} className={classes.sectionSelectionContainer}>
-        <List component='div' className={classes.listContainer} style={{ maxHeight: props.height }} >
+        <List className={classes.listContainer} style={{ maxHeight: props.height }} >
           {internalSections.map((section) => {
             const isSelected = isSectionSelected(section.id)
             return (
               <ListItem
                 divider
+                disableGutters
                 key={section.id}
-                button
-                component='button'
                 disabled={section.locked}
                 selected={isSelected}
-                aria-pressed={isSelected}
-                onClick={() => handleListItemClick(section.id)}
                 className={(section.locked !== true && props.highlightUnlocked === true) ? classes.highlighted : ''}
               >
-                {listItemText(section)}
+                <ButtonBase
+                  className={classes.listButton}
+                  onClick={() => handleListItemClick(section.id)}
+                  disabled={section.locked}
+                  aria-pressed={isSelected}
+                  focusVisibleClassName={classes.buttonFocusVisible}
+                >
+                  {listItemText(section)}
+                </ButtonBase>
               </ListItem>
             )
           })}

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -118,6 +118,7 @@ interface ISectionSelectorWidgetProps {
 
 function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element {
   const classes = useStyles()
+  const theme = useTheme()
   const { enqueueSnackbar } = useSnackbar()
 
   // The search text ultimately used when searching
@@ -319,7 +320,9 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   const listItemText = (section: SelectableCanvasCourseSection): JSX.Element => {
     const isSelected = isSectionSelected(section.id)
     return (
-      <ListItemText primary={section.name} style={isSelected ? { color: '#3777c5' } : {}}
+      <ListItemText
+        primary={section.name}
+        style={isSelected ? { color: theme.palette.info.main } : undefined}
         secondary={
           <React.Fragment>
             {
@@ -427,7 +430,6 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   }
 
   const checkboxStyle = (): Record<string, unknown> => {
-    const theme = useTheme()
     const xs = useMediaQuery(theme.breakpoints.up('xs'))
     return { float: xs ? 'left' : 'right' }
   }

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -412,7 +412,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
     return props.header?.sort !== undefined
   }
 
-  const gridSpacing: Record<string, Record<'sm' | 'xs' | 'md', GridSize>> = {
+  const gridSpacing: Record<'title' | 'select all' | 'sort' | 'action', Record<'sm' | 'xs' | 'md', GridSize>> = {
     title: { xs: 12, sm: 8, md: hasSort() ? 4 : 6 },
     'select all': { xs: 4, sm: 4, md: 3 },
     sort: { xs: 4, sm: 6, md: 2 },
@@ -462,7 +462,7 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
       <Grid container>
         <Grid className={classes.header} container item xs={12}>
           {
-            (props.search.length > 0 && searcher?.isInteractive) && (
+            searcher?.isInteractive === true && (
               <Grid item container className={classes.searchContainer} xs={12}>
                 <TextField
                   className={classes.searchTextField}
@@ -483,11 +483,9 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
             {
               props.header?.title !== undefined && (
                 <Grid item {...gridSpacing.title} className={classes.title}>
-                  <Typography variant='h6'>
+                  <Typography variant='h6' component='h2'>
                     {props.header.title}
-                    {props.selectedSections.length > 0 && (
-                      <span> ({props.selectedSections.length})</span>
-                    )}
+                    {props.selectedSections.length > 0 && <span> ({props.selectedSections.length})</span>}
                   </Typography>
                 </Grid>
               )
@@ -526,9 +524,8 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
                 divider
                 disableGutters
                 classes={{ root: classes.listItemRoot }}
-                disabled={section.locked}
                 selected={isSelected}
-                className={(section.locked !== true && props.highlightUnlocked === true) ? classes.highlighted : ''}
+                className={(section.locked !== true && props.highlightUnlocked === true) ? classes.highlighted : undefined}
               >
                 <ButtonBase
                   className={classes.listButton}

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -20,10 +20,7 @@ import Help from '../components/Help'
 const useStyles = makeStyles((theme) => ({
   root: {
     padding: 25,
-    textAlign: 'left',
-    '& button': {
-      margin: 5
-    }
+    textAlign: 'left'
   },
   sectionSelectionContainer: {
     position: 'relative',

--- a/ccm_web/client/src/pages/MergeSections.tsx
+++ b/ccm_web/client/src/pages/MergeSections.tsx
@@ -7,7 +7,10 @@ import { useSnackbar } from 'notistack'
 import { adminRoles } from '../models/feature'
 import { CCMComponentProps, isAuthorizedForRoles } from '../models/FeatureUIData'
 import SectionSelectorWidget, { SelectableCanvasCourseSection } from '../components/SectionSelectorWidget'
-import { CanvasCourseSectionSort_AZ, CanvasCourseSectionSort_UserCount, CanvasCourseSectionSort_ZA, CanvasCourseSectionWithCourseName, ICanvasCourseSectionSort } from '../models/canvas'
+import {
+  CanvasCourseSectionBase, CanvasCourseSectionSort_AZ, CanvasCourseSectionSort_UserCount,
+  CanvasCourseSectionSort_ZA, CanvasCourseSectionWithCourseName, ICanvasCourseSectionSort
+} from '../models/canvas'
 import { mergeSections } from '../api'
 import usePromise from '../hooks/usePromise'
 import { CourseNameSearcher, CourseSectionSearcher, SectionNameSearcher, UniqnameSearcher } from '../utils/SectionSearcher'
@@ -171,8 +174,9 @@ function MergeSections (props: CCMComponentProps): JSX.Element {
     )
   }
 
-  const handleUnmergedSections = (unmergedSections: SelectableCanvasCourseSection[]): void => {
-    setStagedSections(stagedSections.filter(section => { return !unmergedSections.map(us => { return us.id }).includes(section.id) }))
+  const handleUnmergedSections = (unmergedSections: CanvasCourseSectionBase[]): void => {
+    const unmergedSectionIds = unmergedSections.map(us => us.id)
+    setStagedSections(stagedSections.filter(section => !unmergedSectionIds.includes(section.id)))
   }
 
   const getSelectSectionsStaged = (): JSX.Element => {


### PR DESCRIPTION
This PR aims to resolve #230 and #260.

Change(s):
1. Rather than relying on the provided `button` prop on `ListItem`, a `ButtonBase` was placed inside each `ListItem`. This follows the preferred approach identified by the accessibility team meant to resolve #260.
2.  Modified the `usePromise` hook for unmerging sections so an intermediate state variable (`sectionsToUnmerge`) and `useEffect` hook could be removed.
3. Made the text of the course name in a selected section blue, which I believe was the original intention, but wasn't happening before (reason...)
4. Used conditional rendering in a handful of instances (`props.multiSelect`, `props.search`, `props.header`), instead of using hidden styles (this resulted in some minor visual changes). I think this also had the side effect of fixing #230.
5. Broke up long lines for readability.