### PR TITLE
#542 Development support with asgi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ WORKDIR /code
 
 COPY backend ./backend
 COPY templates ./templates
-COPY manage.py start.sh ./
+COPY manage.py  ./
 
 COPY --from=node-build /build/bundles ./ccm_web/bundles 
 COPY --from=node-build /build/webpack-stats.json ./ccm_web/

--- a/shell_scripts/start.sh
+++ b/shell_scripts/start.sh
@@ -34,29 +34,24 @@ if [ -z "${DJANGO_SECRET_KEY}" ]; then
     echo "DJANGO_SECRET_KEY not set, using random value"
 fi
 
-# To have a more static default secret key, this should still be defined
-if [ -z "${DJANGO_SECRET_KEY}" ]; then
-    export DJANGO_SECRET_KEY=`python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'`
-    echo "DJANGO_SECRET_KEY not set, using random value"
-fi
-
-echo "Waiting for DB ${DB_HOST}:${DB_PORT}"
-while ! nc -z "${DB_HOST}" "${DB_PORT}"; do   
-  sleep 1 # wait 1 second before check again
+echo "backend: Waiting for DB ${DB_HOST} at ${DB_PORT}"
+while ! nc -z "${DB_HOST}" "${DB_PORT}"; do
+  sleep 2 # wait 2 seconds before check again
 done
 
-echo Running python migrations
+echo "backend: Running python migrations"
 python manage.py migrate
-
+echo "backend:Django migrations completed."
 
 if [ "${DEBUGPY_ENABLE:-"false"}" == "false" ]; then
-    echo "Starting Gunicorn with uvicorn worker for production"
+    echo "backend: Starting Gunicorn with uvicorn worker for production"
     CMD="gunicorn backend.asgi:application --bind 0.0.0.0:${GUNICORN_PORT} --workers=\"${GUNICORN_WORKERS}\" -k uvicorn_worker.UvicornWorker --timeout=\"${GUNICORN_TIMEOUT}\" "
 else
-    echo "Starting uvicorn for Development"
+    echo "backend: Starting uvicorn for Development"
     CMD="uvicorn backend.asgi:application --host=0.0.0.0 --port=${GUNICORN_PORT} --reload"
 fi
 # Signal backend is ready for qworker
-( echo "Backend finished starting up." && touch /tmp/backend_ready ) &
-
-eval exec $CMD
+touch /tmp/backend_ready
+exec $CMD
+echo "Backend finished starting up."
+# End of backend startup script

--- a/shell_scripts/worker.sh
+++ b/shell_scripts/worker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "qworker is starting..."
+
+# Wait for backend to be ready since supervisor will spawn all the 3 processes backend, qworker, and frontend same time
+while [ ! -f /tmp/backend_ready ]; do
+    echo 'qworker: Waiting for backend to be ready...'
+    sleep 2
+done
+
+# this is to ensure that the backend/DB is fully ready before starting the qworker
+echo "qworker: Backend is ready, starting qworker..."
+if [ "$RUN_QWORKER_DEV_MODE" = "true" ]; then
+    echo 'qworker: Running in DEV mode'
+    rm /tmp/backend_ready
+    watchfiles --filter python 'python manage.py qcluster' /code/backend/ccm/background_tasks
+else
+    echo 'qworker: Running in PROD mode'
+    python manage.py qcluster
+fi
+

--- a/start.sh
+++ b/start.sh
@@ -48,8 +48,6 @@ done
 echo Running python migrations
 python manage.py migrate
 
-echo "Setting domain of default site record"
-echo "DEBUGPY_ENABLE: $DEBUGPY_ENABLE"
 
 if [ "${DEBUGPY_ENABLE:-"false"}" == "false" ]; then
     echo "Starting Gunicorn with uvicorn worker for production"

--- a/start.sh
+++ b/start.sh
@@ -34,12 +34,6 @@ if [ -z "${DJANGO_SECRET_KEY}" ]; then
     echo "DJANGO_SECRET_KEY not set, using random value"
 fi
 
-if [ "${GUNICORN_RELOAD}" ]; then
-    GUNICORN_RELOAD="--reload"
-else
-    GUNICORN_RELOAD=
-fi
-
 # To have a more static default secret key, this should still be defined
 if [ -z "${DJANGO_SECRET_KEY}" ]; then
     export DJANGO_SECRET_KEY=`python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'`
@@ -55,22 +49,16 @@ echo Running python migrations
 python manage.py migrate
 
 echo "Setting domain of default site record"
+echo "DEBUGPY_ENABLE: $DEBUGPY_ENABLE"
 
 if [ "${DEBUGPY_ENABLE:-"false"}" == "false" ]; then
-    echo "Starting Gunicorn for production"
+    echo "Starting Gunicorn with uvicorn worker for production"
+    CMD="gunicorn backend.asgi:application --bind 0.0.0.0:${GUNICORN_PORT} --workers=\"${GUNICORN_WORKERS}\" -k uvicorn_worker.UvicornWorker --timeout=\"${GUNICORN_TIMEOUT}\" "
 else
-    echo "Starting Gunicorn for DEBUGPY debugging"
-    # Workers need to be set to 1 for DEBUGPY
-    GUNICORN_WORKERS=1
-    GUNICORN_RELOAD="--reload"
-    GUNICORN_TIMEOUT=0
+    echo "Starting uvicorn for Development"
+    CMD="uvicorn backend.asgi:application --host=0.0.0.0 --port=${GUNICORN_PORT} --reload"
 fi
 # Signal backend is ready for qworker
 ( echo "Backend finished starting up." && touch /tmp/backend_ready ) &
 
-exec gunicorn backend.asgi:application \
-    --bind 0.0.0.0:${GUNICORN_PORT} \
-    --workers="${GUNICORN_WORKERS}" \
-    -k uvicorn_worker.UvicornWorker \
-    --timeout="${GUNICORN_TIMEOUT}" \
-    ${GUNICORN_RELOAD}
+eval exec $CMD

--- a/supervisor_docker.conf
+++ b/supervisor_docker.conf
@@ -6,7 +6,7 @@ loglevel=info
 pidfile=/tmp/supervisord.pid
 
 [program:backend]
-command=bash -c ./start.sh
+command=bash -c ./shell_scripts/start.sh
 directory=/code
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -29,7 +29,7 @@ startretries=2
 stopsignal=QUIT
 
 [program:qworker]
-command=sh -c "while [ ! -f /tmp/backend_ready ]; do echo 'Waiting for backend to be ready...'; sleep 2; done; if [ \"$RUN_QWORKER_DEV_MODE\" = \"true\" ]; then echo 'Running in qworker DEV mode'; watchfiles --filter python 'python manage.py qcluster' /code/backend/ccm/background_tasks; else echo 'Running in qworker PROD mode'; python manage.py qcluster; fi"
+command=bash -c ./shell_scripts/worker.sh
 directory=/code
 priority=20
 autostart=true

--- a/supervisor_docker.conf
+++ b/supervisor_docker.conf
@@ -1,14 +1,3 @@
-[unix_http_server]
-file=/tmp/supervisor.sock
-chmod=0700
-
-[supervisorctl]
-serverurl=unix:///tmp/supervisor.sock
-
-[rpcinterface:supervisor]
-supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
-
-
 [supervisord]
 nodaemon=true
 logfile=/dev/stdout
@@ -40,7 +29,7 @@ startretries=2
 stopsignal=QUIT
 
 [program:qworker]
-command=sh -c "while [ ! -f /tmp/backend_ready ]; do echo 'Waiting for backend to be ready...'; sleep 2; done; if [ \"$RUN_QWORKER_DEV_MODE\" = \"true\" ]; then echo 'Running in qworker DEV mode'; watchfiles --filter python 'python manage.py qcluster' /code/backend; else echo 'Running in qworker PROD mode'; python manage.py qcluster; fi"
+command=sh -c "while [ ! -f /tmp/backend_ready ]; do echo 'Waiting for backend to be ready...'; sleep 2; done; if [ \"$RUN_QWORKER_DEV_MODE\" = \"true\" ]; then echo 'Running in qworker DEV mode'; watchfiles --filter python 'python manage.py qcluster' /code/backend/ccm/background_tasks; else echo 'Running in qworker PROD mode'; python manage.py qcluster; fi"
 directory=/code
 priority=20
 autostart=true


### PR DESCRIPTION
Fixes #542 #536

There is a bug when shifting to Asgi from wsgi that the `--reload` was not happening. We are now using new Uvicorn worker, and the author [here](https://github.com/Kludex/uvicorn-worker?tab=readme-ov-file) suggested the to use Pure ASGI using UVICORN for development and a mix of GUNICON with Uvicorn pulling the best of both worlds of ASGI and WSGI. 

I looked up ROHQ after witnessing this bug, they followed same approach. 