### PR TITLE
#597 make app TZ as configuraable

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -155,8 +155,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = os.getenv('TIME_ZONE', 'America/Detroit')
-
+TIME_ZONE = os.getenv('TIME_ZONE', os.getenv("TZ", "America/Detroit"))
 USE_I18N = True
 
 USE_TZ = True

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -155,7 +155,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = os.getenv('TIME_ZONE', 'America/Detroit')
 
 USE_I18N = True
 

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -178,6 +178,29 @@ class TestCanvasAdminApiTokenLogging(SimpleTestCase):
         self.assertEqual(settings.CUSTOM_CANVAS_ROLES, {'assistant': 34, 'librarian': 21})
 
 
+class TestTimeZoneSetting(SimpleTestCase):
+    def setUp(self):
+        self.env_key = 'TIME_ZONE'
+        self.old_env = os.environ.get(self.env_key)
+        if self.env_key in os.environ:
+            del os.environ[self.env_key]
+
+    def tearDown(self):
+        if self.old_env is not None:
+            os.environ[self.env_key] = self.old_env
+        elif self.env_key in os.environ:
+            del os.environ[self.env_key]
+
+    def test_time_zone_default(self):
+        importlib.reload(settings)
+        self.assertEqual(settings.TIME_ZONE, 'America/Detroit')
+
+    def test_time_zone_env_override(self):
+        os.environ['TIME_ZONE'] = 'UTC'
+        importlib.reload(settings)
+        self.assertEqual(settings.TIME_ZONE, 'UTC')
+
+
     # Tests for EMAIL_FROM and EMAIL_SUPPORT settings
     class TestEmailSettings(SimpleTestCase):
         def test_email_host_user_password_defaults(self):

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -200,6 +200,17 @@ class TestTimeZoneSetting(SimpleTestCase):
         importlib.reload(settings)
         self.assertEqual(settings.TIME_ZONE, 'UTC')
 
+    def test_time_zone_uses_tz_when_time_zone_unset(self):
+        # Ensure TIME_ZONE falls back to TZ env var when TIME_ZONE is not set
+        # Clear TIME_ZONE and set TZ
+        if 'TIME_ZONE' in os.environ:
+            del os.environ['TIME_ZONE']
+        os.environ['TZ'] = 'Asia/Tokyo'
+        importlib.reload(settings)
+        self.assertEqual(settings.TIME_ZONE, 'Asia/Tokyo')
+        # Clean up
+        del os.environ['TZ']
+
 
     # Tests for EMAIL_FROM and EMAIL_SUPPORT settings
     class TestEmailSettings(SimpleTestCase):

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -106,3 +106,6 @@ CANVAS_ADMIN_API_TOKEN=<your_canvas_admin_api_token>
 
 # Guest account creation link sent to External Users feature in an email
 GUEST_ACCOUNT_CREATION_LINK=https://friend.weblogin.umich.edu/friend/
+
+# Set the time zone for the application
+# TIME_ZONE=America/Detroit


### PR DESCRIPTION
Fixes #597

 The best way to test is 
1. Launch CCM
2. Go to Admin --> API Request Logs
3. this should show the timestamp based on the `TIME_ZONE` setting