### PR TITLE
#341 alter user that first/last name are required

### DIFF
--- a/ccm_web/client/src/components/UserEnrollmentForm.tsx
+++ b/ccm_web/client/src/components/UserEnrollmentForm.tsx
@@ -138,7 +138,7 @@ export default function UserEnrollmentForm (props: UserEnrollmentFormProps): JSX
     if (
       userExists === undefined ||
       role === undefined ||
-      selectedSection === undefined
+      selectedSection === undefined || firstName === undefined || lastName === undefined
     ) {
       return setShowIncompleteAlerts(true)
     }
@@ -215,6 +215,10 @@ export default function UserEnrollmentForm (props: UserEnrollmentFormProps): JSX
 
   const nameInput = (
     <>
+    {
+        showIncompleteAlerts && (firstName === undefined || lastName === undefined) &&
+          <InlineErrorAlert>You must fill in firstname or lastName.</InlineErrorAlert>
+    }
     <Typography className={classes.spacing} gutterBottom>
       The email you entered is not associated with an account in Canvas.
       Please provide a first and last name, and we will send them an email invitation


### PR DESCRIPTION
Fixes #341 

First name and last name are required by API endpoint, so I felt adding the alter saying it is required