### PR TITLE
402: properly cast string course_id to number for global variable

### DIFF
--- a/ccm_web/server/src/lti/lti.service.ts
+++ b/ccm_web/server/src/lti/lti.service.ts
@@ -64,7 +64,7 @@ export class LTIService implements BeforeApplicationShutdown {
         return createLaunchErrorResponse(res, 'please check the LTI configuration in Canvas.')
       }
       const loginId = customLTIVariables.login_id as string
-      const courseId = customLTIVariables.course_id as number
+      const courseId = customLTIVariables.course_id as string
       const roles = customLTIVariables.roles as string
       const isRootAdmin = customLTIVariables.is_root_account_admin as boolean
 
@@ -96,7 +96,7 @@ export class LTIService implements BeforeApplicationShutdown {
       }
       // More data will be added to the session here later
       const course = {
-        id: courseId,
+        id: Number(courseId),
         roles: (roles.length > 0) ? roles.split(',') : [] // role won't be empty but adding a validation for safety
       }
       const sessionData = {

--- a/ccm_web/server/src/lti/lti.service.ts
+++ b/ccm_web/server/src/lti/lti.service.ts
@@ -94,7 +94,7 @@ export class LTIService implements BeforeApplicationShutdown {
         logger.error(`Something went wrong while creating user with loginId ${loginId}: ${logMessageEnding}`)
         return createLaunchErrorResponse(res)
       }
-    
+
       try {
         // More data will be added to the session here later
         const course = {
@@ -113,7 +113,7 @@ export class LTIService implements BeforeApplicationShutdown {
         logger.error(`Failed to build session data with course ID ${courseId} and roles ${roles}: ${logMessageEnding}`)
         return createLaunchErrorResponse(res)
       }
-      
+
       req.session.save((err) => {
         if (err !== null) {
           logger.error('Failed to save session data due to error: ', err)


### PR DESCRIPTION
Consume course_id from canvas Id token as a string, then cast as a number for the globals API endpoint response