### PR TITLE
#358 file name change when downloading csv

### DIFF
--- a/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
+++ b/ccm_web/client/src/pages/FormatThirdPartyGradebook.tsx
@@ -389,7 +389,7 @@ export default function FormatThirdPartyGradebook (props: FormatThirdPartyGradeb
                   setActiveStep(CSVWorkflowStep.Upload)
                 }}
                 download={{
-                  fileName: createOutputFileName(file.name, '-puff'),
+                  fileName: createOutputFileName(file.name),
                   data: dataToDownload
                 }}
               />

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -114,7 +114,7 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
   // Would be nice to rework this so we know file is defined
   const getOutputFilename = (file: File | undefined): string => {
     if (file === undefined) return ''
-    return createOutputFileName(file.name, '-geff')
+    return createOutputFileName(file.name)
   }
 
   const getGradeForExport = (record: GradebookRecord): string => {

--- a/ccm_web/client/src/utils/fileUtils.ts
+++ b/ccm_web/client/src/utils/fileUtils.ts
@@ -15,7 +15,7 @@ Examples:
 */
 function createOutputFileName (oldFileName: string, newfileEnding?: string): string {
   if (newfileEnding === undefined) {
-    newfileEnding = '-formatterd'
+    newfileEnding = '-formatted'
   }
   const splitName = oldFileName.split('.')
   const filenameIndex = splitName.length >= 2 ? splitName.length - 2 : 0

--- a/ccm_web/client/src/utils/fileUtils.ts
+++ b/ccm_web/client/src/utils/fileUtils.ts
@@ -5,14 +5,18 @@ const prepDownloadDataString = (data: string): string => {
 }
 
 /*
-Takes a file name and replaces the string segment without a period
+Takes a file name and replaces the string segment(as optional) without a period
 just before the file name extension with that segment plus a new provided ending.
+the default string segment is '-formatted'
 Examples:
-  createOutputFileName('old-file-name.csv', '-puff') returns 'old-file-name-puff.csv'
-  createOutputFileName('old-file-name', '-puff') returns 'old-file-name-puff
-  createOutputFileName('old.file.name.csv', '-puff') returns 'old.file.name-puff.csv'
+  createOutputFileName('old-file-name.csv', '-new') returns 'old-file-name-new.csv'
+  createOutputFileName('old-file-name') returns 'old-file-name-formatted
+  createOutputFileName('old.file.name.csv', '-alt') returns 'old.file.name-alt.csv'
 */
-function createOutputFileName (oldFileName: string, newfileEnding: string): string {
+function createOutputFileName (oldFileName: string, newfileEnding?: string): string {
+  if (newfileEnding === undefined) {
+    newfileEnding = '-formatterd'
+  }
   const splitName = oldFileName.split('.')
   const filenameIndex = splitName.length >= 2 ? splitName.length - 2 : 0
   splitName[filenameIndex] = splitName[filenameIndex] + newfileEnding

--- a/ccm_web/client/src/utils/fileUtils.ts
+++ b/ccm_web/client/src/utils/fileUtils.ts
@@ -5,9 +5,9 @@ const prepDownloadDataString = (data: string): string => {
 }
 
 /*
-Takes a file name and replaces the string segment(as optional) without a period
-just before the file name extension with that segment plus a new provided ending.
-the default string segment is '-formatted'
+Takes a file name and replaces the string segment without a period
+just before the file name extension with that segment plus a new ending
+(which can be optionally provided). The default new ending is '-formatted'.
 Examples:
   createOutputFileName('old-file-name.csv', '-new') returns 'old-file-name-new.csv'
   createOutputFileName('old-file-name') returns 'old-file-name-formatted


### PR DESCRIPTION
Fixes #358 

This affects both Gradebook tools, not just 3rd-party gradebook