### PR TITLE
I521 django q2 setup

### DIFF
--- a/backend/ccm/background_tasks/math.py
+++ b/backend/ccm/background_tasks/math.py
@@ -1,0 +1,14 @@
+import logging
+logger = logging.getLogger(__name__)
+
+def add(task):
+    """
+    A simple background task that adds two numbers.
+    Call as below from Django Views
+      from django_q.tasks import async_task
+      task_data = {'a': 5, 'b': 8}
+      async_task('backend.ccm.background_tasks.math.add', task=task_data)
+    """
+    a = task.get('a', 0)
+    b = task.get('b', 0)
+    logger.info(f"Adding 2 numbers {a} and {b}: {a + b}")

--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -16,6 +16,7 @@ from .exceptions import CanvasErrorHandler, HTTPAPIError
 from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
 
 from rest_framework_tracking.mixins import LoggingMixin
+from django_q.tasks import async_task
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,10 @@ class CanvasCourseSectionAPIHandler(LoggingMixin, APIView):
         results = asyncio.run(self.create_sections(course, sections))
         end_time: float = time.perf_counter()
         logger.info(f"Time taken to create {len(sections)} sections: {end_time - start_time:.2f} seconds")
+        task_data = {'a': 5, 'b': 8}
+
+        logger.info("Running the call as sync task")
+        async_task('backend.ccm.background_tasks.math.add', task=task_data)
 
         # Filter success and error responses
         success_res = [result for result in results if isinstance(result, dict)]

--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -16,7 +16,6 @@ from .exceptions import CanvasErrorHandler, HTTPAPIError
 from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
 
 from rest_framework_tracking.mixins import LoggingMixin
-from django_q.tasks import async_task
 
 logger = logging.getLogger(__name__)
 

--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -82,10 +82,6 @@ class CanvasCourseSectionAPIHandler(LoggingMixin, APIView):
         results = asyncio.run(self.create_sections(course, sections))
         end_time: float = time.perf_counter()
         logger.info(f"Time taken to create {len(sections)} sections: {end_time - start_time:.2f} seconds")
-        task_data = {'a': 5, 'b': 8}
-
-        logger.info("Running the call as sync task")
-        async_task('backend.ccm.background_tasks.math.add', task=task_data)
 
         # Filter success and error responses
         success_res = [result for result in results if isinstance(result, dict)]

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -280,12 +280,12 @@ SPECTACULAR_SETTINGS = {
 
 DRF_TRACKING_ADMIN_LOG_READONLY = True
 
+# https://django-q2.readthedocs.io/en/master/configure.html
 Q_CLUSTER = {
-    'name': 'DjangORM',
-    'workers': 2,
-    'timeout': 90,
-    'retry': 120,
-    'queue_limit': 50,
-    'bulk': 10,
+    'name': 'CCM_Cluster',
+    'workers': int(os.getenv('Q_CLUSTER_WORKERS', 4)),
+    'timeout': int(os.getenv('Q_CLUSTER_TIMEOUT', 1800)), # 30 minutes
+    'retry': int(os.getenv('Q_CLUSTER_RETRY', 3600)), # 1hr
+    'bulk': int(os.getenv('Q_CLUSTER_BULK', 5)),
     'orm': 'default'
 }

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -55,7 +55,8 @@ INSTALLED_APPS = [
     'lti_tool',
     'rest_framework',
     'drf_spectacular',
-    'rest_framework_tracking'
+    'rest_framework_tracking',
+    'django_q',
 ]
 
 MIDDLEWARE = [
@@ -278,3 +279,13 @@ SPECTACULAR_SETTINGS = {
 }
 
 DRF_TRACKING_ADMIN_LOG_READONLY = True
+
+Q_CLUSTER = {
+    'name': 'DjangORM',
+    'workers': 2,
+    'timeout': 90,
+    'retry': 120,
+    'queue_limit': 50,
+    'bulk': 10,
+    'orm': 'default'
+}

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -59,3 +59,13 @@ CANVAS_OAUTH_CANVAS_DOMAIN=
 #(optional) The Canvas API scopes needed by the application
 # (This should only be used if Canvas changes the scopes from what is in the source code in backend/canvas_scopes.py.)
 # CANVAS_OAUTH_SCOPES=
+
+# Django Q Cluster settings (for background task processing)
+# Number of worker processes for Django Q
+Q_CLUSTER_WORKERS=4
+# Task execution timeout in seconds
+Q_CLUSTER_TIMEOUT=1800
+# Retry interval in seconds for failed tasks
+Q_CLUSTER_RETRY=3600
+# Number of tasks to process in bulk
+Q_CLUSTER_BULK=5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - ./.mysql_data:/var/lib/mysql
       - ./mysql:/docker-entrypoint-initdb.d:ro
     container_name: ccm_db
+
   redis:
     image: redis:7
     read_only: true
@@ -48,7 +49,6 @@ services:
       - ccm-redis-data:/data:ro
     command: redis-server --stop-writes-on-bgsave-error no --save ""
     container_name: ccm_redis
-  
 
 volumes:
   ccm-redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,24 +39,6 @@ services:
       - ./.mysql_data:/var/lib/mysql
       - ./mysql:/docker-entrypoint-initdb.d:ro
     container_name: ccm_db
-  
-  qworker:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    command: > 
-      sh -c "while ! nc -z ccm_db 3306; do
-        echo 'Waiting for MySQL...';
-        sleep 1;
-      done;
-      watchfiles --filter python 'python manage.py qcluster' /code/backend"
-    depends_on:
-      - database
-    env_file: ${HOME}/secrets/ccm/.env
-    volumes:
-      - ./backend:/code/backend
-    container_name: ccm_qworker
-
   redis:
     image: redis:7
     read_only: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,23 @@ services:
       - ./.mysql_data:/var/lib/mysql
       - ./mysql:/docker-entrypoint-initdb.d:ro
     container_name: ccm_db
+  
+  qworker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: > 
+      sh -c "while ! nc -z ccm_db 3306; do
+        echo 'Waiting for MySQL...';
+        sleep 1;
+      done;
+      watchfiles --filter python 'python manage.py qcluster' /code/backend"
+    depends_on:
+      - database
+    env_file: ${HOME}/secrets/ccm/.env
+    volumes:
+      - ./backend:/code/backend
+    container_name: ccm_qworker
 
   redis:
     image: redis:7
@@ -49,6 +66,7 @@ services:
       - ccm-redis-data:/data:ro
     command: redis-server --stop-writes-on-bgsave-error no --save ""
     container_name: ccm_redis
+  
 
 volumes:
   ccm-redis-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,9 @@ redis==5.2.1 # For caching
 django-watchman==1.3 # For status monitoring
 canvasapi==3.3.0 # For Canvas API
 
+#django-q
+django-q2==1.8.0
+watchfiles==1.0.5 # For file watching
+
 # Not in pypi https://github.com/Harvard-University-iCommons/django-canvas-oauth
 https://github.com/Harvard-University-iCommons/django-canvas-oauth/archive/v1.1.1.tar.gz

--- a/supervisor_docker.conf
+++ b/supervisor_docker.conf
@@ -22,3 +22,14 @@ startsecs=5
 startretries=2
 # Graceful stop, see http://nginx.org/en/docs/control.html
 stopsignal=QUIT
+
+[program:qworker]
+command=sh -c "while ! nc -z ccm_db 3306; do echo 'Waiting for MySQL...'; sleep 1; done; watchfiles --filter python 'python manage.py qcluster' /code/backend"
+directory=/code
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+environment=DJANGO_SETTINGS_MODULE="backend.settings"


### PR DESCRIPTION
Fixes #521 

This is establishing the pipeline for the DjangoQ with `django-q2` package. The goal is to run the enrolling user ( UM and Non-UM)  task as background instead of immediate API action. 

Django’s database backend as a message broker instead of Redis since the amount of request we would expect with Enrolling users in CCM
https://django-q2.readthedocs.io/en/master/configure.html#orm 

Configuration: Kept simple If you don't set any config defaults will apply
https://django-q2.readthedocs.io/en/master/configure.html#

Django Admin Console show state of Background Tasks


**Note**:  You will see the below warning, looking at the Package developer, this only effect when you have [Million of Failed ](https://github.com/django-q2/django-q2/issues/245#issuecomment-2448347017)of tasks. Based on this response we can [ignore](https://github.com/django-q2/django-q2/issues/245) 
```
WARNINGS:
django_q.Task: (models.W037) MySQL does not support indexes with conditions.
	HINT: Conditions will be ignored. Silence this warning if you don't care about it.

```