### PR TITLE
#437 dynamic year for copyright and update latest bootstrap version

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-sm">
         <h5><img src={{ "/assets/images/um-logo.png" | relative_url }} alt="UM logo" class="mb-1" width="105" height="114"></h5>
-        <small class="copy-rights cursor-pointer">&#9400; 2022 The Regents of the University of Michigan</small>
+        <small class="copy-rights cursor-pointer">&#9400; {{ "now" | date: "%Y" }} The Regents of the University of Michigan</small>
       </div>
       <div class="col-sm">
         <ul class="list-unstyled">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
    <!-- Bootstrap CSS -->
-   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <!-- Custom styles for this template -->
   <link type="text/css"  href={{ "/assets/css/custom.css" | relative_url }} rel="stylesheet">
 </head>
@@ -30,7 +30,7 @@
   </main>
   {% include footer.html %}
     
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 </body>
 
 </html>

--- a/docs/docker-compose-gh-pages.yml
+++ b/docs/docker-compose-gh-pages.yml
@@ -2,8 +2,8 @@ version: '3.8'
 
 services:
   jekyll:
-    image: jekyll/jekyll:latest
-    command: jekyll serve --port 4020 --watch --force_polling --verbose
+    image: jekyll/jekyll:4.2.0
+    command: jekyll serve --trace --port 4020 --watch --force_polling --verbose
     ports:
       - 4020:4020
     volumes:


### PR DESCRIPTION
Fixes #437

1. Upgrade to [Boostrap v5.3.3](https://getbootstrap.com/docs/5.3/getting-started/download/)
2. [year in the copyright at footer is dynamic now](https://shopify.github.io/liquid/filters/date/)
3. I am tagging jekyll docker image to run locally to v4.2.0 since latest version has some issue. [Until this issue](https://github.com/envygeeks/jekyll-docker/pull/347) is merged we cannot point to latest 


Latest changes from this branch are here if don't want to run locally: https://pushyamig.github.io/canvas-course-manager-next/gradebook-thirdparty.html

How to update CCM documentation: https://github.com/tl-its-umich-edu/canvas-course-manager-next/blob/main/README.md#ccm-documentation

**I am going to keep this issue as draft since a commit to main will lead to update in Prod** 