### PR TITLE
feat: Add replacement notice for Format Canvas Gradebook feature

### DIFF
--- a/ccm_web/client/src/models/FeatureUIData.tsx
+++ b/ccm_web/client/src/models/FeatureUIData.tsx
@@ -15,6 +15,7 @@ import AddUMUsers from '../pages/AddUMUsers.js'
 import BulkSectionCreate from '../pages/BulkSectionCreate.js'
 import FormatThirdPartyGradebook from '../pages/FormatThirdPartyGradebook.js'
 import ConvertCanvasGradebook from '../pages/GradebookCanvas.js'
+import GBCanvasReplacementNotice from '../pages/GBCanvasReplacementNotice.js'
 import MergeSections from '../pages/MergeSections.js'
 import { Globals, RoleEnum } from './models.js'
 import { CanvasCourseBase, CanvasCourseSectionWithCourseName, ClientEnrollmentType } from './canvas.js'
@@ -66,7 +67,7 @@ const mergeSectionCardProps: FeatureUIProps = {
 const formatCanvasGradebookCardProps: FeatureUIProps = {
   data: formatCanvasGradebookProps,
   icon: <LibraryBooksOutlinedIcon fontSize='large' />,
-  component: ConvertCanvasGradebook,
+  component: GBCanvasReplacementNotice,
   route: '/gradebook-canvas'
 }
 

--- a/ccm_web/client/src/pages/GBCanvasReplacementNotice.tsx
+++ b/ccm_web/client/src/pages/GBCanvasReplacementNotice.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { styled } from '@mui/material/styles'
-import { Button, Grid, Link, Typography } from '@mui/material'
+import { Link, Typography } from '@mui/material'
 
 import { CCMComponentProps } from '../models/FeatureUIData.js'
 
@@ -34,7 +34,7 @@ function GBCanvasReplacementNotice (props: CCMComponentProps): JSX.Element {
           <b>This feature has been replaced by Canvas Letter Grades Import</b>
         </Typography>
         <Typography paragraph>
-          <strong>Canvas Letter Grades Import</strong> is a tool located directly in the <Link href="https://wolverineaccess.umich.edu/">Faculty Center's Grade Roster.</Link>
+          <strong>Canvas Letter Grades Import</strong> is a tool located directly in the <Link href="https://wolverineaccess.umich.edu/" target='_blank' rel="noopener">Faculty Center's Grade Roster.</Link>
         </Typography>
         <Typography paragraph>
           You must format final grades in Canvas as letter grades (via the grading scheme) to use Canvas Letter Grades Import.

--- a/ccm_web/client/src/pages/GBCanvasReplacementNotice.tsx
+++ b/ccm_web/client/src/pages/GBCanvasReplacementNotice.tsx
@@ -30,11 +30,11 @@ function GBCanvasReplacementNotice (props: CCMComponentProps): JSX.Element {
     <Root className={classes.root}>
       <Typography variant='h5' component='h1'>{props.title}</Typography>
       <div>
-        <Typography variant='h6' component='h2' sx={{ color: 'warning.main', mb: 2 }}>
-          This feature has been replaced by Canvas Letter Grades Import
+        <Typography variant='h6' component='h2' sx={{ mb: 2 }}>
+          <b>This feature has been replaced by Canvas Letter Grades Import</b>
         </Typography>
         <Typography paragraph>
-          <strong>Canvas Letter Grades Import</strong> is a tool located directly in the Faculty Center's Grade Roster.
+          <strong>Canvas Letter Grades Import</strong> is a tool located directly in the <Link href="https://wolverineaccess.umich.edu/">Faculty Center's Grade Roster.</Link>
         </Typography>
         <Typography paragraph>
           You must format final grades in Canvas as letter grades (via the grading scheme) to use Canvas Letter Grades Import.

--- a/ccm_web/client/src/pages/GBCanvasReplacementNotice.tsx
+++ b/ccm_web/client/src/pages/GBCanvasReplacementNotice.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { styled } from '@mui/material/styles'
+import { Button, Grid, Link, Typography } from '@mui/material'
+
+import { CCMComponentProps } from '../models/FeatureUIData.js'
+
+const PREFIX = 'GBCanvasReplacementNotice'
+
+const classes = {
+  root: `${PREFIX}-root`,
+  buttonGroup: `${PREFIX}-buttonGroup`
+}
+
+const Root = styled('div')((
+  {
+    theme
+  }
+) => ({
+  [`&.${classes.root}`]: {
+    textAlign: 'left'
+  },
+
+  [`& .${classes.buttonGroup}`]: {
+    marginTop: theme.spacing(1)
+  }
+}))
+
+function GBCanvasReplacementNotice (props: CCMComponentProps): JSX.Element {
+  return (
+    <Root className={classes.root}>
+      <Typography variant='h5' component='h1'>{props.title}</Typography>
+      <div>
+        <Typography variant='h6' component='h2' sx={{ color: 'warning.main', mb: 2 }}>
+          This feature has been replaced by Canvas Letter Grades Import
+        </Typography>
+        <Typography paragraph>
+          <strong>Canvas Letter Grades Import</strong> is a tool located directly in the Faculty Center's Grade Roster.
+        </Typography>
+        <Typography paragraph>
+          You must format final grades in Canvas as letter grades (via the grading scheme) to use Canvas Letter Grades Import.
+        </Typography>
+        <Typography variant='h6' component='h3' sx={{ mt: 3, mb: 1 }}>
+          Get Started
+        </Typography>
+         <ol>
+          <li>
+            <Typography>
+              <Link href='https://teamdynamix.umich.edu/TDClient/30/Portal/KB/ArticleDet?ID=7257' target='_blank' rel="noopener">
+                Prep your Canvas Gradebook
+              </Link>
+            </Typography>
+          </li>
+          <li>
+            <Typography>
+              <Link href='https://teamdynamix.umich.edu/TDClient/30/Portal/KB/ArticleDet?ID=11669' target='_blank' rel="noopener">
+                Import grades using Canvas Letter Grades Import in Grade Roster
+              </Link>
+            </Typography>
+          </li>
+        </ol>
+      </div>
+    </Root>
+  )
+}
+
+export default GBCanvasReplacementNotice

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -86,6 +86,7 @@ interface GradebookCanvasPageStateData {
 }
 
 enum GradebookCanvasPageState {
+  ReplacementNotice,
   Upload,
   InvalidUpload,
   Confirm,
@@ -98,7 +99,7 @@ const convertEmptyCellToUndefined = (cell: string | undefined): string | undefin
 }
 
 function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
-  const [pageState, setPageState] = useState<GradebookCanvasPageStateData>({ state: GradebookCanvasPageState.Upload })
+  const [pageState, setPageState] = useState<GradebookCanvasPageStateData>({ state: GradebookCanvasPageState.ReplacementNotice })
   const [file, setFile] = useState<File|undefined>(undefined)
   const [downloadData, setDownloadData] = useState<DownloadData | undefined>(undefined)
 
@@ -331,8 +332,54 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
     })
   }
 
+  const renderReplacementNotice = (): JSX.Element => {
+    return (
+      <div>
+        <Typography variant='h6' component='h2' sx={{ color: 'warning.main', mb: 2 }}>
+          This feature has been replaced by Canvas Letter Grades Import
+        </Typography>
+        <Typography paragraph>
+          <strong>Canvas Letter Grades Import</strong> is a tool located directly in the Faculty Center's Grade Roster.
+        </Typography>
+        <Typography paragraph>
+          <strong>You must format final grades in Canvas as letter grades (via the grading scheme) to use</strong> Canvas Letter Grades Import.
+        </Typography>
+        <Typography variant='h6' component='h3' sx={{ mt: 3, mb: 1 }}>
+          Get Started
+        </Typography>
+        <ol>
+          <li>
+            <Typography>
+              <Link href='https://teamdynamix.umich.edu/TDClient/30/Portal/KB/ArticleDet?ID=7257' target='_blank' rel="noopener">
+                Prep your Canvas Gradebook
+              </Link>
+            </Typography>
+          </li>
+          <li>
+            <Typography>
+              <Link href='https://teamdynamix.umich.edu/TDClient/30/Portal/KB/ArticleDet?ID=11669' target='_blank' rel="noopener">
+                Import grades using Canvas Letter Grades Import in Grade Roster
+              </Link>
+            </Typography>
+          </li>
+        </ol>
+        <Grid container className={classes.buttonGroup} justifyContent='flex-start' sx={{ mt: 3 }}>
+          <Button 
+            variant='outlined' 
+            onClick={() => setPageState({ state: GradebookCanvasPageState.Upload })}
+            sx={{ mr: 2 }}
+          >
+            Use Legacy Tool Instead
+          </Button>
+        </Grid>
+      </div>
+    )
+  }
+
   const renderComponent = (): JSX.Element => {
     switch (pageState.state) {
+      case GradebookCanvasPageState.ReplacementNotice:
+        return renderReplacementNotice()
       case GradebookCanvasPageState.Upload:
         return renderUpload()
       case GradebookCanvasPageState.InvalidUpload:

--- a/ccm_web/client/src/pages/GradebookCanvas.tsx
+++ b/ccm_web/client/src/pages/GradebookCanvas.tsx
@@ -86,7 +86,6 @@ interface GradebookCanvasPageStateData {
 }
 
 enum GradebookCanvasPageState {
-  ReplacementNotice,
   Upload,
   InvalidUpload,
   Confirm,
@@ -99,7 +98,7 @@ const convertEmptyCellToUndefined = (cell: string | undefined): string | undefin
 }
 
 function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
-  const [pageState, setPageState] = useState<GradebookCanvasPageStateData>({ state: GradebookCanvasPageState.ReplacementNotice })
+  const [pageState, setPageState] = useState<GradebookCanvasPageStateData>({ state: GradebookCanvasPageState.Upload })
   const [file, setFile] = useState<File|undefined>(undefined)
   const [downloadData, setDownloadData] = useState<DownloadData | undefined>(undefined)
 
@@ -332,54 +331,8 @@ function ConvertCanvasGradebook (props: CCMComponentProps): JSX.Element {
     })
   }
 
-  const renderReplacementNotice = (): JSX.Element => {
-    return (
-      <div>
-        <Typography variant='h6' component='h2' sx={{ color: 'warning.main', mb: 2 }}>
-          This feature has been replaced by Canvas Letter Grades Import
-        </Typography>
-        <Typography paragraph>
-          <strong>Canvas Letter Grades Import</strong> is a tool located directly in the Faculty Center's Grade Roster.
-        </Typography>
-        <Typography paragraph>
-          <strong>You must format final grades in Canvas as letter grades (via the grading scheme) to use</strong> Canvas Letter Grades Import.
-        </Typography>
-        <Typography variant='h6' component='h3' sx={{ mt: 3, mb: 1 }}>
-          Get Started
-        </Typography>
-        <ol>
-          <li>
-            <Typography>
-              <Link href='https://teamdynamix.umich.edu/TDClient/30/Portal/KB/ArticleDet?ID=7257' target='_blank' rel="noopener">
-                Prep your Canvas Gradebook
-              </Link>
-            </Typography>
-          </li>
-          <li>
-            <Typography>
-              <Link href='https://teamdynamix.umich.edu/TDClient/30/Portal/KB/ArticleDet?ID=11669' target='_blank' rel="noopener">
-                Import grades using Canvas Letter Grades Import in Grade Roster
-              </Link>
-            </Typography>
-          </li>
-        </ol>
-        <Grid container className={classes.buttonGroup} justifyContent='flex-start' sx={{ mt: 3 }}>
-          <Button 
-            variant='outlined' 
-            onClick={() => setPageState({ state: GradebookCanvasPageState.Upload })}
-            sx={{ mr: 2 }}
-          >
-            Use Legacy Tool Instead
-          </Button>
-        </Grid>
-      </div>
-    )
-  }
-
   const renderComponent = (): JSX.Element => {
     switch (pageState.state) {
-      case GradebookCanvasPageState.ReplacementNotice:
-        return renderReplacementNotice()
       case GradebookCanvasPageState.Upload:
         return renderUpload()
       case GradebookCanvasPageState.InvalidUpload:


### PR DESCRIPTION
Summary: Resolves issue #529 

- Added a `ReplacementNotice` status so it'll display the deprecation message by default
- I also added a `Use Legacy Tool Instead` button for users who still need the old functionality (changes the state back to `Upload`)

![Screenshot 2025-06-23 104203](https://github.com/user-attachments/assets/71878f21-eccd-44cb-8ece-bcfa5ee5e7f5)
