### PR TITLE
Issue 476 create section

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "eslint.options":  {
         "configFile": "./ccm_web/.eslintrc.js"
-    }
+    },
+    // "python.analysis.typeCheckingMode": "basic"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "eslint.options":  {
         "configFile": "./ccm_web/.eslintrc.js"
-    },
-    // "python.analysis.typeCheckingMode": "basic"
+    }
 }

--- a/backend/ccm/canvas_api/canvas_credential_manager.py
+++ b/backend/ccm/canvas_api/canvas_credential_manager.py
@@ -28,8 +28,9 @@ class CanvasCredentialManager:
   
   def handle_serializer_errors(self, serializer_errors: dict, input: str) -> CanvasHTTPError:
       logger.error(f"Serializer error: {serializer_errors} occured during the API call.")
-      # err_response: CanvasHTTPError = CanvasHTTPError(SerializerError(failed_input=str(input), serializer_error=serializer_errors))
-      err_response: CanvasHTTPError = CanvasHTTPError({'failed_input':str(input), 'serializer_error':serializer_errors})
+      # Create a SerializerError instance and pass it to CanvasHTTPError
+      serializer_error_instance = SerializerError(failed_input=str(input), serializer_error=serializer_errors)
+      err_response: CanvasHTTPError = CanvasHTTPError(serializer_error_instance)
       return err_response
   
   def handle_canvas_api_exceptions(self, exceptions: Union[HTTPAPIError, List[HTTPAPIError]]) -> CanvasHTTPError:

--- a/backend/ccm/canvas_api/canvas_credential_manager.py
+++ b/backend/ccm/canvas_api/canvas_credential_manager.py
@@ -1,63 +1,44 @@
 import logging
-from http import HTTPStatus
+from typing import List, Union
 from django.conf import settings
 from canvas_oauth.oauth import get_oauth_token
 from rest_framework.request import Request
-from canvas_oauth.models import CanvasOAuth2Token
 from canvas_oauth.exceptions import InvalidOAuthReturnError
 
 from canvasapi import Canvas
-from canvasapi.exceptions import (
-    BadRequest, Conflict, Forbidden, InvalidAccessToken, RateLimitExceeded,
-    ResourceDoesNotExist, Unauthorized, UnprocessableEntity
-)
-from .exceptions import CanvasHTTPError 
+from canvasapi.exceptions import (InvalidAccessToken, Unauthorized)
+from .exceptions import CanvasAccessTokenException, CanvasHTTPError, HTTPAPIError, SerializerError 
 
 logger = logging.getLogger(__name__)
 
 class CanvasCredentialManager:
-  
-  # Map of Canvas API exceptions to HTTP status codes
-  EXCEPTION_STATUS_MAP = {
-    BadRequest: HTTPStatus.BAD_REQUEST.value,
-    InvalidAccessToken: HTTPStatus.UNAUTHORIZED.value,
-    Unauthorized: HTTPStatus.UNAUTHORIZED.value,
-    Forbidden: HTTPStatus.FORBIDDEN.value,
-    RateLimitExceeded: HTTPStatus.FORBIDDEN.value,
-    ResourceDoesNotExist: HTTPStatus.NOT_FOUND.value,
-    UnprocessableEntity: HTTPStatus.UNPROCESSABLE_ENTITY.value,
-    Conflict: HTTPStatus.CONFLICT.value,
-    InvalidOAuthReturnError: HTTPStatus.FORBIDDEN.value
-}
 
   def __init__(self):
     super().__init__()
     self.canvasURL = f"https://{settings.CANVAS_OAUTH_CANVAS_DOMAIN}"
   
-  def get_canvasapi_instance(self, request: HTTPStatus) -> Canvas:
+  def get_canvasapi_instance(self, request: Request) -> Canvas:
     try:
       access_token = get_oauth_token(request)
     except InvalidOAuthReturnError as e:
       # This issue occurred during non-prod Canvas sync when the API key was deleted, but the token remained in CCM databases. Expired token will trigger the usecase.
       logger.error(f"InvalidOAuthReturnError for user: {request.user}. Remove invalid refresh_token and prompt for reauthentication.")
-      raise InvalidOAuthReturnError(str(e))
+      raise CanvasAccessTokenException()
     return Canvas(self.canvasURL, access_token)
   
-  def handle_canvas_api_exception(self, exception: Exception, request: Request, input: str = None) -> CanvasHTTPError:
-    logger.error(f"API error occcured : {exception}")
-    self.handle_revoked_token(exception, request)
-    
-    for class_key in self.EXCEPTION_STATUS_MAP:
-        if isinstance(exception, class_key):
-            return CanvasHTTPError(str(exception), self.EXCEPTION_STATUS_MAP[class_key], input)
-    return CanvasHTTPError(str(exception), HTTPStatus.INTERNAL_SERVER_ERROR.value, input)
-
-  def handle_revoked_token(self, exception, request):
-      if isinstance(exception, (InvalidAccessToken, InvalidOAuthReturnError)):
-          CanvasOAuth2Token.objects.filter(user=request.user).delete()
-          logger.error(f"Deleted the Canvas OAuth2 token for user: {request.user} since they might have revoked access.")
-  
-  def handle_serializer_errors(self, serializer_errors: dict, input: str = None) -> CanvasHTTPError:
+  def handle_serializer_errors(self, serializer_errors: dict, input: str) -> CanvasHTTPError:
       logger.error(f"Serializer error: {serializer_errors} occured during the API call.")
-      err_response: CanvasHTTPError = CanvasHTTPError(serializer_errors, HTTPStatus.INTERNAL_SERVER_ERROR.value, str(input))
+      err_response: CanvasHTTPError = CanvasHTTPError(SerializerError(failed_input=str(input), serializer_error=serializer_errors))
       return err_response
+  
+  def handle_canvas_api_exceptions(self, exceptions: Union[HTTPAPIError, List[HTTPAPIError]]) -> CanvasHTTPError:
+    logger.error(f"API error occurred: {exceptions}")
+    exceptions = exceptions if isinstance(exceptions, list) else [exceptions]
+    error_exceptions = [entry["error"] for entry in exceptions]
+    
+    if any(isinstance(exc, (InvalidAccessToken, Unauthorized)) for exc in error_exceptions):
+      # Invalid access token occures when a user revokes Canvas Authorization from Canvas Profile settings.
+      # Unauthorized happens when you add more API scopes but the User Authorization is still limited to eariler API scopes.
+      raise CanvasAccessTokenException()
+    
+    return CanvasHTTPError(exceptions)

--- a/backend/ccm/canvas_api/canvas_credential_manager.py
+++ b/backend/ccm/canvas_api/canvas_credential_manager.py
@@ -1,13 +1,11 @@
 import logging
-from typing import List, Union
 from django.conf import settings
 from canvas_oauth.oauth import get_oauth_token
 from rest_framework.request import Request
 from canvas_oauth.exceptions import InvalidOAuthReturnError
 
 from canvasapi import Canvas
-from canvasapi.exceptions import (InvalidAccessToken, Unauthorized)
-from .exceptions import CanvasAccessTokenException, CanvasHTTPError, HTTPAPIError, SerializerError 
+from .exceptions import CanvasAccessTokenException 
 
 logger = logging.getLogger(__name__)
 
@@ -26,21 +24,21 @@ class CanvasCredentialManager:
       raise CanvasAccessTokenException()
     return Canvas(self.canvasURL, access_token)
   
-  def handle_serializer_errors(self, serializer_errors: dict, input: str) -> CanvasHTTPError:
-      logger.error(f"Serializer error: {serializer_errors} occured during the API call.")
-      # Create a SerializerError instance and pass it to CanvasHTTPError
-      serializer_error_instance = SerializerError(failed_input=str(input), serializer_error=serializer_errors)
-      err_response: CanvasHTTPError = CanvasHTTPError(serializer_error_instance)
-      return err_response
+  # def handle_serializer_errors(self, serializer_errors: dict, input: str) -> CanvasHTTPError:
+  #     logger.error(f"Serializer error: {serializer_errors} occured during the API call.")
+  #     # Create a SerializerError instance and pass it to CanvasHTTPError
+  #     serializer_error_instance = SerializerError(failed_input=str(input), serializer_error=serializer_errors)
+  #     err_response: CanvasHTTPError = CanvasHTTPError(serializer_error_instance)
+  #     return err_response
   
-  def handle_canvas_api_exceptions(self, exceptions: Union[HTTPAPIError, List[HTTPAPIError]]) -> CanvasHTTPError:
-    logger.error(f"API error occurred: {exceptions}")
-    exceptions = exceptions if isinstance(exceptions, list) else [exceptions]
+  # def handle_canvas_api_exceptions(self, exceptions: Union[HTTPAPIError, List[HTTPAPIError]]) -> CanvasHTTPError:
+  #   logger.error(f"API error occurred: {exceptions}")
+  #   exceptions = exceptions if isinstance(exceptions, list) else [exceptions]
     
-    # Check for token-related errors
-    if any(isinstance(exc.original_exception, (InvalidAccessToken, Unauthorized)) for exc in exceptions):
-        # Invalid access token occurs when a user revokes Canvas Authorization from Canvas Profile settings.
-        # Unauthorized happens when you add more API scopes but the User Authorization is still limited to earlier API scopes.
-        raise CanvasAccessTokenException()
+  #   # Check for token-related errors
+  #   if any(isinstance(exc.original_exception, (InvalidAccessToken, Unauthorized)) for exc in exceptions):
+  #       # Invalid access token occurs when a user revokes Canvas Authorization from Canvas Profile settings.
+  #       # Unauthorized happens when you add more API scopes but the User Authorization is still limited to earlier API scopes.
+  #       raise CanvasAccessTokenException()
     
-    return CanvasHTTPError(exceptions)
+  #   return CanvasHTTPError(exceptions)

--- a/backend/ccm/canvas_api/canvas_credential_manager.py
+++ b/backend/ccm/canvas_api/canvas_credential_manager.py
@@ -24,21 +24,4 @@ class CanvasCredentialManager:
       raise CanvasAccessTokenException()
     return Canvas(self.canvasURL, access_token)
   
-  # def handle_serializer_errors(self, serializer_errors: dict, input: str) -> CanvasHTTPError:
-  #     logger.error(f"Serializer error: {serializer_errors} occured during the API call.")
-  #     # Create a SerializerError instance and pass it to CanvasHTTPError
-  #     serializer_error_instance = SerializerError(failed_input=str(input), serializer_error=serializer_errors)
-  #     err_response: CanvasHTTPError = CanvasHTTPError(serializer_error_instance)
-  #     return err_response
   
-  # def handle_canvas_api_exceptions(self, exceptions: Union[HTTPAPIError, List[HTTPAPIError]]) -> CanvasHTTPError:
-  #   logger.error(f"API error occurred: {exceptions}")
-  #   exceptions = exceptions if isinstance(exceptions, list) else [exceptions]
-    
-  #   # Check for token-related errors
-  #   if any(isinstance(exc.original_exception, (InvalidAccessToken, Unauthorized)) for exc in exceptions):
-  #       # Invalid access token occurs when a user revokes Canvas Authorization from Canvas Profile settings.
-  #       # Unauthorized happens when you add more API scopes but the User Authorization is still limited to earlier API scopes.
-  #       raise CanvasAccessTokenException()
-    
-  #   return CanvasHTTPError(exceptions)

--- a/backend/ccm/canvas_api/canvas_credential_manager.py
+++ b/backend/ccm/canvas_api/canvas_credential_manager.py
@@ -28,7 +28,8 @@ class CanvasCredentialManager:
   
   def handle_serializer_errors(self, serializer_errors: dict, input: str) -> CanvasHTTPError:
       logger.error(f"Serializer error: {serializer_errors} occured during the API call.")
-      err_response: CanvasHTTPError = CanvasHTTPError(SerializerError(failed_input=str(input), serializer_error=serializer_errors))
+      # err_response: CanvasHTTPError = CanvasHTTPError(SerializerError(failed_input=str(input), serializer_error=serializer_errors))
+      err_response: CanvasHTTPError = CanvasHTTPError({'failed_input':str(input), 'serializer_error':serializer_errors})
       return err_response
   
   def handle_canvas_api_exceptions(self, exceptions: Union[HTTPAPIError, List[HTTPAPIError]]) -> CanvasHTTPError:

--- a/backend/ccm/canvas_api/canvas_credential_manager.py
+++ b/backend/ccm/canvas_api/canvas_credential_manager.py
@@ -36,11 +36,11 @@ class CanvasCredentialManager:
   def handle_canvas_api_exceptions(self, exceptions: Union[HTTPAPIError, List[HTTPAPIError]]) -> CanvasHTTPError:
     logger.error(f"API error occurred: {exceptions}")
     exceptions = exceptions if isinstance(exceptions, list) else [exceptions]
-    error_exceptions = [entry["error"] for entry in exceptions]
     
-    if any(isinstance(exc, (InvalidAccessToken, Unauthorized)) for exc in error_exceptions):
-      # Invalid access token occures when a user revokes Canvas Authorization from Canvas Profile settings.
-      # Unauthorized happens when you add more API scopes but the User Authorization is still limited to eariler API scopes.
-      raise CanvasAccessTokenException()
+    # Check for token-related errors
+    if any(isinstance(exc.original_exception, (InvalidAccessToken, Unauthorized)) for exc in exceptions):
+        # Invalid access token occurs when a user revokes Canvas Authorization from Canvas Profile settings.
+        # Unauthorized happens when you add more API scopes but the User Authorization is still limited to earlier API scopes.
+        raise CanvasAccessTokenException()
     
     return CanvasHTTPError(exceptions)

--- a/backend/ccm/canvas_api/canvasapi_serializer.py
+++ b/backend/ccm/canvas_api/canvasapi_serializer.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 class CourseSerializer(serializers.Serializer):
     # Define the fields you want to update. Adjust fields according to the Canvas API.
-    newName = serializers.CharField(max_length=255, required=True)
+    newNames = serializers.CharField(max_length=255, required=True)
 
 class CourseSectionSerializer(serializers.Serializer):
     sections = serializers.ListField(

--- a/backend/ccm/canvas_api/canvasapi_serializer.py
+++ b/backend/ccm/canvas_api/canvasapi_serializer.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 class CourseSerializer(serializers.Serializer):
     # Define the fields you want to update. Adjust fields according to the Canvas API.
-    newNames = serializers.CharField(max_length=255, required=True)
+    newName = serializers.CharField(max_length=255, required=True)
 
 class CourseSectionSerializer(serializers.Serializer):
     sections = serializers.ListField(

--- a/backend/ccm/canvas_api/canvasapi_serializer.py
+++ b/backend/ccm/canvas_api/canvasapi_serializer.py
@@ -20,9 +20,10 @@ class CanvasObjectROSerializer(serializers.BaseSerializer):
     Adapted from the Django REST Framework documentation:
     https://www.django-rest-framework.org/api-guide/serializers/#creating-new-base-classes
     """
-    def __init__(self, *args, allowed_fields=None, **kwargs):
-      super().__init__(*args, **kwargs)
-      self.allowed_fields = allowed_fields
+    def __init__(self, *args, allowed_fields=None, append_fields=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.allowed_fields = allowed_fields
+        self.append_fields = append_fields
 
     def convert_to_primitives(self, instance):
         data = {}
@@ -54,4 +55,11 @@ class CanvasObjectROSerializer(serializers.BaseSerializer):
         # Filter out fields not in allowed_fields
         if self.allowed_fields:
             data = {key: value for key, value in data.items() if key in self.allowed_fields}
+        
+        # Append fields from append_fields if provided
+        if self.append_fields:
+            for key, value in self.append_fields.items():
+                if key not in data:
+                    data[key] = value
+        
         return data

--- a/backend/ccm/canvas_api/canvasapi_serializer.py
+++ b/backend/ccm/canvas_api/canvasapi_serializer.py
@@ -1,9 +1,18 @@
 from rest_framework import serializers
-from canvasapi.section import Section
 
 class CourseSerializer(serializers.Serializer):
     # Define the fields you want to update. Adjust fields according to the Canvas API.
     newName = serializers.CharField(max_length=255, required=True)
+
+class CourseSectionSerializer(serializers.Serializer):
+    sections = serializers.ListField(
+        child=serializers.CharField(max_length=255, required=True)
+    )
+
+    def validate_sections(self, value):
+        if len(value) > 60:
+            raise serializers.ValidationError("The list cannot be more than 60 items.")
+        return value
 
 class CanvasObjectROSerializer(serializers.BaseSerializer):
     """

--- a/backend/ccm/canvas_api/course_api_handler.py
+++ b/backend/ccm/canvas_api/course_api_handler.py
@@ -52,7 +52,7 @@ class CanvasCourseAPIHandler(LoggingMixin, APIView):
             return Response(serializer.data, status=HTTPStatus.OK)
         
         except (CanvasException, Exception) as e:
-            err_response: CanvasHTTPError = self.credential_manager.handle_canvas_api_exceptions(HTTPAPIError(str(course_id), e).to_dict())
+            err_response: CanvasHTTPError = self.credential_manager.handle_canvas_api_exceptions(HTTPAPIError(str(course_id), e))
             return Response(err_response.to_dict(), status=err_response.to_dict().get('statusCode'))
       
     @extend_schema(
@@ -80,5 +80,5 @@ class CanvasCourseAPIHandler(LoggingMixin, APIView):
             return Response(formatted_course, status=HTTPStatus.OK)
         
         except (CanvasException, Exception) as e:
-            err_response: CanvasHTTPError = self.credential_manager.handle_canvas_api_exceptions(HTTPAPIError(str(course_id), e).to_dict())
+            err_response: CanvasHTTPError = self.credential_manager.handle_canvas_api_exceptions(HTTPAPIError(str(course_id), e))
             return Response(err_response.to_dict(), status=err_response.to_dict().get('statusCode'))

--- a/backend/ccm/canvas_api/course_api_handler.py
+++ b/backend/ccm/canvas_api/course_api_handler.py
@@ -63,6 +63,7 @@ class CanvasCourseAPIHandler(LoggingMixin, APIView):
     )
     def put(self, request: Request, course_id: int) -> Response:
         logger.info(f"Updating course name: {course_id}")
+        course_id = 223444444444444444
 
         serializer: Serializer = CourseSerializer(data=request.data)
         if not serializer.is_valid():

--- a/backend/ccm/canvas_api/course_api_handler.py
+++ b/backend/ccm/canvas_api/course_api_handler.py
@@ -63,7 +63,6 @@ class CanvasCourseAPIHandler(LoggingMixin, APIView):
     )
     def put(self, request: Request, course_id: int) -> Response:
         logger.info(f"Updating course name: {course_id}")
-        course_id = 223444444444444444
 
         serializer: Serializer = CourseSerializer(data=request.data)
         if not serializer.is_valid():
@@ -71,8 +70,8 @@ class CanvasCourseAPIHandler(LoggingMixin, APIView):
             return Response(err_response.to_dict(), status=err_response.to_dict().get('statusCode'))
         update_data = serializer.validated_data
         
+        canvas_api: Canvas = self.credential_manager.get_canvasapi_instance(request)
         try:
-            canvas_api: Canvas = self.credential_manager.get_canvasapi_instance(request)
             # Get the course instance
             course: Course = canvas_api.get_course(course_id)
             # Call the update method on the course instance

--- a/backend/ccm/canvas_api/course_api_handler.py
+++ b/backend/ccm/canvas_api/course_api_handler.py
@@ -21,8 +21,6 @@ from rest_framework_tracking.mixins import LoggingMixin
 
 logger = logging.getLogger(__name__)
 
-# CANVAS_CREDENTIALS = CanvasCredentialManager()
-
 class CanvasCourseAPIHandler(LoggingMixin, APIView):
 
     logging_methods = ['GET', 'PUT']

--- a/backend/ccm/canvas_api/course_api_handler.py
+++ b/backend/ccm/canvas_api/course_api_handler.py
@@ -75,9 +75,11 @@ class CanvasCourseAPIHandler(LoggingMixin, APIView):
             # Get the course instance
             course: Course = canvas_api.get_course(course_id)
             # Call the update method on the course instance
-            put_course_res: str= course.update(course={'name': update_data.get("newName"), 'course_code': update_data.get("newName")})
-            formatted_course = {'id': course.id, 'name': put_course_res, 'enrollment_term_id': course.enrollment_term_id }
-            return Response(formatted_course, status=HTTPStatus.OK)
+            course_name_update_res: str= course.update(course={'name': update_data.get("newName"), 'course_code': update_data.get("newName")})
+            serializer = CanvasObjectROSerializer(course, allowed_fields=self.course_allowed_fields)
+            serialized_data = serializer.data
+            serialized_data["name"] = course_name_update_res 
+            return Response(serialized_data, status=HTTPStatus.OK)
         
         except (CanvasException, Exception) as e:
             err_response: CanvasHTTPError = self.credential_manager.handle_canvas_api_exceptions(HTTPAPIError(str(course_id), e))

--- a/backend/ccm/canvas_api/course_api_handler.py
+++ b/backend/ccm/canvas_api/course_api_handler.py
@@ -78,9 +78,9 @@ class CanvasCourseAPIHandler(LoggingMixin, APIView):
             course: Course = canvas_api.get_course(course_id)
             # Call the update method on the course instance
             course_name_update_res: str= course.update(course={'name': update_data.get("newName"), 'course_code': update_data.get("newName")})
-            serializer = CanvasObjectROSerializer(course, allowed_fields=self.course_allowed_fields)
+            append_fields = {"name": course_name_update_res}
+            serializer = CanvasObjectROSerializer(course, allowed_fields=self.course_allowed_fields, append_fields=append_fields)
             serialized_data = serializer.data
-            serialized_data["name"] = course_name_update_res 
             return Response(serialized_data, status=HTTPStatus.OK)
         
         except (CanvasException, Exception) as e:

--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -26,6 +26,7 @@ class CourseSectionAPIHandler(LoggingMixin, APIView):
     authentication_classes = [authentication.SessionAuthentication]
     permission_classes = [permissions.IsAuthenticated]
     course_section_allowed_fields = {"course_id", "id", "name", "nonxlist_course_id", "total_students"}
+    serializer_class = CourseSectionSerializer  # Ensures Swagger UI recognizes it
 
     def __init__(self, credential_manager=None):
         self.credential_manager = credential_manager or CanvasCredentialManager()
@@ -82,6 +83,7 @@ class CourseSectionAPIHandler(LoggingMixin, APIView):
 
         logger.info(f"{len(success_res)}/{len(sections)} sections successfully created")
         logger.debug(f"Errors while creating the section: {err_res}")
+        
         if not err_res:
             return Response(success_res, status=HTTPStatus.CREATED)
         

--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -80,8 +80,8 @@ class CourseSectionAPIHandler(LoggingMixin, APIView):
         success_res = [result for result in results if isinstance(result, dict)]
         err_res = [res for res in results if isinstance(res, HTTPAPIError)]
 
-        logger.info(f"Success: {success_res}")
-        logger.info(f"Errors: {err_res}")
+        logger.info(f"{len(success_res)}/{len(sections)} sections successfully created")
+        logger.debug(f"Errors while creating the section: {err_res}")
         if not err_res:
             return Response(success_res, status=HTTPStatus.CREATED)
         

--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -101,9 +101,9 @@ class CourseSectionAPIHandler(LoggingMixin, APIView):
             section = canvas_api.get_course(course_id).create_course_section(course_section={"name": section_name})
             
             # Serialize the section and add total_students manually
-            serializer = CanvasObjectROSerializer(section, allowed_fields=self.course_section_allowed_fields)
+            append_fields = {"total_students": 0}  # Default value for total_students
+            serializer = CanvasObjectROSerializer(section, allowed_fields=self.course_section_allowed_fields, append_fields=append_fields)
             serialized_data = serializer.data
-            serialized_data["total_students"] = 0  # Default value for total_students
             return serialized_data
         
         except (CanvasException, Exception) as e:
@@ -114,4 +114,4 @@ class CourseSectionAPIHandler(LoggingMixin, APIView):
         try:
             return await asyncio.to_thread(self.create_section_sync, canvas_api, course_id, section_name)
         except Exception as e:
-          return e if isinstance(e, HTTPAPIError) else HTTPAPIError(section_name, e)
+            return e if isinstance(e, HTTPAPIError) else HTTPAPIError(section_name, e)

--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 import logging, asyncio, time
 from http import HTTPStatus
 from backend.ccm.canvas_api.canvasapi_serializer import CanvasObjectROSerializer, CourseSectionSerializer
@@ -6,14 +5,12 @@ from rest_framework.views import APIView
 from rest_framework import authentication, permissions
 from rest_framework.response import Response
 from rest_framework.request import Request
-from dataclasses import asdict
 
 from canvasapi.exceptions import CanvasException
 from canvasapi import Canvas
 from drf_spectacular.utils import extend_schema
 
 from .exceptions import CanvasHTTPError, HTTPAPIError
-from canvas_oauth.exceptions import InvalidOAuthReturnError
 
 from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
 
@@ -67,8 +64,6 @@ class CourseSectionAPIHandler(LoggingMixin, APIView):
             return Response(err_response.to_dict(), status=err_response.to_dict().get('statusCode'))
         
         sections: list = serializer.validated_data['sections']
-        # a = 'AlexanderMaximilianTheodoreBartholomewChristopherNathanielMontgomeryFitzgeraldBenjaminWellingtonSebastianJonathanAugustusDominicReginaldCorneliusHarrisonMaxwellNicholasFranklinFrederickEmmanuelLeopoldTheophilusAmbroseGideonValentinePeregrineBalthazarOctaviusCassiusSeraphimThaddeusArchibaldIgnatiusSylvesterAlistairDemetriusLysanderPhineasQuintilianEzekielZacharias'
-        # sections = ['u1', a, 'u3','']
         logger.info(f"Creating {sections} sections for course_id: {course_id}")
         canvas_api: Canvas = self.credential_manager.get_canvasapi_instance(request)
            
@@ -107,9 +102,8 @@ class CourseSectionAPIHandler(LoggingMixin, APIView):
             serializer = CanvasObjectROSerializer(section, allowed_fields=allowed_fields)
             serialized_data = serializer.data
             serialized_data["total_students"] = 0  # Default value for total_students
-            
-            logger.info(f"Section created: {serialized_data}")
             return serialized_data
+        
         except (CanvasException, Exception) as e:
             raise HTTPAPIError(section_name, e)
 

--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -66,14 +66,11 @@ class CourseSectionAPIHandler(LoggingMixin, APIView):
             return Response(err_response.to_dict(), status=err_response.to_dict().get('statusCode'))
         
         sections: list = serializer.validated_data['sections']
-        # a = 'AlexanderMaximilianTheodoreBartholomewChristopherNathanielMontgomeryFitzgeraldBenjaminWellingtonSebastianJonathanAugustusDominicReginaldCorneliusHarrisonMaxwellNicholasFranklinFrederickEmmanuelLeopoldTheophilusAmbroseGideonValentinePeregrineBalthazarOctaviusCassiusSeraphimThaddeusArchibaldIgnatiusSylvesterAlistairDemetriusLysanderPhineasQuintilianEzekielZacharias'
-        # sections = ['u1', a, 'u3', '']
         logger.info(f"Creating {sections} sections for course_id: {course_id}")
         canvas_api: Canvas = self.credential_manager.get_canvasapi_instance(request)
            
         start_time: float = time.perf_counter()
         results = asyncio.run(self.create_sections(canvas_api, course_id, sections))
-        logger.info(f"Sections created: {results}")
         end_time: float = time.perf_counter()
         logger.info(f"Time taken to create {len(sections)} sections: {end_time - start_time:.2f} seconds")
 

--- a/backend/ccm/canvas_api/drf_custom_exception_handler.py
+++ b/backend/ccm/canvas_api/drf_custom_exception_handler.py
@@ -1,0 +1,20 @@
+import logging
+from rest_framework.views import exception_handler
+from rest_framework.response import Response
+from canvas_oauth.models import CanvasOAuth2Token
+from http import HTTPStatus
+from .exceptions import CanvasAccessTokenException
+
+logger = logging.getLogger(__name__)
+
+# https://www.django-rest-framework.org/api-guide/exceptions/#custom-exception-handling
+def custom_exception_handler(exc, context):
+    request = context.get('request')
+    response = exception_handler(exc, context)
+    if isinstance(exc, CanvasAccessTokenException):
+        CanvasOAuth2Token.objects.filter(user=request.user).delete()
+        logger.error(f"Deleted the Canvas OAuth2 token for user: {request.user} due to invalid canvas access token.")
+        data = exc.to_dict()
+        return Response(data, status=data.get("statusCode", HTTPStatus.UNAUTHORIZED.value))
+
+    return response

--- a/backend/ccm/canvas_api/exceptions.py
+++ b/backend/ccm/canvas_api/exceptions.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from http import HTTPStatus
 from typing import List, TypedDict, Union, Dict
 from canvasapi.exceptions import (
@@ -7,12 +8,12 @@ from canvasapi.exceptions import (
 from canvas_oauth.exceptions import InvalidOAuthReturnError
 from rest_framework.exceptions import APIException
 
-
-class ErrorData(TypedDict):
+@dataclass
+class ErrorData():
     failed_input: str
     exeption: Exception
-
-class SerializerError(TypedDict):
+@dataclass
+class SerializerError():
     failed_input: str
     serializer_error: dict
     
@@ -38,7 +39,7 @@ class CanvasHTTPError():
         InvalidOAuthReturnError: HTTPStatus.FORBIDDEN.value
     }
 
-    def __init__(self, error_data: Union[List[ErrorData], Dict[str, SerializerError]]) -> None:
+    def __init__(self, error_data: Union[List[ErrorData], SerializerError]) -> None:
         self.errors = []
         if isinstance(error_data, list):
             for error in error_data:

--- a/backend/ccm/canvas_api/exceptions.py
+++ b/backend/ccm/canvas_api/exceptions.py
@@ -43,17 +43,17 @@ class CanvasHTTPError():
         self.errors = []
         if isinstance(error_data, list):
             for error in error_data:
+                # Directly handle ErrorData objects
                 self.errors.append({
                     "canvasStatusCode": self.EXCEPTION_STATUS_MAP.get(type(error['error']), HTTPStatus.INTERNAL_SERVER_ERROR.value),
                     "message": str(error['error']),
                     "failedInput": error['failed_input']
                 })
-
-        elif isinstance(error_data, dict):
+        elif isinstance(error_data, SerializerError):
             self.errors.append({
                 "canvasStatusCode": HTTPStatus.INTERNAL_SERVER_ERROR.value,
-                "message": str(error_data['serializer_error']),
-                "failedInput": error_data['failed_input']
+                "message": str(error_data.serializer_error),
+                "failedInput": error_data.failed_input
             })
 
     def __str__(self) -> str:

--- a/backend/ccm/canvas_api/exceptions.py
+++ b/backend/ccm/canvas_api/exceptions.py
@@ -44,9 +44,6 @@ class CanvasErrorHandler():
 
     def __init__(self) -> None:
         self.errors = []
-
-    def __str__(self) -> str:
-        return f'Errors: {self.errors}'
     
     def handle_serializer_errors(self, serializer_errors: dict, input: str):
       logger.error(f"Serializer error: {serializer_errors} occured during the API call.")
@@ -61,11 +58,6 @@ class CanvasErrorHandler():
         logger.error(f"API error occurred: {exceptions}")
         exceptions = exceptions if isinstance(exceptions, list) else [exceptions]
         
-        # Check for token-related errors
-        # if any(isinstance(exc.original_exception, (InvalidAccessToken, Unauthorized)) for exc in exceptions):
-        #     # Invalid access token occurs when a user revokes Canvas Authorization from Canvas Profile settings.
-        #     # Unauthorized happens when you add more API scopes but the User Authorization is still limited to earlier API scopes.
-        #     raise CanvasAccessTokenException()
         
         # Handle access token-related issues
         for exc in exceptions:

--- a/backend/ccm/canvas_api/exceptions.py
+++ b/backend/ccm/canvas_api/exceptions.py
@@ -18,9 +18,8 @@ class HTTPAPIError(Exception):
     def __init__(self, failed_input: str, original_exception: Exception):
         self.failed_input = failed_input
         self.original_exception = original_exception
-        super().__init__(f"Exception due failed input '{failed_input}': {original_exception}")
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """Returns a dictionary representation of the error."""
         return {"failed_input": self.failed_input, "error": self.original_exception}
 
@@ -61,6 +60,12 @@ class CanvasHTTPError():
                 "message": str(error_data.serializer_error),
                 "failedInput": error_data.failed_input
             })
+        else:
+            self.errors.append({
+                "canvasStatusCode": HTTPStatus.BAD_REQUEST.value,
+                "message": error_data,
+                "failedInput": None
+            })
 
     def __str__(self) -> str:
         return f'Errors: {self.errors}'
@@ -70,16 +75,6 @@ class CanvasHTTPError():
             "statusCode": (sc.pop() if len(sc := {e["canvasStatusCode"] for e in self.errors}) == 1 else HTTPStatus.INTERNAL_SERVER_ERROR.value),
             "errors": self.errors
         }
-class HTTPAPIError(Exception):
-    """Custom exception to capture failed input along with the error details."""
-    def __init__(self, failed_input: str, original_exception: Exception):
-        self.failed_input = failed_input
-        self.original_exception = original_exception
-        super().__init__(f"Exception due failed input '{failed_input}': {original_exception}")
-
-    def to_dict(self):
-        """Returns a dictionary representation of the error."""
-        return {"failed_input": self.failed_input, "error": self.original_exception}
     
 class CanvasAccessTokenException(APIException):
     """

--- a/backend/ccm/canvas_api/exceptions.py
+++ b/backend/ccm/canvas_api/exceptions.py
@@ -1,56 +1,94 @@
-import json
-from typing import Any, List, TypedDict
+from http import HTTPStatus
+from typing import List, TypedDict, Union, Dict
+from canvasapi.exceptions import (
+    BadRequest, Conflict, Forbidden, InvalidAccessToken, RateLimitExceeded,
+    ResourceDoesNotExist, Unauthorized, UnprocessableEntity
+)
+from canvas_oauth.exceptions import InvalidOAuthReturnError
+from rest_framework.exceptions import APIException
 
 
-class StandardCanvasErrorData(TypedDict):
-    message: str
+class ErrorData(TypedDict):
+    failed_input: str
+    exeption: Exception
+
+class SerializerError(TypedDict):
+    failed_input: str
+    serializer_error: dict
     
-class CanvasHTTPError(Exception):
+class CanvasHTTPError():
     """
     Custom exception for HTTP errors originating from Canvas API interactions
     """
 
-    canvas_error_prefix = 'An error occurred while communicating with Canvas. '
+    canvas_error_prefix = 'An error occurred during Canvas API steps. '
 
     message: str
     status_code: int
     errors: List[dict]
+    EXCEPTION_STATUS_MAP = {
+        BadRequest: HTTPStatus.BAD_REQUEST.value,
+        InvalidAccessToken: HTTPStatus.UNAUTHORIZED.value,
+        Unauthorized: HTTPStatus.UNAUTHORIZED.value,
+        Forbidden: HTTPStatus.FORBIDDEN.value,
+        RateLimitExceeded: HTTPStatus.FORBIDDEN.value,
+        ResourceDoesNotExist: HTTPStatus.NOT_FOUND.value,
+        UnprocessableEntity: HTTPStatus.UNPROCESSABLE_ENTITY.value,
+        Conflict: HTTPStatus.CONFLICT.value,
+        InvalidOAuthReturnError: HTTPStatus.FORBIDDEN.value
+    }
 
-    def __init__(self, error_data: Any, status_code: int, failed_input: str = None) -> None:
+    def __init__(self, error_data: Union[List[ErrorData], Dict[str, SerializerError]]) -> None:
         self.errors = []
-        if (
-            isinstance(error_data, list) and
-            all([isinstance(obj, dict) for obj in error_data]) and
-            all(['message' in obj for obj in error_data]) and
-            all([isinstance(obj['message'], str) for obj in error_data])
-        ):
-            canvas_error_data: List[StandardCanvasErrorData] = error_data
-            for error in canvas_error_data:
+        if isinstance(error_data, list):
+            for error in error_data:
                 self.errors.append({
-                    "canvasStatusCode": status_code,
-                    "message": error['message'],
-                    "failedInput": failed_input
+                    "canvasStatusCode": self.EXCEPTION_STATUS_MAP.get(type(error['error']), HTTPStatus.INTERNAL_SERVER_ERROR.value),
+                    "message": str(error['error']),
+                    "failedInput": error['failed_input']
                 })
-        elif isinstance(error_data, str):
-            self.errors.append({
-                "canvasStatusCode": status_code,
-                "message": error_data,
-                "failedInput": failed_input
-            })
-        else:
-            self.errors.append({
-                "canvasStatusCode": status_code,
-                "message": f'Non-standard data shape found: {json.dumps(error_data)}',
-                "failedInput": failed_input
-            })
 
-        self.status_code = status_code
+        elif isinstance(error_data, dict):
+            self.errors.append({
+                "canvasStatusCode": HTTPStatus.INTERNAL_SERVER_ERROR.value,
+                "message": str(error_data['serializer_error']),
+                "failedInput": error_data['failed_input']
+            })
 
     def __str__(self) -> str:
-        return f'Status code: {self.status_code}; Errors: {self.errors}'
+        return f'Errors: {self.errors}'
 
     def to_dict(self) -> dict:
         return {
-            "statusCode": self.status_code,
+            "statusCode": (sc.pop() if len(sc := {e["canvasStatusCode"] for e in self.errors}) == 1 else HTTPStatus.INTERNAL_SERVER_ERROR.value),
             "errors": self.errors
+        }
+class HTTPAPIError(Exception):
+    """Custom exception to capture failed input along with the error details."""
+    def __init__(self, failed_input: str, original_exception: Exception):
+        self.failed_input = failed_input
+        self.original_exception = original_exception
+        super().__init__(f"Exception due failed input '{failed_input}': {original_exception}")
+
+    def to_dict(self):
+        """Returns a dictionary representation of the error."""
+        return {"failed_input": self.failed_input, "error": self.original_exception}
+    
+class CanvasAccessTokenException(APIException):
+    """
+    Custom exception for Canvas token-related errors.
+    """
+    status_code = 401
+    default_detail = 'Unauthorized'
+    default_code = 'unauthorized'
+
+    def __init__(self, detail=None, code=None):
+        self.redirect = True
+        super().__init__(detail or self.default_detail, code)
+
+    def to_dict(self) -> dict:
+        return {
+            "message": self.detail,
+            "statusCode": self.status_code,
+            "redirect": self.redirect
         }

--- a/backend/ccm/canvas_api/exceptions.py
+++ b/backend/ccm/canvas_api/exceptions.py
@@ -9,10 +9,6 @@ from canvas_oauth.exceptions import InvalidOAuthReturnError
 from rest_framework.exceptions import APIException
 
 @dataclass
-class ErrorData():
-    failed_input: str
-    exeption: Exception
-@dataclass
 class SerializerError():
     failed_input: str
     serializer_error: dict

--- a/backend/ccm/canvas_scopes.py
+++ b/backend/ccm/canvas_scopes.py
@@ -4,4 +4,5 @@ DEFAUlT_CANVAS_SCOPES = [
     'url:PUT|/api/v1/courses/:id',
     # Sections
     'url:GET|/api/v1/courses/:course_id/sections',
+    'url:POST|/api/v1/courses/:course_id/sections'
 ]

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -263,6 +263,7 @@ else:
     CANVAS_OAUTH_SCOPES = DEFAUlT_CANVAS_SCOPES
 
 REST_FRAMEWORK = {
+    'EXCEPTION_HANDLER': 'backend.ccm.canvas_api.drf_custom_exception_handler.custom_exception_handler',
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.SessionAuthentication',

--- a/backend/tests/test_canvas_credential_manager.py
+++ b/backend/tests/test_canvas_credential_manager.py
@@ -6,6 +6,8 @@ from canvas_oauth.models import CanvasOAuth2Token
 from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
 from django.utils import timezone
 
+from backend.ccm.canvas_api.exceptions import CanvasAccessTokenException
+
 
 class TestCanvasCredentialManager(TestCase):
     def setUp(self):
@@ -51,5 +53,5 @@ class TestCanvasCredentialManager(TestCase):
         self.assertTrue(CanvasOAuth2Token.objects.filter(user=self.user).exists())
 
         # Execute and Assert
-        with self.assertRaises(InvalidOAuthReturnError):
+        with self.assertRaises(CanvasAccessTokenException):  # Removed parentheses
             self.credential_manager.get_canvasapi_instance(self.request)

--- a/backend/tests/test_canvas_scope.py
+++ b/backend/tests/test_canvas_scope.py
@@ -8,6 +8,7 @@ class TestCanvasScope(SimpleTestCase):
             'url:GET|/api/v1/courses/:id',
             'url:PUT|/api/v1/courses/:id',
             'url:GET|/api/v1/courses/:course_id/sections',
+            'url:POST|/api/v1/courses/:course_id/sections'
         ]
         self.assertEqual(DEFAUlT_CANVAS_SCOPES, expected_scopes, "Canvas scopes do not match the expected values")
 

--- a/backend/tests/test_canvasapi_serializer.py
+++ b/backend/tests/test_canvasapi_serializer.py
@@ -4,6 +4,7 @@ from canvasapi.canvas_object import CanvasObject
 from django.test import SimpleTestCase
 
 from backend.ccm.canvas_api.canvasapi_serializer import CanvasObjectROSerializer, CourseSerializer
+from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
 
 class CanvasAPISerializerTests(SimpleTestCase):
     # --- CourseSerializer Tests ---
@@ -27,7 +28,7 @@ class CanvasAPISerializerTests(SimpleTestCase):
 
     # --- CanvasObjectROSerializer Tests ---
 
-    @patch('backend.ccm.canvas_api.course_api_handler.CANVAS_CREDENTIALS.get_canvasapi_instance')
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
     def test_canvas_object_readonly_serializes_basic_fields(self, mock_get_canvasapi_instance):
         mock_canvas = mock_get_canvasapi_instance.return_value
         canvas_obj = CanvasObject(
@@ -53,7 +54,7 @@ class CanvasAPISerializerTests(SimpleTestCase):
         self.assertIn("start_at_date", data)
         self.assertNotIn("_requester", data)
 
-    @patch('backend.ccm.canvas_api.course_api_handler.CANVAS_CREDENTIALS.get_canvasapi_instance')
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
     def test_canvas_object_readonly_ignores_callables(self, mock_get_canvasapi_instance):
         mock_canvas = mock_get_canvasapi_instance.return_value
         canvas_obj = CanvasObject(

--- a/backend/tests/test_course_api_handler.py
+++ b/backend/tests/test_course_api_handler.py
@@ -115,7 +115,7 @@ class CanvasCourseAPIHandlerTests(APITestCase):
                 {
                     "canvasStatusCode": 404,
                     "message": "Course update failed",
-                    "failedInput": str(self.course_id)  # Use course_id as failedInput
+                    "failedInput": str(data)  # Use course_id as failedInput
                 }
             ]
         }

--- a/backend/tests/test_course_api_handler.py
+++ b/backend/tests/test_course_api_handler.py
@@ -61,7 +61,7 @@ class CanvasCourseAPIHandlerTests(APITestCase):
         mock_canvas = mock_get_canvasapi_instance.return_value
         mock_course = Course(mock_canvas._Canvas__requester, {'id': self.course_id, 'name': 'Old Course Name', 'enrollment_term_id': 1, 'course_code': 'Old Course Name'})
         mock_canvas.get_course.return_value = mock_course
-        mock_course.update = lambda course: 'New Course Name'
+        mock_course.update = lambda course: mock_course.__dict__.update(course) or mock_course.name
 
         data = {'newName': 'New Course Name'}
         response = self.client.put(self.url, data, format='json')

--- a/backend/tests/test_course_api_handler.py
+++ b/backend/tests/test_course_api_handler.py
@@ -8,9 +8,11 @@ from http import HTTPStatus
 from django.utils import timezone
 from unittest.mock import patch, MagicMock
 
-from canvasapi.exceptions import CanvasException
+from canvasapi.exceptions import CanvasException, ResourceDoesNotExist
 from canvas_oauth.models import CanvasOAuth2Token
 from canvas_oauth.exceptions import InvalidOAuthReturnError
+from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
+from backend.ccm.canvas_api.exceptions import CanvasAccessTokenException
 
 class CanvasCourseAPIHandlerTests(APITestCase):
     def setUp(self):
@@ -20,7 +22,7 @@ class CanvasCourseAPIHandlerTests(APITestCase):
         self.course_id = 1
         self.url = reverse('course', kwargs={'course_id': self.course_id})
 
-    @patch('backend.ccm.canvas_api.course_api_handler.CANVAS_CREDENTIALS.get_canvasapi_instance')
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
     def test_get_course_success(self, mock_get_canvasapi_instance):
         mock_canvas = mock_get_canvasapi_instance.return_value
         mock_course = Course(mock_canvas._Canvas__requester, {'id': self.course_id, 'name': 'Test Course', 'enrollment_term_id': 1, 'course_code': 'Test Course'})
@@ -33,7 +35,7 @@ class CanvasCourseAPIHandlerTests(APITestCase):
         self.assertEqual(response.data['name'], 'Test Course')
         self.assertEqual(response.data['enrollment_term_id'], 1)
 
-    @patch('backend.ccm.canvas_api.course_api_handler.CANVAS_CREDENTIALS.get_canvasapi_instance')
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
     def test_get_course_not_found(self, mock_get_canvasapi_instance):
         mock_canvas = mock_get_canvasapi_instance.return_value
         mock_canvas.get_course.side_effect = CanvasException('Course not found')
@@ -54,7 +56,7 @@ class CanvasCourseAPIHandlerTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertEqual(expected_dict, response.data)
 
-    @patch('backend.ccm.canvas_api.course_api_handler.CANVAS_CREDENTIALS.get_canvasapi_instance')
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
     def test_put_course_success(self, mock_get_canvasapi_instance):
         mock_canvas = mock_get_canvasapi_instance.return_value
         mock_course = Course(mock_canvas._Canvas__requester, {'id': self.course_id, 'name': 'Old Course Name', 'enrollment_term_id': 1, 'course_code': 'Old Course Name'})
@@ -69,57 +71,82 @@ class CanvasCourseAPIHandlerTests(APITestCase):
         self.assertEqual(response.data['name'], 'New Course Name')
         self.assertEqual(response.data['enrollment_term_id'], 1)
 
-    @patch('backend.ccm.canvas_api.canvas_credential_manager.CanvasCredentialManager.handle_serializer_errors')
-    def test_put_course_serializer_validatation(self, mock_handle_serializer_errors):
-        expected_dict = [{'canvasStatusCode': 500, 'message': 'Non-standard data shape found: {"newName": ""}', 'failedInput': "{'newName': ''}"}]
-        mock_handle_serializer_errors.return_value.to_dict.return_value = {
-            "statusCode": 500,
-            "errors": expected_dict
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
+    def test_put_course_serializer_validatation(self, mock_get_canvasapi_instance):
+        # Create a mock serializer error that matches the actual format
+        from rest_framework.exceptions import ErrorDetail
+        serializer_errors = {
+            'newName': [ErrorDetail(string='This field may not be blank.', code='blank')]
         }
-        # Ensure the mock returns an integer for status_code
-        mock_handle_serializer_errors.return_value.status_code = 500
+        expected_dict = {
+            "statusCode": 500,
+            "errors": [
+                {
+                    "canvasStatusCode": 500,
+                    "message": str(serializer_errors),
+                    "failedInput": "{'newName': ''}"
+                }
+            ]
+        }
 
-        # FE actually validates that the field is not blank, so this test case is just testing serializer validation
+        # FE actually validates that the field is not blank
         data = {'newName': ''}
-        
         response = self.client.put(self.url, data, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-        self.assertEqual(expected_dict, response.data['errors'])
+        self.assertEqual(expected_dict['statusCode'], response.data['statusCode'])
+        self.assertEqual(len(expected_dict['errors']), len(response.data['errors']))
+        self.assertEqual(expected_dict['errors'][0]['canvasStatusCode'], response.data['errors'][0]['canvasStatusCode'])
+        self.assertEqual(expected_dict['errors'][0]['failedInput'], response.data['errors'][0]['failedInput'])
+        # For message, just verify it contains the error since the exact string format might vary
+        self.assertIn('This field may not be blank', response.data['errors'][0]['message'])
 
-    @patch('backend.ccm.canvas_api.course_api_handler.CANVAS_CREDENTIALS.get_canvasapi_instance')
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
     def test_put_course_canvas_exception(self, mock_get_canvasapi_instance):
         mock_canvas = mock_get_canvasapi_instance.return_value
-        mock_canvas.get_course.side_effect = CanvasException('Course update failed')
+        mock_canvas.get_course.side_effect = ResourceDoesNotExist('Course update failed')
 
         data = {'newName': 'New Course Name'}
         response = self.client.put(self.url, data, format='json')
 
         expected_dict = {
-            "statusCode": 500,
+            "statusCode": 404,
             "errors": [
-            {
-                "canvasStatusCode": 500,
-                "message": "Course update failed",
-                "failedInput": "{'newName': 'New Course Name'}"
-            }
+                {
+                    "canvasStatusCode": 404,
+                    "message": "Course update failed",
+                    "failedInput": str(self.course_id)  # Use course_id as failedInput
+                }
             ]
         }
 
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(expected_dict, response.data)
 
-    @patch('backend.ccm.canvas_api.course_api_handler.CANVAS_CREDENTIALS.get_canvasapi_instance')
-    def test_handle_canvas_api_exception_invalid_access_token(self, mock_get_canvasapi_instance):
-
-        # Create a token for the user
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
+    @patch('canvas_oauth.oauth.get_oauth_token')
+    def test_handle_canvas_api_exception_invalid_access_token(self, mock_get_oauth_token, mock_get_canvasapi_instance):
+        # Mock the oauth token call to throw InvalidOAuthReturnError
+        mock_get_oauth_token.side_effect = InvalidOAuthReturnError({'error': 'invalid_grant'})
         
-        mock_get_canvasapi_instance.side_effect = InvalidOAuthReturnError({'error': 'invalid_grant'})
+        # This will trigger the credential manager to raise CanvasAccessTokenException
+        mock_get_canvasapi_instance.side_effect = CanvasAccessTokenException()
 
-        response = self.client.get(self.url)
-        expected_dict = {'statusCode': 403, 'errors': [{'canvasStatusCode': 403, 'message': "{'error': 'invalid_grant'}", 'failedInput': '1'}]}
+        # Mock the token deletion that would happen in the custom exception handler
+        with patch('canvas_oauth.models.CanvasOAuth2Token.objects.filter') as mock_delete_token:
+            response = self.client.get(self.url)
+            
+            # Verify the token deletion was attempted
+            mock_delete_token.assert_called_once()
+            mock_delete_token.return_value.delete.assert_called_once()
 
-        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN.value)
+        expected_dict = {
+            'message': 'Unauthorized',
+            'statusCode': 401,
+            'redirect': True
+        }
+
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED.value)
         self.assertEqual(expected_dict, response.data)
 
 

--- a/backend/tests/test_course_create_section_api_handler.py
+++ b/backend/tests/test_course_create_section_api_handler.py
@@ -1,0 +1,153 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from http import HTTPStatus
+
+from rest_framework.test import APIRequestFactory
+
+from backend.ccm.canvas_api.course_section_api_handler import CourseSectionAPIHandler
+from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
+
+
+class TestCourseSectionAPIHandler(unittest.TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.credential_manager = MagicMock(spec=CanvasCredentialManager)
+        self.api_handler = CourseSectionAPIHandler(credential_manager=self.credential_manager)
+        
+        # Mock Canvas API instance
+        self.canvas_api = MagicMock()
+        self.credential_manager.get_canvasapi_instance.return_value = self.canvas_api
+        
+        # Mock course
+        self.course = MagicMock()
+        self.canvas_api.get_course.return_value = self.course
+        
+        # Test data
+        self.course_id = 12345
+        self.section_names = ["Section A", "Section B", "Section C"]
+        
+    @patch('backend.ccm.canvas_api.course_section_api_handler.asyncio.to_thread')
+    @patch('backend.ccm.canvas_api.course_section_api_handler.time.perf_counter')
+    def test_create_sections_happy_path(self, mock_perf_counter, mock_to_thread):
+        """Test successful concurrent creation of multiple sections."""
+        # Configure perf_counter mock to return fixed float values
+        mock_perf_counter.side_effect = [100.0, 100.5]  # start_time, end_time
+        
+        # Create request with section data
+        request_data = {"sections": self.section_names}
+        request = self.factory.post(
+            f'/api/canvas/courses/{self.course_id}/sections', 
+            data=request_data,
+            format='json'
+        )
+        request.data = request_data
+        
+        # Mock serializer validation
+        with patch('backend.ccm.canvas_api.course_section_api_handler.CourseSectionSerializer') as mock_serializer_class:
+            mock_serializer = MagicMock()
+            mock_serializer.is_valid.return_value = True
+            mock_serializer.validated_data = request_data
+            mock_serializer_class.return_value = mock_serializer
+            
+            # Mock section creation results
+            section_results = []
+            for i, name in enumerate(self.section_names):
+                section_result = {
+                    "id": 1000 + i,
+                    "name": name,
+                    "course_id": self.course_id,
+                    "total_students": 0
+                }
+                section_results.append(section_result)
+            
+            # Configure to_thread mock to return section results
+            async def mock_async_result(func, *args, **kwargs):
+                # Find the section name from args
+                section_name = args[2]  # Third argument to create_section_sync
+                # Find the corresponding result
+                for result in section_results:
+                    if result["name"] == section_name:
+                        return result
+                return None
+                
+            mock_to_thread.side_effect = mock_async_result
+            
+            # Execute the API call
+            response = self.api_handler.post(request, self.course_id)
+            
+            # Verify response
+            self.assertEqual(response.status_code, HTTPStatus.CREATED)
+            self.assertEqual(len(response.data), len(self.section_names))
+            
+            # Verify each section was created with correct data
+            for i, section_name in enumerate(self.section_names):
+                self.assertEqual(response.data[i]["name"], section_name)
+                self.assertEqual(response.data[i]["course_id"], self.course_id)
+                
+            # Verify concurrency - to_thread should be called for each section
+            self.assertEqual(mock_to_thread.call_count, len(self.section_names))
+            
+    @patch('backend.ccm.canvas_api.course_section_api_handler.asyncio.run')
+    def test_create_sections_with_real_async(self, mock_asyncio_run):
+        """Test that asyncio.run is called with create_sections."""
+        # Create request with section data
+        request_data = {"sections": self.section_names}
+        request = self.factory.post(
+            f'/api/canvas/courses/{self.course_id}/sections', 
+            data=request_data,  # Add data= explicitly
+            format='json'
+        )
+        request.data = request_data  # Also set data attribute directly
+        
+        # Mock serializer validation
+        with patch('backend.ccm.canvas_api.course_section_api_handler.CourseSectionSerializer') as mock_serializer_class:
+            mock_serializer = MagicMock()
+            mock_serializer.is_valid.return_value = True
+            mock_serializer.validated_data = request_data
+            mock_serializer_class.return_value = mock_serializer
+            
+            # Mock the result of asyncio.run
+            mock_asyncio_run.return_value = [
+                {"id": 1001, "name": "Section A", "course_id": self.course_id, "total_students": 0},
+                {"id": 1002, "name": "Section B", "course_id": self.course_id, "total_students": 0},
+                {"id": 1003, "name": "Section C", "course_id": self.course_id, "total_students": 0}
+            ]
+            
+            # Execute the API call
+            response = self.api_handler.post(request, self.course_id)
+            
+            # Verify asyncio.run was called with create_sections
+            mock_asyncio_run.assert_called_once()
+            args, _ = mock_asyncio_run.call_args
+            self.assertEqual(args[0].__name__, 'create_sections')
+            
+            # Verify response
+            self.assertEqual(response.status_code, HTTPStatus.CREATED)
+            self.assertEqual(len(response.data), len(self.section_names))
+            
+    def test_create_sections_validation_error(self):
+        """Test that serializer validates section count doesn't exceed 60."""
+        # Create request with too many sections
+        request_data = {"sections": [f"Section {i}" for i in range(61)]}
+        request = self.factory.post(
+            f'/api/canvas/courses/{self.course_id}/sections',
+            data=request_data,
+            format='json'
+        )
+        request.data = request_data
+        
+        # Mock the error response
+        mock_error_response = {
+            'statusCode': HTTPStatus.BAD_REQUEST,
+            'message': "The list cannot be more than 60 items."
+        }
+        self.credential_manager.handle_serializer_errors.return_value = MagicMock(
+            to_dict=MagicMock(return_value=mock_error_response)
+        )
+        
+        # Execute the API call
+        response = self.api_handler.post(request, self.course_id)
+        
+        # Verify response
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("The list cannot be more than 60 items", str(response.data))

--- a/backend/tests/test_course_create_section_api_handler.py
+++ b/backend/tests/test_course_create_section_api_handler.py
@@ -6,12 +6,14 @@ from rest_framework.test import APIRequestFactory
 
 from backend.ccm.canvas_api.course_section_api_handler import CourseSectionAPIHandler
 from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
+from backend.ccm.canvas_api.exceptions import CanvasErrorHandler
 
 
 class TestCourseSectionAPIHandler(unittest.TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
         self.credential_manager = MagicMock(spec=CanvasCredentialManager)
+        self.mock_canvas_error_handler = MagicMock(spec=CanvasErrorHandler)
         self.api_handler = CourseSectionAPIHandler(credential_manager=self.credential_manager)
         
         # Mock Canvas API instance
@@ -138,10 +140,10 @@ class TestCourseSectionAPIHandler(unittest.TestCase):
         
         # Mock the error response
         mock_error_response = {
-            'statusCode': HTTPStatus.BAD_REQUEST,
+            'statusCode': HTTPStatus.INTERNAL_SERVER_ERROR,
             'message': "The list cannot be more than 60 items."
         }
-        self.credential_manager.handle_serializer_errors.return_value = MagicMock(
+        self.mock_canvas_error_handler.handle_serializer_errors.return_value = MagicMock(
             to_dict=MagicMock(return_value=mock_error_response)
         )
         
@@ -149,5 +151,5 @@ class TestCourseSectionAPIHandler(unittest.TestCase):
         response = self.api_handler.post(request, self.course_id)
         
         # Verify response
-        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
         self.assertIn("The list cannot be more than 60 items", str(response.data))

--- a/backend/tests/test_course_section_api_handler.py
+++ b/backend/tests/test_course_section_api_handler.py
@@ -2,7 +2,7 @@ from django.test import RequestFactory
 from django.urls import reverse
 from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
 from backend.ccm.canvas_api.course_section_api_handler import CourseSectionAPIHandler
-from backend.ccm.canvas_api.exceptions import CanvasHTTPError, HTTPAPIError
+from backend.ccm.canvas_api.exceptions import CanvasErrorHandler, HTTPAPIError
 from rest_framework import status
 from rest_framework.test import APITestCase
 from django.contrib.auth.models import User
@@ -26,13 +26,15 @@ class CourseSectionAPIHandlerTests(APITestCase):
         mock_canvas = MagicMock()
         mock_course = MagicMock(spec=Course)
         mock_manager = MagicMock(spec=CanvasCredentialManager)
+        mock_canvas_error_handler = MagicMock(spec=CanvasErrorHandler)
 
         if exception:
             # Create an HTTPAPIError first, then pass it to CanvasHTTPError
             http_api_error = HTTPAPIError(str(self.course_id), exception)
-            error_obj = CanvasHTTPError([http_api_error])
+            error_obj = CanvasErrorHandler()
+            error_obj.handle_canvas_api_exceptions([http_api_error])
             mock_course.get_sections.side_effect = exception
-            mock_manager.handle_canvas_api_exceptions.return_value = error_obj
+            mock_canvas_error_handler.handle_canvas_api_exceptions.return_value = error_obj
         else:
             sections = [Section(mock_canvas._Canvas__requester, data) for data in (section_data or [])]
             mock_paginated = MagicMock(spec=PaginatedList)

--- a/backend/tests/test_course_section_api_handler.py
+++ b/backend/tests/test_course_section_api_handler.py
@@ -2,7 +2,7 @@ from django.test import RequestFactory
 from django.urls import reverse
 from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
 from backend.ccm.canvas_api.course_section_api_handler import CourseSectionAPIHandler
-from backend.ccm.canvas_api.exceptions import CanvasHTTPError
+from backend.ccm.canvas_api.exceptions import CanvasHTTPError, HTTPAPIError
 from rest_framework import status
 from rest_framework.test import APITestCase
 from django.contrib.auth.models import User
@@ -28,9 +28,11 @@ class CourseSectionAPIHandlerTests(APITestCase):
         mock_manager = MagicMock(spec=CanvasCredentialManager)
 
         if exception:
-            error_obj = CanvasHTTPError(exception.message, status.HTTP_500_INTERNAL_SERVER_ERROR, failed_input=str(self.course_id))
+            # Create an HTTPAPIError first, then pass it to CanvasHTTPError
+            http_api_error = HTTPAPIError(str(self.course_id), exception)
+            error_obj = CanvasHTTPError([http_api_error])
             mock_course.get_sections.side_effect = exception
-            mock_manager.handle_canvas_api_exception.return_value = error_obj
+            mock_manager.handle_canvas_api_exceptions.return_value = error_obj
         else:
             sections = [Section(mock_canvas._Canvas__requester, data) for data in (section_data or [])]
             mock_paginated = MagicMock(spec=PaginatedList)

--- a/backend/tests/test_drf_custom_exception_handler.py
+++ b/backend/tests/test_drf_custom_exception_handler.py
@@ -1,0 +1,75 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import User
+from canvas_oauth.models import CanvasOAuth2Token
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from backend.ccm.canvas_api.exceptions import CanvasAccessTokenException
+from backend.ccm.canvas_api.drf_custom_exception_handler import custom_exception_handler
+from rest_framework.test import APIClient
+from django.urls import path
+from django.utils import timezone
+from django.test import override_settings
+
+class TestView(APIView):
+    def get(self, request):
+        raise CanvasAccessTokenException()
+    
+class TestCustomExceptionHandler(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(username='testuser', password='testpass')
+        self.token = CanvasOAuth2Token.objects.create(
+            user=self.user,
+            access_token='test_access_token',
+            refresh_token='test_refresh_token',
+            expires=timezone.now() + timezone.timedelta(days=1)
+        )
+
+    def test_custom_handler_called_for_canvas_access_token_exception(self):
+
+        # Create request and context
+        request = self.factory.get('/test/')
+        request.user = self.user
+        context = {'request': request}
+
+        # Verify token exists before the call
+        self.assertTrue(CanvasOAuth2Token.objects.filter(user=self.user).exists())
+
+        # Call the handler directly with the exception
+        exception = CanvasAccessTokenException()
+        response = custom_exception_handler(exception, context)
+
+        # Verify token was deleted
+        self.assertFalse(CanvasOAuth2Token.objects.filter(user=self.user).exists())
+
+        # Verify response format
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.data, {
+            'message': 'Unauthorized',
+            'statusCode': 401,
+            'redirect': True
+        })
+
+    @override_settings(ROOT_URLCONF=__name__)
+    def test_custom_handler_via_api(self):
+        # Verify token exists before the call
+        self.assertTrue(CanvasOAuth2Token.objects.filter(user=self.user).exists())
+
+        # Create client and make request
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        response = client.get('/test/')
+        
+        # Verify response
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json(), {
+            'message': 'Unauthorized',
+            'statusCode': 401,
+            'redirect': True
+        })
+        self.assertFalse(CanvasOAuth2Token.objects.filter(user=self.user).exists())
+
+# Add URL patterns at module level
+urlpatterns = [
+    path('test/', TestView.as_view())
+]

--- a/backend/tests/test_exceptions.py
+++ b/backend/tests/test_exceptions.py
@@ -1,91 +1,67 @@
 from django.test import SimpleTestCase
-from backend.ccm.canvas_api.exceptions import CanvasHTTPError
+from backend.ccm.canvas_api.exceptions import CanvasHTTPError, HTTPAPIError, SerializerError
 from rest_framework.exceptions import ErrorDetail
-import json
+from canvasapi.exceptions import (BadRequest)
 
 class TestCanvasHTTPError(SimpleTestCase):
 
-    def test_list_error_data(self):
-        error_data = [{'message': 'Revoked access token.'}]
-        status_code = 401
-        failed_input = "403334"
-        error = CanvasHTTPError(error_data, status_code, failed_input)
+    def test_canvas_error_case(self):
+        err_message = '{"errors":{"name":[{"attribute":"name","message":"is too long (maximum is 255 characters)","type":"too_long"}],"course_code":[{"attribute":"course_code","message":"is too long (maximum is 255 characters)","type":"too_long"}]}'
+        error_data = [
+            HTTPAPIError(
+                failed_input="403334",
+                original_exception=BadRequest(err_message)
+            )
+        ]
+        error = CanvasHTTPError(error_data)
         
-        self.assertEqual(error.status_code, status_code)
-        self.assertEqual(len(error.errors), 1)
-        self.assertEqual(error.errors[0]["message"], "Revoked access token.")
-        self.assertEqual(error.errors[0]["failedInput"], failed_input)
         expected_dict = {
-            "statusCode": 401,
+            "statusCode": 400,  # Default status code since Exception isn't in EXCEPTION_STATUS_MAP
             "errors": [
-            {
-                "canvasStatusCode": 401,
-                "message": "Revoked access token.",
-                "failedInput": "403334"
-            }
+                {
+                    "canvasStatusCode": 400,
+                    "message": err_message,
+                    "failedInput": "403334"
+                }
             ]
         }
         self.assertEqual(error.to_dict(), expected_dict)
 
-    def test_string_error_data(self):
-        error_data = "The Resource does not exist."
-        status_code = 500
-        failed_input = "2020202020202020202"
-        error = CanvasHTTPError(error_data, status_code, failed_input)
+    def test_serializer_error(self):
+        error_data = SerializerError(
+            failed_input="2020202020202020202",
+            serializer_error={"error": "The Resource does not exist."}
+        )
+        error = CanvasHTTPError(error_data)
         
-        self.assertEqual(error.status_code, status_code)
         self.assertEqual(len(error.errors), 1)
-        self.assertEqual(error.errors[0]["message"], error_data)
-        self.assertEqual(error.errors[0]["failedInput"], failed_input)
+        self.assertEqual(error.errors[0]["message"], str({"error": "The Resource does not exist."}))
+        self.assertEqual(error.errors[0]["failedInput"], "2020202020202020202")
         expected_dict = {
             "statusCode": 500,
             "errors": [
-            {
-                "canvasStatusCode": 500,
-                "message": "The Resource does not exist.",
-                "failedInput": "2020202020202020202"
-            }
+                {
+                    "canvasStatusCode": 500,
+                    "message": "{'error': 'The Resource does not exist.'}",
+                    "failedInput": "2020202020202020202"
+                }
             ]
         }
         self.assertEqual(error.to_dict(), expected_dict)
 
     def test_non_standard_error_data(self):
-
-        error_data = {'newName': [ErrorDetail(string='This field is required.', code='required')]} # type: ignore
-        status_code = 404
-        failed_input = "{'newNames': 'CCM Test Course'}"
-        error = CanvasHTTPError(error_data, status_code, failed_input)
-        
-        self.assertEqual(error.status_code, status_code)
-        self.assertEqual(len(error.errors), 1)
-        self.assertIn("Non-standard data shape found", error.errors[0]["message"])
-        self.assertEqual(error.errors[0]["failedInput"], failed_input)
-
-    def test_invalid_grant_error_data(self):
-        '''
-        This is the case when Canvas API Key changes and access/refresh token is created using previous API Key.
-        In this case is triggered when the refresh/access token is expired as well.
-        This case only happen during the Local development when the Canvas Test instance is reset with Prod data.
-        '''
-        error_data = {"error": "invalid_grant", "error_description": "refresh_token not found"}
-        status_code = 403
-        failed_input = None
-        error = CanvasHTTPError(error_data, status_code, failed_input)
-        
-        self.assertEqual(error.status_code, status_code)
-        self.assertEqual(len(error.errors), 1)
-        expected_message = f'Non-standard data shape found: {json.dumps(error_data)}'
-        self.assertEqual(error.errors[0]["message"], expected_message)
-        self.assertEqual(error.errors[0]["failedInput"], failed_input)
+        error_data = "invalid error data"
+        error = CanvasHTTPError(error_data) 
         expected_dict = {
-            "statusCode": 403,
+            "statusCode": 400,
             "errors": [
-            {
-                "canvasStatusCode": 403,
-                "message": expected_message,
-                "failedInput": None
-            }
+                {
+                    "canvasStatusCode": 400,
+                    "message": error_data,
+                    "failedInput": None
+                }
             ]
         }
         self.assertEqual(error.to_dict(), expected_dict)
+  
 

--- a/ccm_web/client/src/api.ts
+++ b/ccm_web/client/src/api.ts
@@ -72,7 +72,7 @@ export const getCourseSections = async (courseId: number): Promise<CanvasCourseS
 export const addCourseSections = async (courseId: number, sectionNames: string[]): Promise<CanvasCourseSection[]> => {
   const body = JSON.stringify({ sections: sectionNames })
   const request = getPost(body)
-  const resp = await fetch('/api/course/' + courseId.toString() + '/sections', request)
+  const resp = await fetch('/api/course/' + courseId.toString() + '/sections/', request)
   await handleErrors(resp)
   return await resp.json()
 }


### PR DESCRIPTION
Fixes #476 #510 #511 

Step need while running locally, enable following scopes

     # Courses
    'url:GET|/api/v1/courses/:id',
    'url:PUT|/api/v1/courses/:id',
    # Sections
    'url:GET|/api/v1/courses/:course_id/sections',
    'url:POST|/api/v1/courses/:course_id/sections'

**Code Changes**
1. This PR addressing the complete integration of Create section single and bulk. Creating single section is used in the enrolling users features. 
    1. Bulk creating section using Concurrency approach and creating 60 is taking about 2 secs. Asyncio is used for doing this action, which is native Python lib feature.
3. In case of Canvas Token related error like revoked token, now the BE raises the error and DRF Custom Exception handler create a error response and FE does a browser redirect. FE Redirect is something already present
4. Refactoring the Canvas API Error response handler, this was done since the Bulk create section can return a mixed success/error response, only error response and all success. So `canvas_credential_manager.py`, `exception.py` handles all. There is a slight change in how `any_api_handler.py` call these classes when returning the error response.
5. Unit test are written to support all the use cases that is relevant to write test. 
6. API tracker should be tracking the Create section API calls

**Canvas Token anamolies testing steps**
1. Go to Canvas accounts --> Setting --> Delete the CCM API authorization ---> comeback to CCM ---> Make and API call from FE like get section, update course name --> Redirects to User Pre-OAuth page
2. When you add new features/API for CCM, then new scopes are added to Canvas Developer API registration, and scopes are added to CCM code as well, but the Canvas Access Token in the DB doesn't include permission with news scoped add, Canvas Throws unauthorized, in this case as well we are handling it using Browser redirect as described in `Code Changes` Step 2  
3. If Canvas API Registration is reset due to Prod sync, and we create a new API Key then the Canvas Access Token in DB are not valid with new API key. So this cases are handling it using Browser redirect as described in `Code Changes` Step 2 .Expired token in DB will trigger the use case.

