### PR TITLE
Add one second delay after redirect; fix spacing in AuthorizePrompt

### DIFF
--- a/ccm_web/client/src/components/AuthorizePrompt.tsx
+++ b/ccm_web/client/src/components/AuthorizePrompt.tsx
@@ -5,7 +5,6 @@ import Help from './Help'
 
 const useStyles = makeStyles(() => ({
   root: {
-    padding: 25,
     textAlign: 'left'
   },
   button: {

--- a/ccm_web/client/src/utils/handleErrors.ts
+++ b/ccm_web/client/src/utils/handleErrors.ts
@@ -140,7 +140,10 @@ const handleErrors = async (resp: Response): Promise<void> => {
     case 400:
       throw new BadRequestError(apiErrorMessage)
     case 401:
-      if (errorBody.redirect === true) redirect('/')
+      if (errorBody.redirect === true) {
+        redirect('/')
+        await new Promise(resolve => setTimeout(resolve, 1000))
+      }
       throw new UnauthorizedError()
     case 403:
       throw new ForbiddenError()


### PR DESCRIPTION
The PR aims to resolve #372.

It feels like a band-aid solution, but also low-risk. I also removed some redundant spacing in `AuthorizePrompt` I forgot about when implementing `Layout` (see #348).