### PR TITLE
Throw `InvalidTokenRefreshError` for all HTTP errors returned from Canvas OAuth refresh call (#397)

### DIFF
--- a/ccm_web/server/src/canvas/canvas.service.ts
+++ b/ccm_web/server/src/canvas/canvas.service.ts
@@ -204,13 +204,11 @@ export class CanvasService {
     } catch (error) {
       if (axios.isAxiosError(error) && error.response !== undefined) {
         const { status, data } = error.response
-        if (status === HttpStatus.BAD_REQUEST && typeof data?.error === 'string' && data.error === 'invalid_request') {
-          logger.warn('Discovered during refresh that existing token is now invalid.')
-          throw new InvalidTokenRefreshError()
-        } else {
-          logger.error(`Received unusual status code ${error.response.status}`)
-          logger.error(`Response body: ${JSON.stringify(error.response.data, null, 2)}`)
-        }
+        logger.warn(
+          `Error occurred during refresh. Status code: ${status}; response body: ${JSON.stringify(data, null, 2)}`
+        )
+        logger.warn('Existing token is now likely invalid.')
+        throw new InvalidTokenRefreshError()
       } else {
         logger.error(
           `Error occurred while making request to Canvas for access token: ${JSON.stringify(error, null, 2)}`


### PR DESCRIPTION
The PR aims to resolve #397.