### PR TITLE
Making it DJango async style

### DIFF
--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -5,12 +5,12 @@ from rest_framework.views import APIView
 from rest_framework import authentication, permissions
 from rest_framework.response import Response
 from rest_framework.request import Request
-from asgiref.sync import sync_to_async
 
 from canvasapi.exceptions import CanvasException
 from canvasapi import Canvas
 from canvasapi.course import Course
 from drf_spectacular.utils import extend_schema
+from asgiref.sync import async_to_sync
 
 from .exceptions import CanvasErrorHandler, HTTPAPIError
 
@@ -80,7 +80,6 @@ class CanvasCourseSectionAPIHandler(LoggingMixin, APIView):
         course = Course(canvas_api._Canvas__requester, {'id': course_id})
            
         start_time: float = time.perf_counter()
-        from asgiref.sync import async_to_sync
         results = async_to_sync(self.create_sections)(course, sections)
         end_time: float = time.perf_counter()
         logger.info(f"Time taken to create {len(sections)} sections: {end_time - start_time:.2f} seconds")

--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -80,7 +80,7 @@ class CanvasCourseSectionAPIHandler(LoggingMixin, APIView):
         course = Course(canvas_api._Canvas__requester, {'id': course_id})
            
         start_time: float = time.perf_counter()
-        results = async_to_sync(self.create_sections)(course, sections)
+        results = self.create_sections(course, sections)
         end_time: float = time.perf_counter()
         logger.info(f"Time taken to create {len(sections)} sections: {end_time - start_time:.2f} seconds")
 
@@ -97,11 +97,12 @@ class CanvasCourseSectionAPIHandler(LoggingMixin, APIView):
         # Handle errors
         self.canvas_error.handle_canvas_api_exceptions(err_res)
         return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
-        
+
     async def sem_task(self, semaphore, course, name):
         async with semaphore:
             return await self.create_section(course, name)
 
+    @async_to_sync
     async def create_sections(self, course: Course, section_names: list):
         """Creates multiple sections concurrently, guarded by a semaphore."""
         max_concurrent = 10  # Set your desired concurrency limit here

--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -5,6 +5,7 @@ from rest_framework.views import APIView
 from rest_framework import authentication, permissions
 from rest_framework.response import Response
 from rest_framework.request import Request
+from asgiref.sync import sync_to_async
 
 from canvasapi.exceptions import CanvasException
 from canvasapi import Canvas
@@ -79,7 +80,8 @@ class CanvasCourseSectionAPIHandler(LoggingMixin, APIView):
         course = Course(canvas_api._Canvas__requester, {'id': course_id})
            
         start_time: float = time.perf_counter()
-        results = asyncio.run(self.create_sections(course, sections))
+        from asgiref.sync import async_to_sync
+        results = async_to_sync(self.create_sections)(course, sections)
         end_time: float = time.perf_counter()
         logger.info(f"Time taken to create {len(sections)} sections: {end_time - start_time:.2f} seconds")
 

--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -98,9 +98,15 @@ class CanvasCourseSectionAPIHandler(LoggingMixin, APIView):
         self.canvas_error.handle_canvas_api_exceptions(err_res)
         return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
         
+    async def sem_task(self, semaphore, course, name):
+        async with semaphore:
+            return await self.create_section(course, name)
+
     async def create_sections(self, course: Course, section_names: list):
-        """Creates multiple sections concurrently."""
-        tasks = [self.create_section(course, name) for name in section_names]
+        """Creates multiple sections concurrently, guarded by a semaphore."""
+        max_concurrent = 10  # Set your desired concurrency limit here
+        semaphore = asyncio.Semaphore(max_concurrent)
+        tasks = [self.sem_task(semaphore, course, name) for name in section_names]
         return await asyncio.gather(*tasks, return_exceptions=True)
 
     def create_section_sync(self, course: Course, section_name: str):


### PR DESCRIPTION
Fixes #542 #152 

Alternative to asyncio.run() for starting the async flow in Django. I feel with this approach we don't have worry about performance what will happen when concurrent users start hitting us and behavior of running the async workflow.  

- https://youtu.be/B5uQPwX4VLo?si=qcmm3mZiD-B8hWP6. (This provide a good overview of Django Async changes needed)
- https://docs.djangoproject.com/en/5.2/topics/async/  (Django Async support)
- https://docs.djangoproject.com/en/5.2/topics/async/#async-adapter-functions 

I think world in Python/Django is shifting towards supporting async development. But the ecosystem is still not fully caught up. `Django ORM` is one use case of stepping towards async support.`requests` supports only sync, but libraries like `aiohttp` and `httpx` has support for async and support the `asyncio`. `asyncio` module is default async support in Python is well supported by most of the major packages and is a much mature state. 

`FastAPI` and `Sanic` are emerging asynchronous web framework. 

I guess async is evolving topic and something we started to adopt  (like adding Uvicorn addition ), learn and grow. I guess my learning so far is that there is no playbook async web development since the echo system is moving towards it and we just need to pick and chose what best work for our project. 