### PR TITLE
#561 adding a getting user info

### DIFF
--- a/backend/ccm/canvas_api/canvas_credential_manager.py
+++ b/backend/ccm/canvas_api/canvas_credential_manager.py
@@ -24,4 +24,9 @@ class CanvasCredentialManager:
       raise CanvasAccessTokenException()
     return Canvas(self.canvasURL, access_token)
   
+  # This token only used when getting and creating user in canvas
+  def get_canvasapi_admin_instance(self) -> Canvas:
+    admin_token = settings.CANVAS_ADMIN_API_TOKEN
+    return Canvas(self.canvasURL, admin_token)
+  
   

--- a/backend/ccm/canvas_api/canvas_user_handler.py
+++ b/backend/ccm/canvas_api/canvas_user_handler.py
@@ -1,0 +1,46 @@
+import logging
+from http import HTTPStatus
+from rest_framework.views import APIView
+from rest_framework_tracking.mixins import LoggingMixin
+from rest_framework import authentication, permissions
+from rest_framework.request import Request
+from rest_framework.response import Response
+from canvasapi import Canvas
+from canvasapi.exceptions import CanvasException
+from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
+from backend.ccm.canvas_api.canvasapi_serializer import CanvasObjectROSerializer, LoginIdSerializer
+from .exceptions import CanvasErrorHandler, HTTPAPIError
+
+logger = logging.getLogger(__name__)
+
+class CanvasUserHandler(LoggingMixin, APIView):
+    logging_methods = ['GET']
+    authentication_classes = [authentication.SessionAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+    user_allowed_fields = ['name']   
+    serializer_class = LoginIdSerializer
+
+    def __init__(self, credential_manager=None):
+        self.credential_manager = credential_manager or CanvasCredentialManager()
+        self.canvas_error = CanvasErrorHandler()
+        super().__init__()
+    
+    def get(self, request: Request, login_id: str) -> Response:
+        # Validate login_id is an email address
+        serializer = LoginIdSerializer(data={'login_id': login_id})
+        if not serializer.is_valid():
+            self.canvas_error.handle_serializer_errors(serializer.errors,str(login_id))
+            return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
+        
+        canvas_api: Canvas = self.credential_manager.get_canvasapi_admin_instance()
+        safe_login_id: str = login_id.replace('@', '+')
+        try:
+            user_info = canvas_api.get_user(safe_login_id, 'sis_login_id')
+            append_fields ={"login_id": login_id}
+            serializer = CanvasObjectROSerializer(user_info, allowed_fields=self.user_allowed_fields, append_fields=append_fields)
+            return Response(serializer.data, status=HTTPStatus.OK)
+        except (CanvasException, Exception) as e:
+            self.canvas_error.handle_canvas_api_exceptions(HTTPAPIError(str(login_id), e))
+            return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
+      
+

--- a/backend/ccm/canvas_api/canvas_user_handler.py
+++ b/backend/ccm/canvas_api/canvas_user_handler.py
@@ -32,10 +32,10 @@ class CanvasUserHandler(LoggingMixin, APIView):
             self.canvas_error.handle_serializer_errors(serializer.errors,str(login_id))
             return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
         
-        canvas_api: Canvas = self.credential_manager.get_canvasapi_admin_instance()
+        canvas_admin_api: Canvas = self.credential_manager.get_canvasapi_admin_instance()
         safe_login_id: str = login_id.replace('@', '+')
         try:
-            user_info = canvas_api.get_user(safe_login_id, 'sis_login_id')
+            user_info = canvas_admin_api.get_user(safe_login_id, 'sis_login_id')
             append_fields ={"login_id": login_id}
             serializer = CanvasObjectROSerializer(user_info, allowed_fields=self.user_allowed_fields, append_fields=append_fields)
             return Response(serializer.data, status=HTTPStatus.OK)

--- a/backend/ccm/canvas_api/canvasapi_serializer.py
+++ b/backend/ccm/canvas_api/canvasapi_serializer.py
@@ -117,3 +117,7 @@ class CanvasObjectROSerializer(serializers.BaseSerializer):
                     data[key] = value
         
         return data
+    
+# Serializer to validate login_id as an email address
+class LoginIdSerializer(serializers.Serializer):
+    login_id = serializers.EmailField()

--- a/backend/ccm/canvas_api/urls.py
+++ b/backend/ccm/canvas_api/urls.py
@@ -1,3 +1,4 @@
+from backend.ccm.canvas_api.canvas_user_handler import CanvasUserHandler
 from backend.ccm.canvas_api.course_api_handler import CanvasCourseAPIHandler
 from django.urls import path
 
@@ -12,4 +13,5 @@ urlpatterns = [
   path('course/<int:course_id>/sections/<int:section_id>/enroll', SingleSectionEnrollmentView.as_view(), name='singleSectionEnrollments'),
   path('course/<int:course_id>/sections/enroll', MultiSectionEnrollmentView.as_view(), name='multipleSectionEnrollments'),
   path('instructor/sections', CanvasInstructorSectionsAPIHandler.as_view(), name='instructorSections'),
+  path('admin/user/<str:login_id>', CanvasUserHandler.as_view(), name='checkUser')
 ]

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -18,6 +18,7 @@ from backend.ccm.utils import parse_csp
 from backend.ccm.canvas_scopes import DEFAUlT_CANVAS_SCOPES
 from datetime import timedelta
 import json
+import logging
 
 config_to_bool = lambda value: str(value).lower() in ('true', '1', 'yes', 'on')
 
@@ -322,3 +323,7 @@ EMAIL_USE_TLS = True
 EMAIL_FROM = os.getenv('EMAIL_FROM', 'canvas-ccm-system@umich.edu')
 EMAIL_TO_REPLY = os.getenv('EMAIL_TO_REPLY', '4help@umich.edu')
 EMAIL_DEBUG = os.getenv('EMAIL_DEBUG', False)
+
+CANVAS_ADMIN_API_TOKEN = os.environ.get('CANVAS_ADMIN_API_TOKEN')
+if CANVAS_ADMIN_API_TOKEN is None or CANVAS_ADMIN_API_TOKEN == '':
+    logging.error('CANVAS_ADMIN_API_TOKEN is not set in environment variables!')

--- a/backend/tests/test_canvas_credential_manager.py
+++ b/backend/tests/test_canvas_credential_manager.py
@@ -25,9 +25,23 @@ class TestCanvasCredentialManager(TestCase):
             expires=timezone.now() + timezone.timedelta(days=1)
         )
 
+
     def tearDown(self):
         self.user.delete()
         CanvasOAuth2Token.objects.all().delete()
+
+    @patch('backend.ccm.canvas_api.canvas_credential_manager.Canvas')
+    @patch('backend.ccm.canvas_api.canvas_credential_manager.settings')
+    def test_get_canvasapi_admin_instance_with_valid_token(self, mock_settings, mock_canvas):
+        mock_settings.CANVAS_ADMIN_API_TOKEN = 'admin_token_123'
+        mock_settings.CANVAS_OAUTH_CANVAS_DOMAIN = 'canvas.test.instructure.com'  # Set domain for test
+        expected_url = f"https://{mock_settings.CANVAS_OAUTH_CANVAS_DOMAIN}"
+        mock_canvas_instance = MagicMock()
+        mock_canvas.return_value = mock_canvas_instance
+        credential_manager = CanvasCredentialManager()  # Instantiate after mocking settings
+        result = credential_manager.get_canvasapi_admin_instance()
+        mock_canvas.assert_called_once_with(expected_url, 'admin_token_123')
+        self.assertEqual(result, mock_canvas_instance)
         
     @patch('backend.ccm.canvas_api.canvas_credential_manager.get_oauth_token')
     @patch('backend.ccm.canvas_api.canvas_credential_manager.Canvas')

--- a/backend/tests/test_canvas_user_handler.py
+++ b/backend/tests/test_canvas_user_handler.py
@@ -74,7 +74,7 @@ class TestCanvasUserHandler(TestCase):
         # Simulate ResourceDoesNotExist exception when calling get_user
         mock_canvas_api.get_user.side_effect = ResourceDoesNotExist('Not Found')
 
-        login_id = 'pushyamiredy@gmail.com'
+        login_id = 'test@gmail.com'
         view = CanvasUserHandler()
         request = self.factory.get(f'/api/admin/user/{login_id}')
         force_authenticate(request, user=self.user)

--- a/backend/tests/test_canvas_user_handler.py
+++ b/backend/tests/test_canvas_user_handler.py
@@ -1,0 +1,65 @@
+from django.test import TestCase, RequestFactory
+from unittest.mock import patch, MagicMock
+from backend.ccm.canvas_api.canvas_user_handler import CanvasUserHandler
+from backend.ccm.canvas_api.canvasapi_serializer import LoginIdSerializer
+from django.contrib.auth.models import AnonymousUser, User
+from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework import status
+
+class TestCanvasUserHandler(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.user = User.objects.create_user(username='testuser', email='testuser@gmail.com', password='testpass')
+
+    @patch('backend.ccm.canvas_api.canvas_credential_manager.CanvasCredentialManager.get_canvasapi_admin_instance')
+    @patch('backend.ccm.canvas_api.canvas_user_handler.CanvasObjectROSerializer')
+    def test_get_user_happy_path(self, mock_serializer, mock_get_canvasapi_admin_instance):
+        # Setup mocks
+        mock_canvas_api = MagicMock()
+        mock_get_canvasapi_admin_instance.return_value = mock_canvas_api
+        mock_user_info = MagicMock()
+        mock_canvas_api.get_user.return_value = mock_user_info
+        mock_serializer_instance = MagicMock()
+        mock_serializer.return_value = mock_serializer_instance
+        mock_serializer_instance.data = {'name': 'Test User', 'login_id': 'testuser@gmail.com'}
+
+        # Prepare request
+        login_id = 'testuser@gmail.com'
+        view = CanvasUserHandler()
+        request = self.factory.get(f'/api/admin/user/{login_id}')
+        force_authenticate(request, user=self.user)
+
+        # Call view
+        response = view.get(request, login_id)
+
+        # Assertions
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['name'], 'Test User')
+        self.assertEqual(response.data['login_id'], 'testuser@gmail.com')
+        mock_get_canvasapi_admin_instance.assert_called_once()
+        mock_canvas_api.get_user.assert_called_once_with('testuser+gmail.com', 'sis_login_id')
+        mock_serializer.assert_called_once_with(mock_user_info, allowed_fields=view.user_allowed_fields, append_fields={'login_id': login_id})
+
+    @patch('backend.ccm.canvas_api.canvas_credential_manager.CanvasCredentialManager.get_canvasapi_admin_instance')
+    @patch('backend.ccm.canvas_api.canvas_user_handler.CanvasObjectROSerializer')
+    def test_get_user_exception_path(self, mock_serializer, mock_get_canvasapi_admin_instance):
+        # Setup mocks
+        mock_canvas_api = MagicMock()
+        mock_get_canvasapi_admin_instance.return_value = mock_canvas_api
+        # Simulate exception when calling get_user
+        mock_canvas_api.get_user.side_effect = Exception('Test error')
+
+        login_id = 'testuser@gmail.com'
+        view = CanvasUserHandler()
+        request = self.factory.get(f'/api/admin/user/{login_id}')
+        force_authenticate(request, user=self.user)
+
+        response = view.get(request, login_id)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIn('errors', response.data)
+        self.assertEqual(response.data['statusCode'], 500)
+        error = response.data['errors'][0]
+        self.assertEqual(error['canvasStatusCode'], 500)
+        self.assertEqual(error['message'], 'Test error')
+        self.assertEqual(error['failedInput'], login_id)

--- a/backend/tests/test_canvas_user_handler.py
+++ b/backend/tests/test_canvas_user_handler.py
@@ -63,3 +63,29 @@ class TestCanvasUserHandler(TestCase):
         self.assertEqual(error['canvasStatusCode'], 500)
         self.assertEqual(error['message'], 'Test error')
         self.assertEqual(error['failedInput'], login_id)
+        
+    @patch('backend.ccm.canvas_api.canvas_credential_manager.CanvasCredentialManager.get_canvasapi_admin_instance')
+    @patch('backend.ccm.canvas_api.canvas_user_handler.CanvasObjectROSerializer')
+    def test_get_user_not_found(self, mock_serializer, mock_get_canvasapi_admin_instance):
+        # Setup mocks
+        from canvasapi.exceptions import ResourceDoesNotExist
+        mock_canvas_api = MagicMock()
+        mock_get_canvasapi_admin_instance.return_value = mock_canvas_api
+        # Simulate ResourceDoesNotExist exception when calling get_user
+        mock_canvas_api.get_user.side_effect = ResourceDoesNotExist('Not Found')
+
+        login_id = 'pushyamiredy@gmail.com'
+        view = CanvasUserHandler()
+        request = self.factory.get(f'/api/admin/user/{login_id}')
+        force_authenticate(request, user=self.user)
+
+        response = view.get(request, login_id)
+
+        # Assertions
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('errors', response.data)
+        self.assertEqual(response.data['statusCode'], 404)
+        error = response.data['errors'][0]
+        self.assertEqual(error['canvasStatusCode'], 404)
+        self.assertEqual(error['message'], 'Not Found')
+        self.assertEqual(error['failedInput'], login_id)

--- a/backend/tests/test_canvasapi_serializer.py
+++ b/backend/tests/test_canvasapi_serializer.py
@@ -176,6 +176,23 @@ class EnrollRequestSerializerTests(SimpleTestCase):
         finally:
             canvasapi_serializer.MAX_ALLOWED_ENROLLMENTS = original_max
 
+    # --- LoginIdSerializer Tests ---
+    class LoginIdSerializerTests(SimpleTestCase):
+        def test_login_id_serializer_valid_email(self):
+            from backend.ccm.canvas_api.canvasapi_serializer import LoginIdSerializer
+            payload = {"login_id": "user@example.com"}
+            serializer = LoginIdSerializer(data=payload)
+            self.assertTrue(serializer.is_valid())
+            self.assertEqual(serializer.validated_data["login_id"], "user@example.com")
+
+        def test_login_id_serializer_invalid_email(self):
+            from backend.ccm.canvas_api.canvasapi_serializer import LoginIdSerializer
+            payload = {"login_id": "not-an-email"}
+            serializer = LoginIdSerializer(data=payload)
+            self.assertFalse(serializer.is_valid())
+            self.assertIn("login_id", serializer.errors)
+            self.assertIn("Enter a valid email address.", str(serializer.errors["login_id"]))
+
 
 
 

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -116,23 +116,44 @@ class TestCustomCanvasRoles(SimpleTestCase):
         if self.env_key in os.environ:
             del os.environ[self.env_key]
 
+
+class TestCanvasAdminApiTokenLogging(SimpleTestCase):
+    def setUp(self):
+        self.admin_token_env_key = 'CANVAS_ADMIN_API_TOKEN'
+        self.roles_env_key = 'CUSTOM_CANVAS_ROLES'
+        self.old_admin_token_env = os.environ.get(self.admin_token_env_key)
+        self.old_roles_env = os.environ.get(self.roles_env_key)
+        if self.admin_token_env_key in os.environ:
+            del os.environ[self.admin_token_env_key]
+        if self.roles_env_key in os.environ:
+            del os.environ[self.roles_env_key]
+
     def tearDown(self):
-        if self.old_env is not None:
-            os.environ[self.env_key] = self.old_env
-        elif self.env_key in os.environ:
-            del os.environ[self.env_key]
+        if self.old_admin_token_env is not None:
+            os.environ[self.admin_token_env_key] = self.old_admin_token_env
+        elif self.admin_token_env_key in os.environ:
+            del os.environ[self.admin_token_env_key]
+        if self.old_roles_env is not None:
+            os.environ[self.roles_env_key] = self.old_roles_env
+        elif self.roles_env_key in os.environ:
+            del os.environ[self.roles_env_key]
+
+    def test_canvas_admin_api_token_missing_logs_error(self):
+        with self.assertLogs('root', level='ERROR') as cm:
+            importlib.reload(settings)
+        self.assertTrue(any('CANVAS_ADMIN_API_TOKEN is not set in environment variables!' in msg for msg in cm.output))
 
     def test_custom_canvas_roles_default(self):
         importlib.reload(settings)
         self.assertEqual(settings.CUSTOM_CANVAS_ROLES, {'assistant': 34, 'librarian': 21})
 
     def test_custom_canvas_roles_env_override(self):
-        os.environ[self.env_key] = '{"assistant": 99, "librarian": 88}'
+        os.environ[self.roles_env_key] = '{"assistant": 99, "librarian": 88}'
         importlib.reload(settings)
         self.assertEqual(settings.CUSTOM_CANVAS_ROLES, {'assistant': 99, 'librarian': 88})
 
     def test_custom_canvas_roles_env_invalid(self):
-        os.environ[self.env_key] = 'not a json string'
+        os.environ[self.roles_env_key] = 'not a json string'
         importlib.reload(settings)
         self.assertEqual(settings.CUSTOM_CANVAS_ROLES, {'assistant': 34, 'librarian': 21})
 

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -99,3 +99,6 @@ Q_CLUSTER_MAX_ATTEMPTS=1
 # (optional) Custom Canvas Roles mapping as a JSON string. Defaults to {"Assistant": 34, "Librarian": 21} if not set or invalid.
 # Example: CUSTOM_CANVAS_ROLES='{"assistant": 99, "librarian": 88}'
 CUSTOM_CANVAS_ROLES='{"assistant": 34, "librarian": 21}'
+
+# Static Canvas API token for user with admin permissions
+CANVAS_ADMIN_API_TOKEN=<your_canvas_admin_api_token>


### PR DESCRIPTION
Fixes #561 

**Config Change needed**: Take the config from Dropbox, if you ran a Node app it should be available. 
`CANVAS_ADMIN_API_TOKEN`

The PR checking if the login_id is available or not.  Tests are written to support the UI. 
New function created in CanvasCredentialManager class to support the Admin token, this token don't have any expiry and scoped to user manage permission and don't do need to go via Canvas API key setup for scope setting.  

**Test Plan**
1. Give an existing Non-Umich email id. You can look at the course (403334) for an existing one
2. Give a new Non-Umich email Id, just make some random
3. UI should message appropriate to users. Either recognize as new user or existing user  