### PR TITLE
427: fix section selection styling by refactoring ListItem Button

### DIFF
--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -54,8 +54,7 @@ const classes = {
   sectionSelectionContainer: `${PREFIX}-sectionSelectionContainer`,
   backdrop: `${PREFIX}-backdrop`,
   highlighted: `${PREFIX}-highlighted`,
-  button: `${PREFIX}-button`,
-  unmergeWrapper: `${PREFIX}-unmergeWrapper`
+  button: `${PREFIX}-button`
 }
 
 // TODO jss-to-styled codemod: The Fragment root was replaced by div. Change the tag if needed.
@@ -178,12 +177,6 @@ const Root = styled('div')((
   [`& .${classes.button}`]: {
     margin: theme.spacing(1),
     marginLeft: '24px',
-  },
-
-  [`& .${classes.unmergeWrapper}`]: {
-    position: 'absolute',
-    right: '0',
-    padding: 'inherit'
   }
 }))
 
@@ -398,20 +391,18 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   const unmergeButton = (section: SelectableCanvasCourseSection): JSX.Element | undefined => {
     if (section.nonxlist_course_id !== null && props.canUnmerge && (section.locked ?? false)) {
       return (
-        <Box component="div" className={classes.unmergeWrapper}>
-          <Button
-            sx={{ pointerEvents: 'auto'}}
-            color='primary'
-            variant='contained'
-            disabled={isUnmerging}
-            onClick={async (e) => {
-              e.stopPropagation()
-              await doUnmerge([section])
-            }}
-          >
-            Unmerge
-          </Button>
-        </Box>
+        <Button
+          sx={{ pointerEvents: 'auto', marginTop: '8px'}}
+          color='primary'
+          variant='contained'
+          disabled={isUnmerging}
+          onClick={async (e) => {
+            e.stopPropagation()
+            await doUnmerge([section])
+          }}
+        >
+          Unmerge
+        </Button>
       )
     }
   }
@@ -431,8 +422,10 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
                 </Typography>
               )
             }
-            <Box component="span" sx={props.showCourseName === true ? { display: 'block', textAlign: 'right', mt: 0.5 } : undefined}>
-              {`${section.total_students ?? '?'} students`}
+            
+            <Box component="span" sx={props.showCourseName === true ? { display:'flex', justifyContent:'space-between', alignItems:'center'} : undefined}>
+              <Box component="span">{unmergeButton(section)}</Box>
+              <Box component="span">{`${section.total_students ?? '?'} students`}</Box>
             </Box>
           </React.Fragment>
         }>
@@ -611,7 +604,6 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
                 root: `${classes.listItemRoot} ${classes.listButton}`,
                 focusVisible: classes.listButtonFocusVisible
               }}>
-                {unmergeButton(section)}
                 {listItemText(section)}
               </ListItemButton>
             )

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -603,7 +603,8 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
               classes={{
                 root: `${classes.listItemRoot} ${classes.listButton}`,
                 focusVisible: classes.listButtonFocusVisible
-              }}>
+              }}
+              className={(section.locked !== true && props.highlightUnlocked === true) ? classes.highlighted : undefined}>
                 {listItemText(section)}
               </ListItemButton>
             )

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -608,13 +608,13 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
               </ListItemButton>
             )
           })}
-          <Backdrop className={classes.backdrop} open={isSearching || isIniting || isUnmerging}>
+      </List> 
+      <Backdrop className={classes.backdrop} open={isSearching || isIniting || isUnmerging}>
           <Grid container>
             <Grid item xs={12}><CircularProgress color='inherit' /></Grid>
             <Grid item xs={12}>{isSearching || isIniting ? 'Searching...' : 'Unmerging...'}</Grid>
           </Grid>
-        </Backdrop>
-      </List>    
+        </Backdrop>   
       </Grid>
     </Grid>
     </Root>

--- a/ccm_web/client/src/components/SectionSelectorWidget.tsx
+++ b/ccm_web/client/src/components/SectionSelectorWidget.tsx
@@ -3,8 +3,8 @@ import { styled } from '@mui/material/styles'
 import { useSnackbar } from 'notistack'
 import {
   Backdrop,
+  Box,
   Button,
-  ButtonBase,
   Checkbox,
   CircularProgress,
   FormControl,
@@ -14,7 +14,7 @@ import {
   GridSize,
   InputLabel,
   List,
-  ListItem,
+  ListItemButton,
   ListItemText,
   Menu,
   MenuItem,
@@ -54,7 +54,8 @@ const classes = {
   sectionSelectionContainer: `${PREFIX}-sectionSelectionContainer`,
   backdrop: `${PREFIX}-backdrop`,
   highlighted: `${PREFIX}-highlighted`,
-  button: `${PREFIX}-button`
+  button: `${PREFIX}-button`,
+  unmergeWrapper: `${PREFIX}-unmergeWrapper`
 }
 
 // TODO jss-to-styled codemod: The Fragment root was replaced by div. Change the tag if needed.
@@ -74,11 +75,6 @@ const Root = styled('div')((
       '& > .MuiListItemText-root': {
         '& > :not(.MuiListItemText-secondary)': {
           opacity: theme.palette.action.disabledOpacity
-        },
-        '& .MuiListItemText-secondary': {
-          '& > Button': {
-            pointerEvents: 'auto'
-          }
         }
       }
     }
@@ -181,7 +177,13 @@ const Root = styled('div')((
 
   [`& .${classes.button}`]: {
     margin: theme.spacing(1),
-    marginLeft: '24px'
+    marginLeft: '24px',
+  },
+
+  [`& .${classes.unmergeWrapper}`]: {
+    position: 'absolute',
+    right: '0',
+    padding: 'inherit'
   }
 }))
 
@@ -396,18 +398,20 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
   const unmergeButton = (section: SelectableCanvasCourseSection): JSX.Element | undefined => {
     if (section.nonxlist_course_id !== null && props.canUnmerge && (section.locked ?? false)) {
       return (
-        <Button
-          className={classes.button}
-          color='primary'
-          variant='contained'
-          disabled={isUnmerging}
-          onClick={async (e) => {
-            e.stopPropagation()
-            await doUnmerge([section])
-          }}
-        >
-          Unmerge
-        </Button>
+        <Box component="div" className={classes.unmergeWrapper}>
+          <Button
+            sx={{ pointerEvents: 'auto'}}
+            color='primary'
+            variant='contained'
+            disabled={isUnmerging}
+            onClick={async (e) => {
+              e.stopPropagation()
+              await doUnmerge([section])
+            }}
+          >
+            Unmerge
+          </Button>
+        </Box>
       )
     }
   }
@@ -427,9 +431,9 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
                 </Typography>
               )
             }
-            <span style={props.showCourseName === true ? { float: 'right' } : undefined}>
+            <Box component="span" sx={props.showCourseName === true ? { display: 'block', textAlign: 'right', mt: 0.5 } : undefined}>
               {`${section.total_students ?? '?'} students`}
-            </span>
+            </Box>
           </React.Fragment>
         }>
       </ListItemText>
@@ -596,33 +600,29 @@ function SectionSelectorWidget (props: ISectionSelectorWidgetProps): JSX.Element
           {internalSections.map((section) => {
             const isSelected = isSectionSelected(section.id)
             return (
-              <ListItem
-                key={section.id}
-                divider
-                disableGutters
-                classes={{ root: classes.listItemRoot }}
-                secondaryAction={unmergeButton(section)}
-                className={(section.locked !== true && props.highlightUnlocked === true) ? classes.highlighted : undefined}
-              >
-                <ButtonBase
-                  className={classes.listButton}
-                  onClick={() => handleListItemClick(section.id)}
-                  disabled={section.locked}
-                  aria-pressed={isSelected}
-                  focusVisibleClassName={classes.listButtonFocusVisible}
-                >
-                  {listItemText(section)}
-                </ButtonBase>
-              </ListItem>
+              <ListItemButton
+              key={section.id}
+              divider
+              disableGutters
+              onClick={() => handleListItemClick(section.id)}
+              selected={isSelected}
+              disabled={section.locked}
+              classes={{
+                root: `${classes.listItemRoot} ${classes.listButton}`,
+                focusVisible: classes.listButtonFocusVisible
+              }}>
+                {unmergeButton(section)}
+                {listItemText(section)}
+              </ListItemButton>
             )
           })}
-        </List>
-        <Backdrop className={classes.backdrop} open={isSearching || isIniting || isUnmerging}>
+          <Backdrop className={classes.backdrop} open={isSearching || isIniting || isUnmerging}>
           <Grid container>
             <Grid item xs={12}><CircularProgress color='inherit' /></Grid>
             <Grid item xs={12}>{isSearching || isIniting ? 'Searching...' : 'Unmerging...'}</Grid>
           </Grid>
         </Backdrop>
+      </List>    
       </Grid>
     </Grid>
     </Root>


### PR DESCRIPTION
Fixes #427 

Fix section selection styling by refactoring ListItem button. ~~In trying to fix styling bugs on Merge Section page, I moved unmerge button to an alternate position.~~ Merge section styling is updated to retain old layout