### PR TITLE
434: put loading spinner backdrop inside enrollment section accordion

### DIFF
--- a/ccm_web/client/src/components/MultipleSectionEnrollmentWorkflow.tsx
+++ b/ccm_web/client/src/components/MultipleSectionEnrollmentWorkflow.tsx
@@ -270,14 +270,16 @@ export default function MultipleSectionEnrollmentWorkflow (props: MultipleSectio
             <Link href={sectionDataToDownload} download='course_section_ids.csv'>
               Download a CSV with the Canvas Course Section IDs data
             </Link>
-            <Accordion title='Course Section Canvas IDs' id='section-ids'>{sectionIdsTable}</Accordion>
+            <Accordion title='Course Section Canvas IDs' id='section-ids'>
+              <Backdrop className={classes.backdrop} open={props.isGetSectionsLoading}>
+                <Grid container>
+                  <Grid item xs={12}><CircularProgress color='inherit' /></Grid>
+                  <Grid item xs={12}>Loading section data from Canvas</Grid>
+                </Grid>
+              </Backdrop>
+              {sectionIdsTable}
+          </Accordion>
           </Grid>
-          <Backdrop className={classes.backdrop} open={props.isGetSectionsLoading}>
-            <Grid container>
-              <Grid item xs={12}><CircularProgress color='inherit' /></Grid>
-              <Grid item xs={12}>Loading section data from Canvas</Grid>
-            </Grid>
-          </Backdrop>
         </Grid>
         <FileUpload onUploadComplete={handleFile} />
         <div className={classes.buttonGroup}>


### PR DESCRIPTION
Fixes #434 

I made this change thinking that cleaning up this loading screen was a requirement for another task. Seeing that it introduces a new design decision, I split it out into this PR.

Old loading backdrop
 <img width="1309" alt="Screenshot 2024-04-18 at 4 58 43 PM" src="https://github.com/tl-its-umich-edu/canvas-course-manager-next/assets/147423601/598992ae-6ff5-4a50-8d7e-adc47039fc29">

 Proposed new loading backdrop
<img width="1309" alt="Screenshot 2024-04-18 at 4 58 17 PM" src="https://github.com/tl-its-umich-edu/canvas-course-manager-next/assets/147423601/d2ba6159-9a8f-4ca5-9d2e-a884a748711d">
