### PR TITLE
Adding appropriate headers to avoid triggering automated responses

### DIFF
--- a/backend/ccm/canvas_api/email_users.py
+++ b/backend/ccm/canvas_api/email_users.py
@@ -37,7 +37,8 @@ def send_email(
         )
         email.content_subtype = "html"
         # Add headers to suppress automatic replies (out-of-office, vacation, etc.)
-        email.extra_headers = getattr(settings, 'EMAIL_EXTRA_HEADERS', {}) or {}
+        headers = getattr(settings, 'EMAIL_EXTRA_HEADERS', {}) or {}
+        email.extra_headers = headers if isinstance(headers, dict) else {}
         if attachment:
             filename, content, mime_type = attachment
             email.attach(filename, content, mime_type)

--- a/backend/ccm/canvas_api/email_users.py
+++ b/backend/ccm/canvas_api/email_users.py
@@ -37,7 +37,7 @@ def send_email(
         )
         email.content_subtype = "html"
         # Add headers to suppress automatic replies (out-of-office, vacation, etc.)
-        email.extra_headers = getattr(settings, 'EMAIL_EXTRA_HEADERS', {})
+        email.extra_headers = getattr(settings, 'EMAIL_EXTRA_HEADERS', {}) or {}
         if attachment:
             filename, content, mime_type = attachment
             email.attach(filename, content, mime_type)

--- a/backend/ccm/canvas_api/email_users.py
+++ b/backend/ccm/canvas_api/email_users.py
@@ -36,6 +36,8 @@ def send_email(
             connection=connection
         )
         email.content_subtype = "html"
+        # Add headers to suppress automatic replies (out-of-office, vacation, etc.)
+        email.extra_headers = getattr(settings, 'EMAIL_EXTRA_HEADERS', {})
         if attachment:
             filename, content, mime_type = attachment
             email.attach(filename, content, mime_type)

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -309,10 +309,11 @@ Q_CLUSTER = {
 }
 
 # Custom Canvas Roles
+DEFAULT_CUSTOM_CANVAS_ROLES = {'assistant': 34, 'librarian': 21}
 try:
-    CUSTOM_CANVAS_ROLES = json.loads(os.getenv('CUSTOM_CANVAS_ROLES', '{"assistant": 34, "librarian": 21}'))
+    CUSTOM_CANVAS_ROLES = json.loads(os.getenv('CUSTOM_CANVAS_ROLES', json.dumps(DEFAULT_CUSTOM_CANVAS_ROLES)))
 except Exception:
-    CUSTOM_CANVAS_ROLES = {'assistant': 34, 'librarian': 21}
+    CUSTOM_CANVAS_ROLES = DEFAULT_CUSTOM_CANVAS_ROLES
 
 # Email settings
 EMAIL_BACKEND = os.getenv('EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend')
@@ -325,6 +326,17 @@ EMAIL_USE_TLS = True
 EMAIL_FROM = os.getenv('EMAIL_FROM', 'canvas-ccm-system@umich.edu')
 EMAIL_TO_REPLY = os.getenv('EMAIL_TO_REPLY', '4help@umich.edu')
 EMAIL_DEBUG = os.getenv('EMAIL_DEBUG', False)
+
+# Email headers to suppress automatic replies (out-of-office, vacation, etc.)
+DEFAULT_EMAIL_EXTRA_HEADERS = {
+    "Auto-Submitted": "auto-generated",      # RFC 3834: Standard header for automated emails
+    "X-Auto-Response-Suppress": "All",       # Outlook/Exchange: Suppress all auto-replies
+    "Precedence": "bulk",                    # Legacy header for mail systems
+}
+try:
+    EMAIL_EXTRA_HEADERS = json.loads(os.getenv('EMAIL_EXTRA_HEADERS', json.dumps(DEFAULT_EMAIL_EXTRA_HEADERS)))
+except Exception:
+    EMAIL_EXTRA_HEADERS = DEFAULT_EMAIL_EXTRA_HEADERS
 
 CANVAS_ADMIN_API_TOKEN = os.environ.get('CANVAS_ADMIN_API_TOKEN')
 if CANVAS_ADMIN_API_TOKEN is None or CANVAS_ADMIN_API_TOKEN == '':

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -325,7 +325,7 @@ EMAIL_USE_TLS = True
 
 EMAIL_FROM = os.getenv('EMAIL_FROM', 'canvas-ccm-system@umich.edu')
 EMAIL_TO_REPLY = os.getenv('EMAIL_TO_REPLY', '4help@umich.edu')
-EMAIL_DEBUG = os.getenv('EMAIL_DEBUG', False)
+EMAIL_DEBUG = config_to_bool(os.getenv('EMAIL_DEBUG', False))
 
 # Email headers to suppress automatic replies (out-of-office, vacation, etc.)
 DEFAULT_EMAIL_EXTRA_HEADERS = {

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -334,7 +334,9 @@ DEFAULT_EMAIL_EXTRA_HEADERS = {
     "Precedence": "bulk",                    # Legacy header for mail systems
 }
 try:
-    EMAIL_EXTRA_HEADERS = json.loads(os.getenv('EMAIL_EXTRA_HEADERS', json.dumps(DEFAULT_EMAIL_EXTRA_HEADERS)))
+    parsed_headers = json.loads(os.getenv('EMAIL_EXTRA_HEADERS', json.dumps(DEFAULT_EMAIL_EXTRA_HEADERS)))
+    # Ensure the parsed value is a dict, not a list, string, or other JSON type
+    EMAIL_EXTRA_HEADERS = parsed_headers if isinstance(parsed_headers, dict) else DEFAULT_EMAIL_EXTRA_HEADERS
 except Exception:
     EMAIL_EXTRA_HEADERS = DEFAULT_EMAIL_EXTRA_HEADERS
 

--- a/backend/tests/test_email_extra_headers.py
+++ b/backend/tests/test_email_extra_headers.py
@@ -1,0 +1,108 @@
+import os
+import importlib
+import json
+from django.test import SimpleTestCase
+
+
+class TestEmailExtraHeaders(SimpleTestCase):
+    def setUp(self):
+        self.settings_path = 'backend.settings'
+        self.env_key = 'EMAIL_EXTRA_HEADERS'
+        self.old_env = os.environ.get(self.env_key)
+        if self.env_key in os.environ:
+            del os.environ[self.env_key]
+
+    def tearDown(self):
+        if self.old_env is not None:
+            os.environ[self.env_key] = self.old_env
+        elif self.env_key in os.environ:
+            del os.environ[self.env_key]
+
+    def test_email_extra_headers_default(self):
+        """Test that EMAIL_EXTRA_HEADERS uses defaults when env var is not set"""
+        import backend.settings as settings
+        importlib.reload(settings)
+        expected = {
+            "Auto-Submitted": "auto-generated",
+            "X-Auto-Response-Suppress": "All",
+            "Precedence": "bulk",
+        }
+        self.assertEqual(settings.EMAIL_EXTRA_HEADERS, expected)
+
+    def test_email_extra_headers_env_override(self):
+        """Test that EMAIL_EXTRA_HEADERS can be overridden via environment variable"""
+        os.environ[self.env_key] = '{"Auto-Submitted": "auto-generated", "X-Custom-Header": "custom-value"}'
+        import backend.settings as settings
+        importlib.reload(settings)
+        expected = {
+            "Auto-Submitted": "auto-generated",
+            "X-Custom-Header": "custom-value",
+        }
+        self.assertEqual(settings.EMAIL_EXTRA_HEADERS, expected)
+
+    def test_email_extra_headers_env_empty_dict(self):
+        """Test that EMAIL_EXTRA_HEADERS can be set to empty dict to disable headers"""
+        os.environ[self.env_key] = '{}'
+        import backend.settings as settings
+        importlib.reload(settings)
+        self.assertEqual(settings.EMAIL_EXTRA_HEADERS, {})
+
+    def test_email_extra_headers_env_invalid_json(self):
+        """Test that invalid JSON falls back to default"""
+        os.environ[self.env_key] = 'not a json string'
+        import backend.settings as settings
+        importlib.reload(settings)
+        expected = {
+            "Auto-Submitted": "auto-generated",
+            "X-Auto-Response-Suppress": "All",
+            "Precedence": "bulk",
+        }
+        self.assertEqual(settings.EMAIL_EXTRA_HEADERS, expected)
+
+    def test_email_extra_headers_env_malformed_json(self):
+        """Test that malformed JSON falls back to default"""
+        os.environ[self.env_key] = '{"incomplete": '
+        import backend.settings as settings
+        importlib.reload(settings)
+        expected = {
+            "Auto-Submitted": "auto-generated",
+            "X-Auto-Response-Suppress": "All",
+            "Precedence": "bulk",
+        }
+        self.assertEqual(settings.EMAIL_EXTRA_HEADERS, expected)
+
+    def test_email_extra_headers_env_json_list(self):
+        """Test that JSON list falls back to default"""
+        os.environ[self.env_key] = '["header1", "header2"]'
+        import backend.settings as settings
+        importlib.reload(settings)
+        expected = {
+            "Auto-Submitted": "auto-generated",
+            "X-Auto-Response-Suppress": "All",
+            "Precedence": "bulk",
+        }
+        self.assertEqual(settings.EMAIL_EXTRA_HEADERS, expected)
+
+    def test_email_extra_headers_env_json_string(self):
+        """Test that JSON string falls back to default"""
+        os.environ[self.env_key] = '"just a string"'
+        import backend.settings as settings
+        importlib.reload(settings)
+        expected = {
+            "Auto-Submitted": "auto-generated",
+            "X-Auto-Response-Suppress": "All",
+            "Precedence": "bulk",
+        }
+        self.assertEqual(settings.EMAIL_EXTRA_HEADERS, expected)
+
+    def test_email_extra_headers_env_json_number(self):
+        """Test that JSON number falls back to default"""
+        os.environ[self.env_key] = '123'
+        import backend.settings as settings
+        importlib.reload(settings)
+        expected = {
+            "Auto-Submitted": "auto-generated",
+            "X-Auto-Response-Suppress": "All",
+            "Precedence": "bulk",
+        }
+        self.assertEqual(settings.EMAIL_EXTRA_HEADERS, expected)

--- a/backend/tests/test_email_users.py
+++ b/backend/tests/test_email_users.py
@@ -58,3 +58,26 @@ class SendEmailTests(TestCase):
         email_users.send_email('to@example.com', 'Test Subject', 'Test Body')
         self.assertEqual(mock_instance.content_subtype, "html")
         mock_logger.error.assert_called_once()
+
+    @override_settings(
+        EMAIL_FROM='from@example.com', 
+        EMAIL_TO_REPLY='reply@example.com',
+        EMAIL_EXTRA_HEADERS={
+            "Auto-Submitted": "auto-generated",
+            "X-Auto-Response-Suppress": "All",
+            "Precedence": "bulk",
+        }
+    )
+    @patch('backend.ccm.canvas_api.email_users.EmailMessage')
+    def test_send_email_includes_auto_reply_suppression_headers(self, mock_email_message):
+        mock_instance = MagicMock()
+        mock_email_message.return_value = mock_instance
+        email_users.send_email('to@example.com', 'Test Subject', 'Test Body')
+        # Verify that extra_headers are set with auto-reply suppression headers
+        expected_headers = {
+            "Auto-Submitted": "auto-generated",
+            "X-Auto-Response-Suppress": "All",
+            "Precedence": "bulk",
+        }
+        self.assertEqual(mock_instance.extra_headers, expected_headers)
+        mock_instance.send.assert_called_once()

--- a/backend/tests/test_email_users.py
+++ b/backend/tests/test_email_users.py
@@ -81,3 +81,17 @@ class SendEmailTests(TestCase):
         }
         self.assertEqual(mock_instance.extra_headers, expected_headers)
         mock_instance.send.assert_called_once()
+
+    @override_settings(
+        EMAIL_FROM='from@example.com', 
+        EMAIL_TO_REPLY='reply@example.com',
+        EMAIL_EXTRA_HEADERS=None
+    )
+    @patch('backend.ccm.canvas_api.email_users.EmailMessage')
+    def test_send_email_handles_none_extra_headers(self, mock_email_message):
+        mock_instance = MagicMock()
+        mock_email_message.return_value = mock_instance
+        email_users.send_email('to@example.com', 'Test Subject', 'Test Body')
+        # Verify that extra_headers falls back to empty dict when None
+        self.assertEqual(mock_instance.extra_headers, {})
+        mock_instance.send.assert_called_once()

--- a/config/.env.sample
+++ b/config/.env.sample
@@ -64,6 +64,11 @@ EMAIL_TO_REPLY=4HELP@UMICH.EDU
 #EMAIL_HOST_PASSWORD=
 # Email Debug for Non-prod testing
 EMAIL_DEBUG=True
+# (optional) Email headers to suppress automatic replies (out-of-office, vacation, etc.)
+# Can be customized as JSON. Default includes headers for RFC 3834, Outlook/Exchange, and legacy mail systems.
+# To override: EMAIL_EXTRA_HEADERS='{"Auto-Submitted": "auto-generated", "X-Auto-Response-Suppress": "All"}'
+# To disable all headers: EMAIL_EXTRA_HEADERS='{}'
+#EMAIL_EXTRA_HEADERS=
 
 
 # (optional) The token for accessing the /status URL; leaving it undefined means the route is unprotected


### PR DESCRIPTION
Making headers fully configurable if needed but providing defaults that shoudl supress notifications.

Some slight refactor for CUSTOM_CANVAS_ROLES to use this default pattern which looked better.