### PR TITLE
#582 fix Uvicorn worker starting error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # server and workers
 gunicorn==23.0.0
-uvicorn-worker==0.3.0
+uvicorn-worker==0.4.0
 
 mysqlclient==2.2.7
 


### PR DESCRIPTION
Fixes #582 
This is not currently an issue with local development, but in the CCMDev when processing this step `gunicorn backend.asgi:application --bind 0.0.0.0:${GUNICORN_PORT} --workers=${GUNICORN_WORKERS} -k uvicorn_worker.UvicornWorker --timeout=${GUNICORN_TIMEOUT}`

The Fix seems to be upgrading to new version of Unicorn worker.

To replicate this locally simply remove `DEBUGPY_ENABLE` from `.env` 

```
if [ "${DEBUGPY_ENABLE:-"false"}" == "false" ]; then
    echo "backend: Starting Gunicorn with uvicorn worker for production"
    CMD="gunicorn backend.asgi:application --bind 0.0.0.0:${GUNICORN_PORT} --workers=${GUNICORN_WORKERS} -k uvicorn_worker.UvicornWorker --timeout=${GUNICORN_TIMEOUT}"
else
    echo "backend: Starting uvicorn for Development"
    CMD="uvicorn backend.asgi:application --host=0.0.0.0 --port=${GUNICORN_PORT} --reload"

```