### PR TITLE
Add `tabIndex` to `TableRow` to allow keyboard accessibility of scrollable table (#349)

### DIFF
--- a/ccm_web/client/src/components/MultipleSectionEnrollmentWorkflow.tsx
+++ b/ccm_web/client/src/components/MultipleSectionEnrollmentWorkflow.tsx
@@ -216,7 +216,7 @@ export default function MultipleSectionEnrollmentWorkflow (props: MultipleSectio
           <TableBody>
             {
               props.sections.map((s, i) => (
-                <TableRow key={i}>
+                <TableRow tabIndex={0} key={i}>
                   <TableCell>{s.name}</TableCell>
                   <TableCell>{s.id}</TableCell>
                 </TableRow>


### PR DESCRIPTION
The PR aims to resolve #349.