### PR TITLE
#558 Fix Gunicorn starting the prod mode error

### DIFF
--- a/shell_scripts/start.sh
+++ b/shell_scripts/start.sh
@@ -45,7 +45,7 @@ echo "backend:Django migrations completed."
 
 if [ "${DEBUGPY_ENABLE:-"false"}" == "false" ]; then
     echo "backend: Starting Gunicorn with uvicorn worker for production"
-    CMD="gunicorn backend.asgi:application --bind 0.0.0.0:${GUNICORN_PORT} --workers=${GUNICORN_WORKERS} -k uvicorn_worker.UvicornWorker --timeout=${GUNICORN_TIMEOUT} "
+    CMD="gunicorn backend.asgi:application --bind 0.0.0.0:${GUNICORN_PORT} --workers=${GUNICORN_WORKERS} -k uvicorn_worker.UvicornWorker --timeout=${GUNICORN_TIMEOUT}"
 else
     echo "backend: Starting uvicorn for Development"
     CMD="uvicorn backend.asgi:application --host=0.0.0.0 --port=${GUNICORN_PORT} --reload"

--- a/shell_scripts/start.sh
+++ b/shell_scripts/start.sh
@@ -45,7 +45,7 @@ echo "backend:Django migrations completed."
 
 if [ "${DEBUGPY_ENABLE:-"false"}" == "false" ]; then
     echo "backend: Starting Gunicorn with uvicorn worker for production"
-    CMD="gunicorn backend.asgi:application --bind 0.0.0.0:${GUNICORN_PORT} --workers=\"${GUNICORN_WORKERS}\" -k uvicorn_worker.UvicornWorker --timeout=\"${GUNICORN_TIMEOUT}\" "
+    CMD="gunicorn backend.asgi:application --bind 0.0.0.0:${GUNICORN_PORT} --workers=${GUNICORN_WORKERS} -k uvicorn_worker.UvicornWorker --timeout=${GUNICORN_TIMEOUT} "
 else
     echo "backend: Starting uvicorn for Development"
     CMD="uvicorn backend.asgi:application --host=0.0.0.0 --port=${GUNICORN_PORT} --reload"


### PR DESCRIPTION
Fixes #558 

To reproduce this locally
1. Remove `DEBUGPY_ENABLE=True`  from `.env` this will start the Server in prod mode and can replicate the error
2. The error `gunicorn: error: argument -w/--workers: invalid int value: '"4"'` should go away with the fix