### PR TITLE
I333 support librarian/assistant roles when enrolling users to sections

### DIFF
--- a/ccm_web/client/src/models/canvas.ts
+++ b/ccm_web/client/src/models/canvas.ts
@@ -61,7 +61,9 @@ export enum CanvasEnrollmentType {
   Teacher = 'TeacherEnrollment',
   TA = 'TaEnrollment',
   Observer = 'ObserverEnrollment',
-  Designer = 'DesignerEnrollment'
+  Designer = 'DesignerEnrollment',
+  Librarian = 'Librarian',
+  Assistant = 'Assistant'
 }
 
 export enum ClientEnrollmentType {
@@ -69,7 +71,9 @@ export enum ClientEnrollmentType {
   Teacher = 'teacher',
   TA = 'ta',
   Observer = 'observer',
-  Designer = 'designer'
+  Designer = 'designer',
+  Assistant = 'assistant',
+  Librarian = 'librarian'
 }
 const clientStringValues = Object.values(ClientEnrollmentType).map(m => String(m))
 
@@ -86,7 +90,9 @@ const clientToCanvasRoleMap: Record<ClientEnrollmentType, CanvasEnrollmentType> 
   teacher: CanvasEnrollmentType.Teacher,
   ta: CanvasEnrollmentType.TA,
   observer: CanvasEnrollmentType.Observer,
-  designer: CanvasEnrollmentType.Designer
+  designer: CanvasEnrollmentType.Designer,
+  assistant: CanvasEnrollmentType.Assistant,
+  librarian: CanvasEnrollmentType.Librarian
 }
 
 const levelOneAddableRoles = [ClientEnrollmentType.Student]

--- a/ccm_web/client/src/models/canvas.ts
+++ b/ccm_web/client/src/models/canvas.ts
@@ -98,7 +98,8 @@ const clientToCanvasRoleMap: Record<ClientEnrollmentType, CanvasEnrollmentType> 
 const levelOneAddableRoles = [ClientEnrollmentType.Student]
 const levelTwoAddableRoles = [...levelOneAddableRoles, ClientEnrollmentType.Observer]
 const levelThreeAddableRoles = [
-  ...levelTwoAddableRoles, ClientEnrollmentType.TA, ClientEnrollmentType.Designer, ClientEnrollmentType.Teacher
+  ...levelTwoAddableRoles, ClientEnrollmentType.TA, ClientEnrollmentType.Designer, ClientEnrollmentType.Teacher,
+  ClientEnrollmentType.Assistant, ClientEnrollmentType.Librarian
 ]
 
 type RankedRoleData = Record<RoleEnum, number>

--- a/ccm_web/client/src/models/canvas.ts
+++ b/ccm_web/client/src/models/canvas.ts
@@ -114,7 +114,7 @@ export const rankedRoleData: RankedRoleData = {
   'Sub-Account Admin': 3,
   'Account Admin': 3,
   'Tool Installer (by ITS Approval only)': 0,
-  'Support Consultant': 0,
+  'Support Consultant': 3,
   Librarian: 0,
   Grader: 0
 } as const

--- a/ccm_web/server/src/api/api.section.handler.ts
+++ b/ccm_web/server/src/api/api.section.handler.ts
@@ -8,7 +8,7 @@ import {
 } from '../canvas/canvas.interfaces'
 
 import baseLogger from '../logger'
-import { CustomCanvasRoles } from '../config'
+import { CustomCanvasRoleData } from '../config'
 
 const logger = baseLogger.child({ filePath: __filename })
 
@@ -18,9 +18,9 @@ Handler class for Canvas API calls dealing with a specific section (i.e. those b
 export class SectionApiHandler {
   requestor: CanvasRequestor
   sectionId: number
-  customCanvasRoles?: CustomCanvasRoles
+  customCanvasRoles?: CustomCanvasRoleData
 
-  constructor (requestor: CanvasRequestor, sectionId: number, customCanvasRoles?: CustomCanvasRoles) {
+  constructor (requestor: CanvasRequestor, sectionId: number, customCanvasRoles?: CustomCanvasRoleData) {
     this.requestor = requestor
     this.sectionId = sectionId
     this.customCanvasRoles = customCanvasRoles

--- a/ccm_web/server/src/api/api.section.handler.ts
+++ b/ccm_web/server/src/api/api.section.handler.ts
@@ -1,3 +1,5 @@
+import { Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
 import CanvasRequestor from '@kth/canvas-api'
 
 import { APIErrorData } from './api.interfaces'
@@ -7,6 +9,7 @@ import {
   CanvasCourseSection, CanvasCourseSectionBase, CanvasEnrollment, CanvasEnrollmentWithUser, UserEnrollmentType
 } from '../canvas/canvas.interfaces'
 
+import { Config } from '../config'
 import baseLogger from '../logger'
 
 const logger = baseLogger.child({ filePath: __filename })
@@ -14,7 +17,9 @@ const logger = baseLogger.child({ filePath: __filename })
 /*
 Handler class for Canvas API calls dealing with a specific section (i.e. those beginning with "/sections/:id")
 */
+@Injectable()
 export class SectionApiHandler {
+  // private readonly configService: ConfigService<Config, true>
   requestor: CanvasRequestor
   sectionId: number
 
@@ -55,16 +60,19 @@ export class SectionApiHandler {
     try {
       const endpoint = `sections/${this.sectionId}/enrollments`
       const method = HttpMethod.Post
-      const body = {
+      const enrollParams = {
         enrollment: {
-          // 'sis_login_id:' prefix per...
-          // https://canvas.instructure.com/doc/api/file.object_ids.html
+        // 'sis_login_id:' prefix per...
+        // https://canvas.instructure.com/doc/api/file.object_ids.html
           user_id: `sis_login_id:${enrollLoginId}`,
-          type: user.type,
           enrollment_state: 'active',
           notify: false
         }
       }
+      if (user.type === 'Assistant' || user.type === 'Librarian') {
+
+      }
+      const body = { enrollParams }
       logger.debug(`Sending request to Canvas endpoint: "${endpoint}"; method: "${method}"; body: "${JSON.stringify(body)}"`)
       const response = await this.requestor.request<CanvasEnrollment>(endpoint, method, body)
       logger.debug(`Received response with status code ${response.statusCode}`)

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -116,17 +116,18 @@ export class APIService {
   }
 
   async enrollSectionUsers (user: User, sectionId: number, sectionUsers: SectionUserDto[]): Promise<CanvasEnrollment[] | APIErrorData> {
-    const customRoles = JSON.parse(this.configService.get('canvas.customRoles', { infer: true }))
+    const customCanvasRoles = this.configService.get('canvas.customCanvasRole', { infer: true })
     const requestor = await this.canvasService.createRequestorForUser(user, '/api/v1/')
-    const sectionHandler = new SectionApiHandler(requestor, sectionId)
+    const sectionHandler = new SectionApiHandler(requestor, sectionId, customCanvasRoles)
     return await sectionHandler.enrollUsers(sectionUsers)
   }
 
   async createSectionEnrollments (user: User, enrollments: SectionEnrollmentDto[]): Promise<CanvasEnrollment[] | APIErrorData> {
+    const customCanvasRoles = this.configService.get('canvas.customCanvasRole', { infer: true })
     const requestor = await this.canvasService.createRequestorForUser(user, '/api/v1/')
     const apiPromises = enrollments.map(async (e) => {
       const { sectionId, ...sectionUser } = e
-      const sectionHandler = new SectionApiHandler(requestor, e.sectionId)
+      const sectionHandler = new SectionApiHandler(requestor, e.sectionId, customCanvasRoles)
       return await sectionHandler.enrollUser(sectionUser)
     })
     const enrollmentResults = await Promise.all(apiPromises)

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -116,14 +116,14 @@ export class APIService {
   }
 
   async enrollSectionUsers (user: User, sectionId: number, sectionUsers: SectionUserDto[]): Promise<CanvasEnrollment[] | APIErrorData> {
-    const customCanvasRoles = this.configService.get('canvas.customCanvasRole', { infer: true })
+    const customCanvasRoles = this.configService.get('canvas.customCanvasRoleData', { infer: true })
     const requestor = await this.canvasService.createRequestorForUser(user, '/api/v1/')
     const sectionHandler = new SectionApiHandler(requestor, sectionId, customCanvasRoles)
     return await sectionHandler.enrollUsers(sectionUsers)
   }
 
   async createSectionEnrollments (user: User, enrollments: SectionEnrollmentDto[]): Promise<CanvasEnrollment[] | APIErrorData> {
-    const customCanvasRoles = this.configService.get('canvas.customCanvasRole', { infer: true })
+    const customCanvasRoles = this.configService.get('canvas.customCanvasRoleData', { infer: true })
     const requestor = await this.canvasService.createRequestorForUser(user, '/api/v1/')
     const apiPromises = enrollments.map(async (e) => {
       const { sectionId, ...sectionUser } = e

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -116,7 +116,7 @@ export class APIService {
   }
 
   async enrollSectionUsers (user: User, sectionId: number, sectionUsers: SectionUserDto[]): Promise<CanvasEnrollment[] | APIErrorData> {
-    
+    const customRoles = JSON.parse(this.configService.get('canvas.customRoles', { infer: true }))
     const requestor = await this.canvasService.createRequestorForUser(user, '/api/v1/')
     const sectionHandler = new SectionApiHandler(requestor, sectionId)
     return await sectionHandler.enrollUsers(sectionUsers)

--- a/ccm_web/server/src/api/api.service.ts
+++ b/ccm_web/server/src/api/api.service.ts
@@ -116,6 +116,7 @@ export class APIService {
   }
 
   async enrollSectionUsers (user: User, sectionId: number, sectionUsers: SectionUserDto[]): Promise<CanvasEnrollment[] | APIErrorData> {
+    
     const requestor = await this.canvasService.createRequestorForUser(user, '/api/v1/')
     const sectionHandler = new SectionApiHandler(requestor, sectionId)
     return await sectionHandler.enrollUsers(sectionUsers)

--- a/ccm_web/server/src/api/dtos/api.section.users.dto.ts
+++ b/ccm_web/server/src/api/dtos/api.section.users.dto.ts
@@ -2,6 +2,7 @@ import {
   ArrayMaxSize,
   ArrayMinSize,
   IsArray,
+  IsIn,
   IsNotEmpty,
   ValidateNested
 } from 'class-validator'
@@ -16,6 +17,7 @@ export class SectionUserDto {
 
   @ApiProperty({ enum: UserEnrollmentType })
   @IsNotEmpty()
+  @IsIn(Object.values(UserEnrollmentType))
   type: UserEnrollmentType
 
   constructor (loginId: string, type: UserEnrollmentType) {

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -124,14 +124,6 @@ export interface CanvasAccount {
   parent_account_id: number | null
 }
 
-export interface EnrollmentParams {
-  user_id: string
-  enrollment_state: string
-  notify: boolean
-  role_id?: number
-  type?: UserEnrollmentType
-}
-
 // Composites
 
 export interface CourseWithSections extends CanvasCourseBase {

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -83,6 +83,7 @@ export enum CustomCanvasRoleType {
   Librarian = CanvasRole.Librarian,
   Assistant = CanvasRole.Assistant
 }
+
 export enum UserEnrollmentType {
   DesignerEnrollment = CanvasRole.DesignerEnrollment,
   ObserverEnrollment = CanvasRole.ObserverEnrollment,

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -119,6 +119,14 @@ export interface CanvasAccount {
   parent_account_id: number | null
 }
 
+export interface EnrollmentParams {
+  user_id: string
+  enrollment_state: string
+  notify: boolean
+  role_id?: number
+  type?: UserEnrollmentType
+}
+
 // Composites
 
 export interface CourseWithSections extends CanvasCourseBase {

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -79,6 +79,10 @@ export enum CanvasRole {
   Librarian = 'Librarian',
 }
 
+export enum CustomCanvasRoleType {
+  Librarian = CanvasRole.Librarian,
+  Assistant = CanvasRole.Assistant
+}
 export enum UserEnrollmentType {
   DesignerEnrollment = CanvasRole.DesignerEnrollment,
   ObserverEnrollment = CanvasRole.ObserverEnrollment,

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -75,7 +75,8 @@ export enum CanvasRole {
   ObserverEnrollment = 'ObserverEnrollment',
   StudentEnrollment = 'StudentEnrollment',
   TaEnrollment = 'TaEnrollment',
-  TeacherEnrollment = 'TeacherEnrollment'
+  TeacherEnrollment = 'TeacherEnrollment',
+  Librarian = 'Librarian',
 }
 
 export enum UserEnrollmentType {
@@ -83,7 +84,9 @@ export enum UserEnrollmentType {
   ObserverEnrollment = CanvasRole.ObserverEnrollment,
   StudentEnrollment = CanvasRole.StudentEnrollment,
   TaEnrollment = CanvasRole.TaEnrollment,
-  TeacherEnrollment = CanvasRole.TeacherEnrollment
+  TeacherEnrollment = CanvasRole.TeacherEnrollment,
+  Librarian = CanvasRole.Librarian,
+  Assistant = CanvasRole.Assistant
 }
 
 // valid role types for LTI launch

--- a/ccm_web/server/src/canvas/canvas.interfaces.ts
+++ b/ccm_web/server/src/canvas/canvas.interfaces.ts
@@ -76,7 +76,7 @@ export enum CanvasRole {
   StudentEnrollment = 'StudentEnrollment',
   TaEnrollment = 'TaEnrollment',
   TeacherEnrollment = 'TeacherEnrollment',
-  Librarian = 'Librarian',
+  Librarian = 'Librarian'
 }
 
 export enum CustomCanvasRoleType {

--- a/ccm_web/server/src/canvas/canvas.scopes.ts
+++ b/ccm_web/server/src/canvas/canvas.scopes.ts
@@ -20,7 +20,9 @@ const canvasScopes = [
   'url:POST|/api/v1/sections/:section_id/enrollments',
   // Accounts
   'url:GET|/api/v1/accounts',
-  'url:GET|/api/v1/accounts/:account_id/courses'
+  'url:GET|/api/v1/accounts/:account_id/courses',
+
+  'url:GET|/api/v1/accounts/:account_id/roles'
 ]
 
 export default canvasScopes

--- a/ccm_web/server/src/canvas/canvas.scopes.ts
+++ b/ccm_web/server/src/canvas/canvas.scopes.ts
@@ -20,9 +20,7 @@ const canvasScopes = [
   'url:POST|/api/v1/sections/:section_id/enrollments',
   // Accounts
   'url:GET|/api/v1/accounts',
-  'url:GET|/api/v1/accounts/:account_id/courses',
-
-  'url:GET|/api/v1/accounts/:account_id/roles'
+  'url:GET|/api/v1/accounts/:account_id/courses'
 ]
 
 export default canvasScopes

--- a/ccm_web/server/src/config.ts
+++ b/ccm_web/server/src/config.ts
@@ -30,7 +30,7 @@ interface CanvasConfig {
   instanceURL: string
   apiClientId: string
   apiSecret: string
-  customCanvasRoleData?: CustomCanvasRoleData
+  customCanvasRoleData: CustomCanvasRoleData
 }
 
 export interface DatabaseConfig {

--- a/ccm_web/server/src/config.ts
+++ b/ccm_web/server/src/config.ts
@@ -145,7 +145,9 @@ export function validateConfig (): Config {
       instanceURL: validate<string>('CANVAS_INSTANCE_URL', env.CANVAS_INSTANCE_URL, isString, [isNotEmpty]),
       apiClientId: validate<string>('CANVAS_API_CLIENT_ID', env.CANVAS_API_CLIENT_ID, isString, [isNotEmpty]),
       apiSecret: validate<string>('CANVAS_API_SECRET', env.CANVAS_API_SECRET, isString, [isNotEmpty]),
-      customCanvasRole: validate<CustomCanvasRoles>('CANVAS_CUSTOM_ROLES', prepObjectFromJSON(env.CANVAS_CUSTOM_ROLES), isCustomCanvasRoles, [], { Assistant: 34, Librarian: 21 })
+      customCanvasRole: validate<CustomCanvasRoles>(
+        'CANVAS_CUSTOM_ROLES', prepObjectFromJSON(env.CANVAS_CUSTOM_ROLES), isCustomCanvasRoles, [], { Assistant: 34, Librarian: 21 }
+      )
     }
     db = {
       host: validate<string>('DB_HOST', env.DB_HOST, isString, [isNotEmpty]),

--- a/ccm_web/server/src/config.ts
+++ b/ccm_web/server/src/config.ts
@@ -26,6 +26,7 @@ interface CanvasConfig {
   instanceURL: string
   apiClientId: string
   apiSecret: string
+  customRoles: string
 }
 
 export interface DatabaseConfig {
@@ -119,7 +120,8 @@ export function validateConfig (): Config {
     canvas = {
       instanceURL: validate<string>('CANVAS_INSTANCE_URL', env.CANVAS_INSTANCE_URL, isString, [isNotEmpty]),
       apiClientId: validate<string>('CANVAS_API_CLIENT_ID', env.CANVAS_API_CLIENT_ID, isString, [isNotEmpty]),
-      apiSecret: validate<string>('CANVAS_API_SECRET', env.CANVAS_API_SECRET, isString, [isNotEmpty])
+      apiSecret: validate<string>('CANVAS_API_SECRET', env.CANVAS_API_SECRET, isString, [isNotEmpty]),
+      customRoles: validate<string>('CANVAS_CUSTOM_ROLES', env.CANVAS_CUSTOM_ROLES, isString, [isNotEmpty])
     }
     db = {
       host: validate<string>('DB_HOST', env.DB_HOST, isString, [isNotEmpty]),

--- a/ccm_web/server/src/config.ts
+++ b/ccm_web/server/src/config.ts
@@ -61,6 +61,17 @@ const isNotNan = (v: number): boolean => !isNaN(v)
 const isLogLevel = (v: unknown): v is LogLevel => {
   return isString(v) && ['debug', 'info', 'warn', 'error'].includes(v)
 }
+const isCustomCanvasRoles = (v: unknown): v is CustomCanvasRoleData => {
+  if (typeof v === 'object' && v !== null) {
+    for (const [key, value] of Object.entries(v)) {
+      if (typeof value !== 'number') return false
+      if (typeof key !== 'string') return false
+    }
+    return true
+  } else {
+    return false // undefined or not an object
+  }
+}
 const errorBase = 'Exception while loading configuration: '
 
 // Handles some edge cases and casts all other values using Number
@@ -74,18 +85,6 @@ const prepObjectFromJSON = (value: string | undefined): Record<string, unknown> 
     return JSON.parse(value)
   } catch (error) {
     throw new Error(errorBase + 'a provided JSON value was found to be invalid.')
-  }
-}
-
-const isCustomCanvasRoles = (v: unknown): v is CustomCanvasRoleData => {
-  if (typeof v === 'object' && v !== null) {
-    for (const [key, value] of Object.entries(v)) {
-      if (typeof value !== 'number') return false
-      if (typeof key !== 'string') return false
-    }
-    return true
-  } else {
-    return false // undefined or not an object
   }
 }
 

--- a/ccm_web/server/src/config.ts
+++ b/ccm_web/server/src/config.ts
@@ -68,7 +68,7 @@ const prepNumber = (value: string | undefined): string | number | undefined => {
   return (value === undefined) ? undefined : value.trim() === '' ? value : Number(value)
 }
 
-const prepObjectFromJSON = (value: string | undefined): Record<string, unknown > | undefined => {
+const prepObjectFromJSON = (value: string | undefined): Record<string, unknown> | undefined => {
   if (value === undefined) return undefined
   try {
     return JSON.parse(value)

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -47,8 +47,8 @@ CANVAS_INSTANCE_URL=https://canvas-test.it.umich.edu
 CANVAS_API_CLIENT_ID=
 # Secret for the Canvas Developer Key associated with the application
 CANVAS_API_SECRET=
-# The canvas custom roles id's that used when enrolling users to section, this has a fallback value if not set
-CANVAS_CUSTOM_ROLES={"Assistant": 1, "Librarian": 2}
+# The Canvas custom roles IDs to use when enrolling users to sections (optional)
+# CANVAS_CUSTOM_ROLES={ "Assistant": 34, "Librarian": 21 }
 
 # Database variables
 # Parameters for connecting to the MySQL database (port is optional)

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -47,6 +47,7 @@ CANVAS_INSTANCE_URL=https://canvas-test.it.umich.edu
 CANVAS_API_CLIENT_ID=
 # Secret for the Canvas Developer Key associated with the application
 CANVAS_API_SECRET=
+# The canvas custom roles id's that used when enrolling users to section, this has a fallback value if not set
 CANVAS_CUSTOM_ROLES={"Assistant": 1, "Librarian": 2}
 
 # Database variables

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -47,6 +47,7 @@ CANVAS_INSTANCE_URL=https://canvas-test.it.umich.edu
 CANVAS_API_CLIENT_ID=
 # Secret for the Canvas Developer Key associated with the application
 CANVAS_API_SECRET=
+CANVAS_CUSTOM_ROLES={"Assistant": 1, "Librarian": 2}
 
 # Database variables
 # Parameters for connecting to the MySQL database (port is optional)


### PR DESCRIPTION
Fixes #333 

1. Adding [test plan](https://docs.google.com/spreadsheets/d/1NxUnwo1cxD8gTxYK5DGwVwdb4u65u2FIp5iRcTpR7xg/edit#gid=0) testing this feature
2. Fixed a bug for Add Non-UM user Support consultant  no roles populated. Support consultant share same privileges in **CCM** as Account Admin role.
3. Add a check in the single Add UM user case for possible enrollments expected. Was already done with Multiple section user enroll case
4. For Non-UM users the code only displaying if the custom roles get picked up for Admin/Designer/Teacher and don't throw any validation error. Actual integration test can't be done until #247 get resolved

@ssciolla Thanks for the help with the validating the custom role props structure