### PR TITLE
496: add privacy link for google analytics

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -221,6 +221,7 @@ RANDOM_PASSWORD_DEFAULT_LENGTH = os.getenv('RANDOM_PASSWORD_DEFAULT_LENGTH', 32)
 # Google Analytics
 GOOGLE_ANALYTICS_ID = os.getenv('GOOGLE_ANALYTICS_ID', None)
 ONE_TRUST_DOMAIN = os.getenv('ONE_TRUST_DOMAIN', None)
+PRIVACY_URL = os.getenv('PRIVACY_URL', None)
 
 HELP_URL = os.getenv('HELP_URL', 'https://ccm.tl-pages.tl.it.umich.edu')
 

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -27,4 +27,5 @@ urlpatterns = [
     path(".well-known/jwks.json", jwks, name="jwks"),
     path("init/<uuid:registration_uuid>/", OIDCLoginInitView.as_view(), name="init"),
     path("ltilaunch", CCMLTILaunchView.as_view(), name="ltilaunch"),
+    path('privacy/', views.privacy_view, name="privacy"),
 ]

--- a/backend/views.py
+++ b/backend/views.py
@@ -1,8 +1,13 @@
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
+from backend import settings
 
 # Create your views here.
 @login_required
 def home_view(request: HttpRequest) -> HttpResponse:
     return render(request, 'home.html')
+
+# For /privacy/ requested by U-M OneTrust Privacy Banner
+def privacy_view(request: HttpRequest) -> HttpResponse:
+    return redirect(settings.PRIVACY_URL)

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -34,6 +34,9 @@ HELP_URL=https://ccm.tl-pages.tl.it.umich.edu
 GOOGLE_ANALYTICS_ID=
 # OneTrust domain for cookie consent
 ONE_TRUST_DOMAIN=
+# "Privacy Policy" link in OneTrust banner
+PRIVACY_URL=https://umich.edu/about/privacy/
+
 CANVAS_INSTANCE_URL=https://canvas-test.it.umich.edu
 
 # Redis settings


### PR DESCRIPTION
This is used by the script for the onetrust banner that appears for analytics tracking. Adds PRIVACY_URL into environment variables and redirect the <URL>/privacy/ link to the U-M privacy policy resource.

Testing plan:
1. update env with the new PRIVACY_URL value
2. After starting your local instance, paste the ngrok or loophole URL into the browser and add /privacy/ to the end of it. 
3. submitting should redirect the page to the https://umich.edu/about/privacy/

If you'd like to do a more comprehensive test in an LTI in canvas, this response can be tested by using a VPN to target a EU country. This will result in the banner appearing, where you can select the "Privacy Policy" link and get directed to the page. 

