### PR TITLE
fix: correct async error ordering in tests, rename canvas scopes cons…

### DIFF
--- a/backend/ccm/canvas_api/course_section_api_handler.py
+++ b/backend/ccm/canvas_api/course_section_api_handler.py
@@ -188,8 +188,11 @@ class CanvasMergeSectionsToCourseView(LoggingMixin, APIView):
     @async_to_sync
     async def _merge_sections(self, canvas_api: Canvas, course_id: int, section_ids: list[int]):
         """
-        Merge sections to a course via Canvas API crosslist endpoint. 
-        Guarded by a semaphore for concurrency control
+        Merge sections to a course via the Canvas crosslist endpoint.
+
+        Uses a semaphore for bounded concurrency. If any task fails, returned
+        errors are collected in task-completion order, which is non-deterministic.
+        Returns a tuple of (success, results_or_errors).
         """
         max_concurrent = MAX_CONCURRENCY 
         semaphore = asyncio.Semaphore(max_concurrent)
@@ -266,8 +269,11 @@ class CanvasUnmergeSectionsView(LoggingMixin, APIView):
     @async_to_sync
     async def _unmerge_sections(self, canvas_api: Canvas, section_ids: list[int]):
         """
-        Unmerge sections via Canvas API un-crosslist endpoint. 
-        Guarded by a semaphore for concurrency control
+        Unmerge sections via the Canvas un-crosslist endpoint.
+
+        Uses a semaphore for bounded concurrency. If any task fails, returned
+        errors are collected in task-completion order, which is non-deterministic.
+        Returns a tuple of (success, results_or_errors).
         """
         max_concurrent = MAX_CONCURRENCY 
         semaphore = asyncio.Semaphore(max_concurrent)

--- a/backend/ccm/canvas_scopes.py
+++ b/backend/ccm/canvas_scopes.py
@@ -1,4 +1,4 @@
-DEFAUlT_CANVAS_SCOPES = [
+DEFAULT_CANVAS_SCOPES = [
     # Courses
     'url:GET|/api/v1/courses',
     'url:GET|/api/v1/courses/:id',

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -15,7 +15,7 @@ import os
 from django.core.management.utils import get_random_secret_key
 from csp.constants import UNSAFE_INLINE, UNSAFE_EVAL
 from backend.ccm.utils import parse_csp
-from backend.ccm.canvas_scopes import DEFAUlT_CANVAS_SCOPES
+from backend.ccm.canvas_scopes import DEFAULT_CANVAS_SCOPES
 from datetime import timedelta
 import json
 import logging
@@ -278,7 +278,7 @@ except Exception:
 if isinstance((env_canvas_scopes := os.getenv('CANVAS_OAUTH_SCOPES')), str):
     CANVAS_OAUTH_SCOPES = env_canvas_scopes.split(',')
 else:
-    CANVAS_OAUTH_SCOPES = DEFAUlT_CANVAS_SCOPES
+    CANVAS_OAUTH_SCOPES = DEFAULT_CANVAS_SCOPES
 
 REST_FRAMEWORK = {
     'EXCEPTION_HANDLER': 'backend.ccm.canvas_api.drf_custom_exception_handler.custom_exception_handler',

--- a/backend/tests/test_canvas_scope.py
+++ b/backend/tests/test_canvas_scope.py
@@ -1,6 +1,6 @@
 import unittest
 from django.test import SimpleTestCase
-from backend.ccm.canvas_scopes import DEFAUlT_CANVAS_SCOPES
+from backend.ccm.canvas_scopes import DEFAULT_CANVAS_SCOPES
 
 class TestCanvasScope(SimpleTestCase):
     def test_canvas_scopes(self):
@@ -17,7 +17,7 @@ class TestCanvasScope(SimpleTestCase):
             'url:GET|/api/v1/accounts',
             'url:GET|/api/v1/accounts/:account_id/courses',
         ]
-        self.assertEqual(DEFAUlT_CANVAS_SCOPES, expected_scopes, "Canvas scopes do not match the expected values")
+        self.assertEqual(DEFAULT_CANVAS_SCOPES, expected_scopes, "Canvas scopes do not match the expected values")
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_course_merge_unmerge_sections_view.py
+++ b/backend/tests/test_course_merge_unmerge_sections_view.py
@@ -130,10 +130,10 @@ class CanvasCourseMergeSectionsViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertIn('errors', response.data)
         self.assertEqual(len(response.data['errors']), 2)
-        self.assertEqual(response.data['errors'][0]['message'], 'Canvas API error during cross-listing')
-        self.assertIn('402', response.data['errors'][0]['failedInput'])
-        self.assertEqual(response.data['errors'][1]['message'], 'Canvas API error during cross-listing')
-        self.assertIn('403', response.data['errors'][1]['failedInput'])
+        self.assertTrue(all(error['message'] == 'Canvas API error during cross-listing' for error in response.data['errors']))
+        failed_inputs = [error['failedInput'] for error in response.data['errors']]
+        self.assertTrue(any('402' in failed_input for failed_input in failed_inputs))
+        self.assertTrue(any('403' in failed_input for failed_input in failed_inputs))
 
 
 class CanvasCourseUnmergeSectionsViewTests(APITestCase):

--- a/backend/tests/test_views.py
+++ b/backend/tests/test_views.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 from canvas_oauth.models import CanvasOAuth2Token
 from django.utils import timezone
-from backend.ccm.canvas_scopes import DEFAUlT_CANVAS_SCOPES
+from backend.ccm.canvas_scopes import DEFAULT_CANVAS_SCOPES
 from unittest import mock
 
 
@@ -38,7 +38,7 @@ class TestViews(TestCase):
         url_redirect = response.url
         self.assertIn('/login/oauth2/auth', url_redirect)
         self.assertIn('response_type=code', url_redirect)
-        scopes_encoded = '+'.join([scope.replace('|', '%7C').replace('/', '%2F').replace(':', '%3A') for scope in DEFAUlT_CANVAS_SCOPES])
+        scopes_encoded = '+'.join([scope.replace('|', '%7C').replace('/', '%2F').replace(':', '%3A') for scope in DEFAULT_CANVAS_SCOPES])
         self.assertIn(f'scope={scopes_encoded}', url_redirect)
 
     @mock.patch('webpack_loader.loader.WebpackLoader.get_bundle', return_value={})


### PR DESCRIPTION
…tant

- Update test_merge_sections_partial_failure to assert error presence by membership rather than by position, since concurrent async tasks return errors in non-deterministic (task-completion) order

- Add docstrings to _merge_sections and _unmerge_sections documenting the non-deterministic error ordering and (success, results_or_errors) return contract

- Rename DEFAUlT_CANVAS_SCOPES → DEFAULT_CANVAS_SCOPES in canvas_scopes.py, settings.py, test_canvas_scope.py, and test_views.py

Fixes #620
Fixes #621