### PR TITLE
#543, #540 GA csp fixes and admin link fix for chrome

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -218,12 +218,13 @@ CONTENT_SECURITY_POLICY = {
     "DIRECTIVES": {
         "frame-ancestors": parse_csp('CSP_FRAME_ANCESTORS'),
         "script-src": parse_csp('CSP_SCRIPT_SRC', [UNSAFE_INLINE, UNSAFE_EVAL]),
-        "connect-src": parse_csp('CSP_SCRIPT_SRC'),
-        "img-src": parse_csp('CSP_SCRIPT_SRC'),
+        "connect-src": parse_csp('CSP_CONNECT_SRC'),
+        "img-src": parse_csp('CSP_IMG_SRC'),
         "font-src": parse_csp('CSP_FONT_SRC'),
         "style-src": parse_csp('CSP_STYLE_SRC', ["https:", UNSAFE_INLINE]),
     }
 }
+print("Content Security Policy:", CONTENT_SECURITY_POLICY)
 
 # making LTI launch smooth
 CSRF_COOKIE_SECURE = os.getenv("CSRF_COOKIE_SECURE", False)

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -224,7 +224,6 @@ CONTENT_SECURITY_POLICY = {
         "style-src": parse_csp('CSP_STYLE_SRC', ["https:", UNSAFE_INLINE]),
     }
 }
-print("Content Security Policy:", CONTENT_SECURITY_POLICY)
 
 # making LTI launch smooth
 CSRF_COOKIE_SECURE = os.getenv("CSRF_COOKIE_SECURE", False)

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -25,7 +25,7 @@ import watchman.views
 from backend import views
 
 urlpatterns = [
-    path('admin', admin.site.urls),
+    path('admin/', admin.site.urls),
     path('', views.home_view, name='home'),
     path(".well-known/jwks.json", jwks, name="jwks"),
     path("init/<uuid:registration_uuid>", OIDCLoginInitView.as_view(), name="init"),

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -21,7 +21,7 @@ DEBUGPY_WAIT_FOR_DEBUGGER=False
 ALLOWED_HOSTS=.ngrok.io,.localhost,127.0.0.1,.loophole.site,0.0.0.0
 
 # A comma separated list of domains where you want to allow the application to be framed
-CSP_FRAME_ANCESTORS=https://canvas-test.it.umich.edu,*.ngrok-free.app,*.ngrok.io
+CSP_FRAME_ANCESTORS=https://canvas-test.it.umich.edu
 CSP_SCRIPT_SRC=*.google-analytics.com,*.analytics.google.com,*.googletagmanager.com,umich.edu,*.umich.edu,cdn.jsdelivr.net,cdnjs.cloudflare.com
 CSP_CONNECT_SRC=*.google-analytics.com,*.analytics.google.com,*.googletagmanager.com,umich.edu,*.umich.edu
 CSP_IMG_SRC=*.google-analytics.com,*.analytics.google.com,*.googletagmanager.com,umich.edu,*.umich.edu


### PR DESCRIPTION
This issue fixed the CSP changes that did not assigned properly  with PR #543. I don't see any warning in the Dev tool console with GA. But couldn't  test full GA tracking, But I saw banner appearing 

and #540 fixing the bug when Chrome has some issue `admin` view without `admin/`. I am not going to fight with this for now. will create an issue to understand this. I don't think this is anything to do with CSP

Here is the output of the CSP directives in setting.py
```
Content_Security_Policy = {
    'DIRECTIVES': {
        'frame-ancestors': [
            "'self'",
            'https://canvas-test.it.umich.edu',
        ],
        'script-src': [
            "'self'",
            '*.google-analytics.com',
            '*.analytics.google.com',
            '*.googletagmanager.com',
            'umich.edu',
            '*.umich.edu',
            'cdn.jsdelivr.net',
            'cdnjs.cloudflare.com',
            "'unsafe-inline'",
            "'unsafe-eval'",
        ],
        'connect-src': [
            "'self'",
            '*.google-analytics.com',
            '*.analytics.google.com',
            '*.googletagmanager.com',
            'umich.edu',
            '*.umich.edu',
        ],
        'img-src': [
            "'self'",
            '*.google-analytics.com',
            '*.analytics.google.com',
            '*.googletagmanager.com',
            'umich.edu',
            '*.umich.edu',
        ],
        'font-src': [
            "'self'",
        ],
        'style-src': [
            "'self'",
            'https:',
            "'unsafe-inline'",
        ],
    }
}
