### PR TITLE
#589 exit getting course early when limit is reached

### DIFF
--- a/backend/ccm/canvas_api/admin_sections_api_handler.py
+++ b/backend/ccm/canvas_api/admin_sections_api_handler.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from asgiref.sync import async_to_sync
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
+from itertools import islice
 
 from canvasapi.exceptions import CanvasException
 from canvasapi.account import Account
@@ -17,8 +18,6 @@ from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialMan
 from backend.ccm.canvas_api.constants import MAX_CONCURRENCY, MAX_SEARCH_COURSES
 from backend.ccm.canvas_api.exceptions import CanvasErrorHandler, HTTPAPIError
 from backend.ccm.canvas_api.canvasapi_serializer import AdminSectionsQuerySerializer, CanvasObjectROSerializer
-from backend.ccm.canvas_api.instructor_sections_api_handler import CanvasInstructorSectionsAPIHandler
-from backend.ccm.utils import timeit
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +31,7 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
     courses_allowed_fields = {"id", "name", "enrollment_term_id"}
     sections_allowed_fields = {"id", "name", "course_id", "nonxlist_course_id", "total_students"}
     serializer_class = AdminSectionsQuerySerializer  # Ensures Swagger UI recognizes it
+    COURSE_LIMIT_ERROR_MESSAGE = 'Too many courses matched your search term; please refine your search.'
 
     def __init__(self, credential_manager=None):
         self.credential_manager = credential_manager or CanvasCredentialManager()
@@ -106,6 +106,11 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
             if not courses_success:
                 self.canvas_error.handle_canvas_api_exceptions(courses_response)
                 return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
+
+            if len(courses_response) >= MAX_SEARCH_COURSES:
+                relevantParams: str = self._error_message_too_many_courses(coursesQueryParams)
+                self.canvas_error.handle_canvas_api_exceptions(HTTPAPIError(relevantParams, Exception(self.COURSE_LIMIT_ERROR_MESSAGE)))
+                return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
             
             #3. Attach sections to course results
             sections_success, sections_response = self._attach_sections_to_courses(courses_response, course_instance_map)
@@ -118,6 +123,11 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
             self.canvas_error.handle_canvas_api_exceptions(e)
             logger.error(f"Error retrieving admin sections for user id {request.user.id}")
             return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
+
+    def _error_message_too_many_courses(self, coursesQueryParams) -> str:
+        relevantParams = {'by_teachers': coursesQueryParams.get('by_teachers'), 'search_term': coursesQueryParams.get('search_term')}
+        logger.error(f"Query with the following search term(s) returned too many course results: {relevantParams}")
+        return str(relevantParams)
         
     def _get_accessible_accounts(self, canvas_api, username, course_name, instructor_name) -> tuple[list[dict], dict[int, Account]]:
         # Retrieve all user accounts, filter to root accounts and subaccounts of unlisted accounts
@@ -173,12 +183,14 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
             account: Account):
         """ Synchronous helper to fetch and append courses from a given account. """
         try:
-            account_courses = list(account.get_courses(**coursesQueryParams))
+            logger.info(f"Retrieving courses from account id {account.id}")
+            account_courses = list(islice(account.get_courses(**coursesQueryParams), MAX_SEARCH_COURSES))
+            logger.info(f"Retrieved courses {len(account_courses)} courses from account id {account.id}")
+
             # Number of courses cannot exceed maxiumum
-            if len(account_courses) > MAX_SEARCH_COURSES:
-                relevantParams = {'by_teachers': coursesQueryParams.get('by_teachers'), 'search_term': coursesQueryParams.get('search_term')}
-                logger.error(f"Query with the following search term(s) returned too many course results: {relevantParams}")
-                raise Exception(f"Course search exceeded maximum of {MAX_SEARCH_COURSES} courses in account. Please refine your search.")
+            if len(account_courses) >= MAX_SEARCH_COURSES:
+                self._error_message_too_many_courses(coursesQueryParams)
+                raise Exception(self.COURSE_LIMIT_ERROR_MESSAGE)
 
             course_instance_map.update({course.id: course for course in account_courses})
             serializer = CanvasObjectROSerializer(account_courses, allowed_fields=self.courses_allowed_fields, many=True)

--- a/backend/ccm/canvas_api/admin_sections_api_handler.py
+++ b/backend/ccm/canvas_api/admin_sections_api_handler.py
@@ -1,4 +1,4 @@
-import asyncio
+import asyncio, time
 from http import HTTPStatus
 import logging
 from rest_framework import authentication, permissions
@@ -10,6 +10,7 @@ from asgiref.sync import async_to_sync
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 from drf_spectacular.types import OpenApiTypes
 from itertools import islice
+from datetime import timedelta
 
 from canvasapi.exceptions import CanvasException
 from canvasapi.account import Account
@@ -18,6 +19,7 @@ from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialMan
 from backend.ccm.canvas_api.constants import MAX_CONCURRENCY, MAX_SEARCH_COURSES, CANVAS_ROOT_ACCOUNT_ID
 from backend.ccm.canvas_api.exceptions import CanvasErrorHandler, HTTPAPIError
 from backend.ccm.canvas_api.canvasapi_serializer import AdminSectionsQuerySerializer, CanvasObjectROSerializer
+from backend.ccm.utils import timeit
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +68,7 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
             )
         ],
     )
+    @timeit
     def get(self, request: Request) -> Response:
         """
         Get sections data from Canvas for admins.
@@ -102,18 +105,24 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
             
             #2. Get courses by account, by search parameters and term_id
             course_instance_map = {}
+            start_time_course: float = time.perf_counter()
             courses_success, courses_response = self._get_courses(coursesQueryParams, course_instance_map, accessible_account_ids, account_instance_map)
+            logger.info(f"getting courses from all accounts: {accessible_account_ids} took {timedelta(seconds=(time.perf_counter() - start_time_course))} seconds")
+            
             if not courses_success:
                 self.canvas_error.handle_canvas_api_exceptions(courses_response)
                 return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
 
             if len(courses_response) >= MAX_SEARCH_COURSES:
-                relevantParams: str = self._error_message_too_many_courses(coursesQueryParams)
-                self.canvas_error.handle_canvas_api_exceptions(HTTPAPIError(relevantParams, Exception(self.COURSE_LIMIT_ERROR_MESSAGE)))
+                failed_input: str = self._failed_input_get_account_courses(coursesQueryParams)
+                self.canvas_error.handle_canvas_api_exceptions(HTTPAPIError(failed_input, Exception(self.COURSE_LIMIT_ERROR_MESSAGE)))
                 return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
             
             #3. Attach sections to course results
+            start_time_sections: float = time.perf_counter()
             sections_success, sections_response = self._attach_sections_to_courses(courses_response, course_instance_map)
+            logger.info(f"getting sections to courses {len(courses_response)} took {timedelta(seconds=(time.perf_counter() - start_time_sections))} seconds")
+            
             if not sections_success:
                 self.canvas_error.handle_canvas_api_exceptions(sections_response)
                 return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
@@ -124,11 +133,10 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
             logger.error(f"Error retrieving admin sections for user id {request.user.id}")
             return Response(self.canvas_error.to_dict(), status=self.canvas_error.to_dict().get('statusCode'))
 
-    def _error_message_too_many_courses(self, coursesQueryParams) -> str:
-        relevantParams = {'by_teachers': coursesQueryParams.get('by_teachers'), 'search_term': coursesQueryParams.get('search_term')}
-        logger.error(f"Query with the following search term(s) returned too many course results: {relevantParams}")
-        return str(relevantParams)
-        
+    def _failed_input_get_account_courses(self, coursesQueryParams) -> str:
+        return str(coursesQueryParams.get('by_teachers') or coursesQueryParams.get('search_term') or 'No input search term provided')
+
+    @timeit
     def _get_accessible_accounts(self, canvas_api, username, course_name, instructor_name) -> tuple[list[dict], dict[int, Account]]:
         # Retrieve all user accounts, filter to root accounts and subaccounts of unlisted accounts
         logger.info(f"Retrieving accessible accounts for user {username}")
@@ -141,7 +149,7 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
                     account.parent_account_id is None 
                     or not(account.parent_account_id in account_instance_map)
             ]
-            logger.info(f"Accessible account IDs: {accessible_account_ids}")
+            logger.info(f"Accessible user: {username} account IDs: {accessible_account_ids}")
             # If the canonical root account id 1 is accessible, prefer it and ignore others
             if CANVAS_ROOT_ACCOUNT_ID in accessible_account_ids:
                 logger.info(f"Root account id {CANVAS_ROOT_ACCOUNT_ID} is accessible; restricting search to account {CANVAS_ROOT_ACCOUNT_ID} only")
@@ -175,9 +183,26 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
             account_instance_map[account_id]
         ) for account_id in accessible_account_ids]
         await asyncio.gather(*tasks, return_exceptions=True)
-        
+
+        # Deduplicate errors to avoid reporting the same failure multiple times
+        errors = self._check_dups_error(errors)
+
         success = len(errors) == 0 # boolean to indicate if errors occurred
         return success, filtered_courses_data if success else errors
+
+    def _check_dups_error(self, errors):
+        """ Deduplicate errors based on failed_input and original_exception message. """
+        if errors:
+            deduped = []
+            seen = set()
+            for err in errors:
+                if isinstance(err, HTTPAPIError):
+                    key = (err.failed_input, str(err.original_exception))
+                if key not in seen:
+                    seen.add(key)
+                    deduped.append(err)
+            errors = deduped
+        return errors
         
     def _get_courses_by_account_sync(
             self, 
@@ -187,22 +212,22 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
             account: Account):
         """ Synchronous helper to fetch and append courses from a given account. """
         try:
-            logger.info(f"Retrieving courses from account id {account.id}")
+            # set the local id you requested
+            start_time: float = time.perf_counter()
+            logger.debug(f"Retrieving courses for account: {account.id} at {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())}")
             account_courses = list(islice(account.get_courses(**coursesQueryParams), MAX_SEARCH_COURSES))
-            logger.info(f"Retrieved courses {len(account_courses)} courses from account id {account.id}")
+            logger.debug(f"Retrieved courses {len(account_courses)} courses from account id {account.id}")
 
             # Number of courses cannot exceed maxiumum
             if len(account_courses) >= MAX_SEARCH_COURSES:
-                self._error_message_too_many_courses(coursesQueryParams)
                 raise Exception(self.COURSE_LIMIT_ERROR_MESSAGE)
 
             course_instance_map.update({course.id: course for course in account_courses})
             serializer = CanvasObjectROSerializer(account_courses, allowed_fields=self.courses_allowed_fields, many=True)
             filtered_courses_data.extend(serializer.data)
-            logger.info(f"Found {len(serializer.data)} courses in account id {account.id} matching search criteria")
+            logger.info(f"getting courses from account: {account.id} took {timedelta(seconds=(time.perf_counter() - start_time))} seconds")
         except (CanvasException, Exception) as e:
-            failed_input = f"account id {account.id} with params {coursesQueryParams}"
-            raise HTTPAPIError(failed_input, e)
+            raise HTTPAPIError(self._failed_input_get_account_courses(coursesQueryParams), e)
     
     @async_to_sync
     async def _attach_sections_to_courses(
@@ -235,7 +260,7 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
             sections = course_instance.get_sections(include=['total_students'], per_page=100)
             section_serializer = CanvasObjectROSerializer(sections, allowed_fields=self.sections_allowed_fields, many=True)
             course['sections'] = section_serializer.data
-            logger.info(f"Attached {len(course['sections'])} sections to course_id {course.get('id')}")
+            logger.debug(f"Attached {len(course['sections'])} sections to course_id {course.get('id')}")
         except (CanvasException, Exception) as e:
             failed_input = f"course id {course.get('id')}"
             raise HTTPAPIError(failed_input, e)

--- a/backend/ccm/canvas_api/admin_sections_api_handler.py
+++ b/backend/ccm/canvas_api/admin_sections_api_handler.py
@@ -15,7 +15,7 @@ from canvasapi.exceptions import CanvasException
 from canvasapi.account import Account
 from canvasapi.course import Course
 from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
-from backend.ccm.canvas_api.constants import MAX_CONCURRENCY, MAX_SEARCH_COURSES
+from backend.ccm.canvas_api.constants import MAX_CONCURRENCY, MAX_SEARCH_COURSES, CANVAS_ROOT_ACCOUNT_ID
 from backend.ccm.canvas_api.exceptions import CanvasErrorHandler, HTTPAPIError
 from backend.ccm.canvas_api.canvasapi_serializer import AdminSectionsQuerySerializer, CanvasObjectROSerializer
 
@@ -141,7 +141,11 @@ class CanvasAdminSectionsAPIHandler(LoggingMixin, APIView):
                     account.parent_account_id is None 
                     or not(account.parent_account_id in account_instance_map)
             ]
-            logger.info(f"Found {len(accessible_account_ids)} of {len(accounts)} accounts accessible to admin user")
+            logger.info(f"Accessible account IDs: {accessible_account_ids}")
+            # If the canonical root account id 1 is accessible, prefer it and ignore others
+            if CANVAS_ROOT_ACCOUNT_ID in accessible_account_ids:
+                logger.info(f"Root account id {CANVAS_ROOT_ACCOUNT_ID} is accessible; restricting search to account {CANVAS_ROOT_ACCOUNT_ID} only")
+                return [CANVAS_ROOT_ACCOUNT_ID], account_instance_map
             return accessible_account_ids, account_instance_map
         except (CanvasException, Exception) as e:
             failed_input = f"username {username}, course_name {course_name}, instructor_name {instructor_name}"

--- a/backend/tests/test_admin_sections_api_handler.py
+++ b/backend/tests/test_admin_sections_api_handler.py
@@ -281,3 +281,49 @@ class CanvasAdminSectionsAPIHandlerTests(APITestCase):
 
         # Ensure the underlying generator was consumed exactly the number of items it yielded
         self.assertEqual(counter['count'], num_courses)
+
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
+    def test_get_admin_sections_prefers_root_account(self, mock_get_canvasapi_instance):
+        """If CANVAS_ROOT_ACCOUNT_ID is present in accounts, only that account should be searched."""
+        mock_canvas = mock_get_canvasapi_instance.return_value
+
+        # course belonging to root account
+        root_course = make_mock_course(1001, 'Root Course', self.term_id, sections=[])
+        # course belonging to another account
+        other_course = make_mock_course(2002, 'Other Course', self.term_id, sections=[])
+
+        account_root = make_mock_account(1, None, courses=[root_course])
+        account_other = make_mock_account(2, None, courses=[other_course])
+
+        mock_canvas.get_accounts.return_value = [account_root, account_other]
+
+        response = self.client.get(f'{self.url}?term_id={self.term_id}&instructor_name={self.instructor_name}')
+
+        # Should return only courses from the root account (id 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Expect only the root course to be present
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], root_course.id)
+
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
+    def test_get_admin_sections_preserves_multiple_accounts(self, mock_get_canvasapi_instance):
+        """When multiple non-root accounts are accessible, courses from all accounts are returned."""
+        mock_canvas = mock_get_canvasapi_instance.return_value
+
+        # courses for two different non-root accounts
+        course_a = make_mock_course(1231, 'Course A', self.term_id, sections=[])
+        course_b = make_mock_course(2342, 'Course B', self.term_id, sections=[])
+
+        account_a = make_mock_account(123, None, courses=[course_a])
+        account_b = make_mock_account(234, None, courses=[course_b])
+
+        mock_canvas.get_accounts.return_value = [account_a, account_b]
+
+        response = self.client.get(f'{self.url}?term_id={self.term_id}&instructor_name={self.instructor_name}')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # both courses from both accounts should be present
+        returned_ids = {c['id'] for c in response.data}
+        self.assertIn(course_a.id, returned_ids)
+        self.assertIn(course_b.id, returned_ids)
+        self.assertEqual(len(response.data), 2)

--- a/backend/tests/test_admin_sections_api_handler.py
+++ b/backend/tests/test_admin_sections_api_handler.py
@@ -11,6 +11,9 @@ from rest_framework.exceptions import ErrorDetail
 
 from backend.ccm.canvas_api.canvas_credential_manager import CanvasCredentialManager
 from backend.ccm.canvas_api.constants import MAX_SEARCH_COURSES
+from backend.ccm.canvas_api.exceptions import HTTPAPIError
+from backend.ccm.canvas_api.admin_sections_api_handler import CanvasAdminSectionsAPIHandler
+from canvasapi.exceptions import ResourceDoesNotExist
 
 def make_mock_section(section_data={}):
     """
@@ -223,7 +226,26 @@ class CanvasAdminSectionsAPIHandlerTests(APITestCase):
         
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertIn('Too many courses matched your search term; please refine your search.', response.data['errors'][0]['message'])
-        self.assertIn('account id', response.data['errors'][0]['failedInput'])
+        self.assertIn("['sis_login_id:jdoe']", response.data['errors'][0]['failedInput'])
+
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
+    def test_get_admin_sections_exact_max_courses_raises_error(self, mock_get_canvasapi_instance):
+        """If the total courses returned equals MAX_SEARCH_COURSES, handler should treat it as too many and return an error."""
+        mock_canvas = mock_get_canvasapi_instance.return_value
+        courses = []
+        # Return exactly MAX_SEARCH_COURSES to test boundary condition
+        for i in range(MAX_SEARCH_COURSES):
+            courses.append(make_mock_course(i, f'Course {i}', self.term_id, sections=[]))
+        account1 = make_mock_account(10, None, courses=courses)
+        mock_canvas.get_accounts.return_value = [account1]
+
+        response = self.client.get(f'{self.url}?term_id={self.term_id}&instructor_name={self.instructor_name}')
+        print(response.data)
+
+        # The handler currently uses >= MAX_SEARCH_COURSES as the trigger, so equal should raise
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertIn('Too many courses matched your search term; please refine your search.', response.data['errors'][0]['message'])
+        self.assertIn("['sis_login_id:jdoe']", response.data['errors'][0]['failedInput'])
 
     @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
     def test_get_admin_sections_pagination_stops(self, mock_get_canvasapi_instance):
@@ -327,3 +349,100 @@ class CanvasAdminSectionsAPIHandlerTests(APITestCase):
         self.assertIn(course_a.id, returned_ids)
         self.assertIn(course_b.id, returned_ids)
         self.assertEqual(len(response.data), 2)
+
+    def test_check_dups_error_only_duplicates_removed(self):
+        """Ensure _check_dups_error removes only duplicated HTTPAPIError entries and preserves distinct ones."""
+        handler = CanvasAdminSectionsAPIHandler()
+
+        dup_message = 'Too many courses matched your search term; please refine your search.'
+        errors = [
+            HTTPAPIError('001', Exception(dup_message)),
+            HTTPAPIError('001', Exception(dup_message)),
+            HTTPAPIError('test', ResourceDoesNotExist('Not Found')),
+        ]
+
+        deduped = handler._check_dups_error(errors)
+
+        # Duplicates should be removed, leaving 2 unique errors
+        self.assertEqual(len(deduped), 2)
+        failed_inputs = {e.failed_input for e in deduped}
+        self.assertIn('001', failed_inputs)
+        self.assertIn('test', failed_inputs)
+
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
+    def test_too_many_single_account_triggers_account_level(self, mock_get_canvasapi_instance):
+        """A single account yielding >= MAX_SEARCH_COURSES should trigger the per-account limit path.
+        We validate this by using a generator and asserting it was advanced up to the islice limit.
+        """
+        mock_canvas = mock_get_canvasapi_instance.return_value
+
+        counter = {'count': 0}
+
+        def gen_courses():
+            # yield a lot (>= MAX_SEARCH_COURSES) so the handler's islice will cut at MAX_SEARCH_COURSES
+            for i in range(MAX_SEARCH_COURSES * 2):
+                counter['count'] += 1
+                yield make_mock_course(i, f'Course {i}', self.term_id, sections=[])
+
+        account1 = make_mock_account(10, None)
+        account1.get_courses.return_value = gen_courses()
+        mock_canvas.get_accounts.return_value = [account1]
+
+        response = self.client.get(f'{self.url}?term_id={self.term_id}&instructor_name={self.instructor_name}')
+
+        # per-account path raises when a single account produces >= MAX_SEARCH_COURSES
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        # ensure the underlying generator was only advanced up to the islice limit
+        self.assertEqual(counter['count'], MAX_SEARCH_COURSES)
+
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
+    def test_too_many_across_multiple_accounts_triggers_top_level(self, mock_get_canvasapi_instance):
+        """Multiple accounts whose combined course counts reach >= MAX_SEARCH_COURSES should trigger the top-level check
+        (no single account reaches the per-account threshold).
+        """
+        mock_canvas = mock_get_canvasapi_instance.return_value
+
+        # create several accounts each with fewer than MAX_SEARCH_COURSES courses
+        per_account = MAX_SEARCH_COURSES // 4
+        accounts = []
+        total = 0
+        for aid in range(5):
+            courses = []
+            for i in range(per_account):
+                courses.append(make_mock_course(aid * 1000 + i, f'Course {i}', self.term_id, sections=[]))
+                total += 1
+            accounts.append(make_mock_account(100 + aid, None, courses=courses))
+
+        # ensure combined total >= MAX_SEARCH_COURSES
+        self.assertTrue(total >= MAX_SEARCH_COURSES)
+        mock_canvas.get_accounts.return_value = accounts
+
+        response = self.client.get(f'{self.url}?term_id={self.term_id}&instructor_name={self.instructor_name}')
+
+        # top-level triggers error when accumulated courses reach the threshold
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        # In this scenario no single account should have been advanced to MAX_SEARCH_COURSES by islice
+        # (we used lists so there are no generator counters); success here is the handler returning the error
+
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
+    def test_duplicate_too_many_errors_are_deduplicated(self, mock_get_canvasapi_instance):
+        """If two accounts raise identical HTTPAPIError (same failed_input and message), the handler should dedupe them and return a single error."""
+        mock_canvas = mock_get_canvasapi_instance.return_value
+
+        def gen_courses():
+            for i in range(MAX_SEARCH_COURSES):
+                yield make_mock_course(i, f'Course {i}', self.term_id, sections=[])
+
+        account1 = make_mock_account(10, None)
+        account1.get_courses.return_value = gen_courses()
+        account2 = make_mock_account(20, None)
+        account2.get_courses.return_value = gen_courses()
+
+        mock_canvas.get_accounts.return_value = [account1, account2]
+
+        response = self.client.get(f'{self.url}?term_id={self.term_id}&instructor_name={self.instructor_name}')
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        # errors should be deduplicated to 1
+        self.assertEqual(len(response.data['errors']), 1)
+        self.assertIn('Too many courses matched your search term; please refine your search.', response.data['errors'][0]['message'])

--- a/backend/tests/test_admin_sections_api_handler.py
+++ b/backend/tests/test_admin_sections_api_handler.py
@@ -222,5 +222,62 @@ class CanvasAdminSectionsAPIHandlerTests(APITestCase):
         response = self.client.get(f'{self.url}?term_id={self.term_id}&instructor_name={self.instructor_name}')
         
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-        self.assertIn('Course search exceeded maximum', response.data['errors'][0]['message'])
+        self.assertIn('Too many courses matched your search term; please refine your search.', response.data['errors'][0]['message'])
         self.assertIn('account id', response.data['errors'][0]['failedInput'])
+
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
+    def test_get_admin_sections_pagination_stops(self, mock_get_canvasapi_instance):
+        """Ensure that islice limits consumption of the underlying iterator to MAX_SEARCH_COURSES."""
+        mock_canvas = mock_get_canvasapi_instance.return_value
+
+        counter = {'count': 0}
+
+        def course_generator():
+            # yield twice as many as the limit
+            for i in range(MAX_SEARCH_COURSES * 2):
+                counter['count'] += 1
+                # yield a course object compatible with the handler
+                yield make_mock_course(i, f'Course {i}', self.term_id, sections=[])
+
+        account1 = make_mock_account(10, None)
+        # return a fresh generator when get_courses is called
+        account1.get_courses.return_value = course_generator()
+        mock_canvas.get_accounts.return_value = [account1]
+
+        response = self.client.get(f'{self.url}?term_id={self.term_id}&instructor_name={self.instructor_name}')
+        
+
+        # Handler currently raises when it sees >= MAX_SEARCH_COURSES, so expect an error response
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        # But the underlying generator should have been advanced only up to the islice limit
+        self.assertEqual(counter['count'], MAX_SEARCH_COURSES)
+
+    @patch.object(CanvasCredentialManager, 'get_canvasapi_instance')
+    def test_get_admin_sections_pagination_not_stopped(self, mock_get_canvasapi_instance):
+        """If get_courses yields fewer than MAX_SEARCH_COURSES, handler returns success and
+        generator is fully consumed (no premature stop)."""
+        mock_canvas = mock_get_canvasapi_instance.return_value
+
+        counter = {'count': 0}
+        num_courses = MAX_SEARCH_COURSES - 1
+
+        def course_generator():
+            for i in range(num_courses):
+                counter['count'] += 1
+                yield make_mock_course(i, f'Course {i}', self.term_id, sections=[])
+
+        account1 = make_mock_account(10, None)
+        account1.get_courses.return_value = course_generator()
+        mock_canvas.get_accounts.return_value = [account1]
+
+        response = self.client.get(f'{self.url}?term_id={self.term_id}&instructor_name={self.instructor_name}')
+
+        # Expect success when results are below the threshold
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # The response should include all courses returned by the generator
+        self.assertEqual(len(response.data), num_courses)
+
+        # Ensure the underlying generator was consumed exactly the number of items it yielded
+        self.assertEqual(counter['count'], num_courses)


### PR DESCRIPTION
Fixes #589 

Check for Limit is happening at 2 places
1. Getting courses for single account call
2. Top level after fetching all the courses in multiple account before proceeding to section call. This way sections are not called
3. If user is part of multiple account like [1, 232, 34], only searches courses from [1]. Root account has all courses , this will save some time and is an improvement.

One side effect of this is getting courses in multiple account is an async process so if user is part of multiple accounts there is no way to stop the process until all the calls that are finished. since we are using a combination of coroutines + Python thread. There is no way a thread can be stopped once started. we are using this combination approach since `canvasapi` is sync HTTP client. ~~If we have to stop `gather` tasks it will be a complicated solution~~.  

Since Getting courses for all the accounts the user belongs to is async call, and Sub-account admin might be practically be part of 2 or 3 account, so the async call (let say for fetching from 3 accounts) all starts at same time, so the amount of time take seem to be same when API call hits 400 count limit. I personally feel this is a Optimal solution since the blocking of time is coming from Pagination getting more courses from the account due to sync HTTP client.  

Currently for seeing `too many courses error` taking about **~8sec**, Node CCM takes **5sec**

I feel we still should extend the timeout on the router, currently without nothing it will times out 30s. Current setting is 30min. since 400 courses making sections call might take another ~17secs

Unit Test written to check this specific use case

----------------------------------
Test Plan 1: 
1. Add your self to Aerospace Engineering [211] account, you should be root admin
2. Search by "AEROSP" 
3. This should only fetch courses from Root account

-----------------------------------
Test Plan 2: 
1. Pick a user who is part of multiple account ( but not root)
2.  Search by  common course text '101'
3. This should exit in about 10 sec and also fetches courses of those 2 sub-accounts




