### PR TITLE
fixes #485: add Watchman monitoring url

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -45,7 +45,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'webpack_loader',
-    "lti_tool"
+    "lti_tool",
+    'watchman',
 ]
 
 MIDDLEWARE = [
@@ -193,6 +194,10 @@ LOGGING = {
         'canvas_oauth': {
             'handlers': ['console'],
             'level': 'WARN'
+        },
+        'watchman': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
         }
     }
 }
@@ -229,3 +234,8 @@ HELP_URL = os.getenv('HELP_URL', 'https://ccm.tl-pages.tl.it.umich.edu')
 CANVAS_INSTANCE_URL = os.getenv('CANVAS_INSTANCE_URL', 'https://canvas.instructure.com')
 
 DEBUGPY_ENABLE = os.getenv('DEBUGPY_ENABLE', False)
+
+# Watchman settings (https://github.com/mwarkentin/django-watchman)
+WATCHMAN_TOKENS = os.getenv('DJANGO_WATCHMAN_TOKENS', None)
+WATCHMAN_TOKEN_NAME = os.getenv('DJANGO_WATCHMAN_TOKEN_NAME', 'ccm-watchman-token')
+WATCHMAN_CHECKS = ('watchman.checks.caches', 'watchman.checks.databases')

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -201,7 +201,7 @@ LOGGING = {
         },
         'watchman': {
             'handlers': ['console'],
-            'level': 'DEBUG',
+            'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
         }
     }
 }

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -18,6 +18,7 @@ from django.contrib import admin
 from django.urls import include, path
 from lti_tool.views import jwks, OIDCLoginInitView
 from backend.ccm.lti_config import CCMLTILaunchView
+import watchman.views
 
 from backend import views
 
@@ -29,6 +30,7 @@ urlpatterns = [
     path("ltilaunch", CCMLTILaunchView.as_view(), name="ltilaunch"),
     path('privacy/', views.privacy_view, name="privacy"),
     path('watchman/', include('watchman.urls')),
+    path('watchman/bare_status/', watchman.views.bare_status),
     path('oauth/', include('canvas_oauth.urls')),
     path('redirectOAuth', views.redirect_oauth_view, name='redirect_oauth_view'),
 ]

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from lti_tool.views import jwks, OIDCLoginInitView
 from backend.ccm.lti_config import CCMLTILaunchView
 
@@ -28,4 +28,5 @@ urlpatterns = [
     path("init/<uuid:registration_uuid>/", OIDCLoginInitView.as_view(), name="init"),
     path("ltilaunch", CCMLTILaunchView.as_view(), name="ltilaunch"),
     path('privacy/', views.privacy_view, name="privacy"),
+    path('watchman/', include('watchman.urls')),
 ]

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -41,3 +41,8 @@ CANVAS_INSTANCE_URL=https://canvas-test.it.umich.edu
 
 # Redis settings
 REDIS_LOCATION=redis://ccm_redis:6379
+
+# (optional) The token for accessing the /status URL; leaving it undefined means the route is unprotected
+# DJANGO_WATCHMAN_TOKENS=
+# (optional) The name of the header or parameter used for passing the above token
+# DJANGO_WATCHMAN_TOKEN_NAME=ccm-watchman-token

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ debugpy==1.8.11 # For debugging
 
 whitenoise==6.8.2 # For serving static files
 redis==5.2.1 # For caching
+
+django-watchman==1.3 # For status monitoring


### PR DESCRIPTION
test plan: check to see if the monitoring endpoint is available using your local ngrok or loophole URL at <URL>/watchman/

The requested resource should be a report and response on the status of database, cache, etc.
