### PR TITLE
Extract core setup to provide basic fix to end-to-end test (#237)

### DIFF
--- a/ccm_web/server/src/config.ts
+++ b/ccm_web/server/src/config.ts
@@ -2,7 +2,7 @@ import baseLogger from './logger'
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
-interface ServerConfig {
+export interface ServerConfig {
   isDev: boolean
   port: number
   domain: string


### PR DESCRIPTION
This PR moves the core setting up of middleware and options (needed by both the main process and testing processes) into a separate function, which is then called in both `main.ts` and `app.e2e-spec.ts`. The PR aims to resolve #237.

Reminder of testing instructions:
1) Start up application using `docker compose up`
2) Enter running container: `docker exec -it ccm-web /bin/bash`
3) Run end-to-end test: `npm run test:e2e`