### PR TITLE
fix: add csp to installed_apps

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     'drf_spectacular',
     'rest_framework_tracking',
     'django_q',
+    'csp',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Summary: adds `csp` to `INSTALLED_APPS`  in `settings.py`.