### PR TITLE
Add dependabot.yml similar to our other apps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
         patterns: ["*"]
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/ccm-web/"
     schedule:
       interval: "weekly"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
         patterns: ["*"]
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
-    directory: "/ccm-web/"
+    directory: "/ccm_web/"
     schedule:
       interval: "weekly"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Maintain dependencies for python
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+      # Update this manually when updating Django/Python to supported version
+      - dependency-name: "django-filter"
+        versions: ["*"]
+    groups:
+      all-python-dependencies:
+        patterns: ["*"]
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-npm-dependencies:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Dependabot should manage version updates similar to our other applications, not updating to majors and avoiding updates to django-filter